### PR TITLE
fix: add WSL-specific debugging for setup wizard venv failures

### DIFF
--- a/installer/cli.js
+++ b/installer/cli.js
@@ -118,10 +118,12 @@ function help() {
   console.log('\nSetup Options:');
   console.log('  --voyage-key=<key>   Provide Voyage AI API key (recommended)');
   console.log('  --local              Run in local mode without API key');
+  console.log('  --debug              Enable debug output for troubleshooting');
   
   console.log('\nExamples:');
   console.log('  claude-self-reflect setup --voyage-key=pa-1234567890');
   console.log('  claude-self-reflect setup --local');
+  console.log('  claude-self-reflect setup --debug  # For troubleshooting');
   
   console.log('\nFor more information: https://github.com/ramakay/claude-self-reflect');
 }


### PR DESCRIPTION
- Add --debug flag to setup command for verbose output
- Detect WSL environment and provide targeted guidance
- Add Python venv module pre-flight checks before attempting creation
- Capture detailed error messages from venv creation attempts
- Provide WSL-specific troubleshooting steps (python3.10-venv, etc)
- Show debug information including Python version, working directory

This helps diagnose issues like the one reported where python3-venv is installed but venv creation still fails on WSL Ubuntu 22.04.