### PR TITLE
Fix: Timestamp parsing bug with 'Z' suffix

### DIFF
--- a/mcp-server/src/server.py
+++ b/mcp-server/src/server.py
@@ -222,10 +222,14 @@ async def reflect_on_past(
                     
                     # Process results from native decay search
                     for point in results.points:
+                        # Clean timestamp for proper parsing
+                        raw_timestamp = point.payload.get('timestamp', datetime.now().isoformat())
+                        clean_timestamp = raw_timestamp.replace('Z', '+00:00') if raw_timestamp.endswith('Z') else raw_timestamp
+                        
                         all_results.append(SearchResult(
                             id=str(point.id),
                             score=point.score,  # Score already includes decay
-                            timestamp=point.payload.get('timestamp', datetime.now().isoformat()),
+                            timestamp=clean_timestamp,
                             role=point.payload.get('start_role', point.payload.get('role', 'unknown')),
                             excerpt=(point.payload.get('text', '')[:500] + '...'),
                             project_name=point.payload.get('project', collection_name.replace('conv_', '').replace('_voyage', '').replace('_local', '')),
@@ -283,10 +287,14 @@ async def reflect_on_past(
                     
                     # Convert to SearchResult format
                     for adjusted_score, point in decay_results[:limit]:
+                        # Clean timestamp for proper parsing
+                        raw_timestamp = point.payload.get('timestamp', datetime.now().isoformat())
+                        clean_timestamp = raw_timestamp.replace('Z', '+00:00') if raw_timestamp.endswith('Z') else raw_timestamp
+                        
                         all_results.append(SearchResult(
                             id=str(point.id),
                             score=adjusted_score,  # Use adjusted score
-                            timestamp=point.payload.get('timestamp', datetime.now().isoformat()),
+                            timestamp=clean_timestamp,
                             role=point.payload.get('start_role', point.payload.get('role', 'unknown')),
                             excerpt=(point.payload.get('text', '')[:500] + '...'),
                             project_name=point.payload.get('project', collection_name.replace('conv_', '').replace('_voyage', '').replace('_local', '')),
@@ -304,10 +312,14 @@ async def reflect_on_past(
                     )
                     
                     for point in results:
+                        # Clean timestamp for proper parsing
+                        raw_timestamp = point.payload.get('timestamp', datetime.now().isoformat())
+                        clean_timestamp = raw_timestamp.replace('Z', '+00:00') if raw_timestamp.endswith('Z') else raw_timestamp
+                        
                         all_results.append(SearchResult(
                             id=str(point.id),
                             score=point.score,
-                            timestamp=point.payload.get('timestamp', datetime.now().isoformat()),
+                            timestamp=clean_timestamp,
                             role=point.payload.get('start_role', point.payload.get('role', 'unknown')),
                             excerpt=(point.payload.get('text', '')[:500] + '...'),
                             project_name=point.payload.get('project', collection_name.replace('conv_', '').replace('_voyage', '').replace('_local', '')),
@@ -330,7 +342,9 @@ async def reflect_on_past(
         result_text = f"Found {len(all_results)} relevant conversation(s) for '{query}':\n\n"
         for i, result in enumerate(all_results):
             result_text += f"**Result {i+1}** (Score: {result.score:.3f})\n"
-            result_text += f"Time: {datetime.fromisoformat(result.timestamp).strftime('%Y-%m-%d %H:%M:%S')}\n"
+            # Handle timezone suffix 'Z' properly
+            timestamp_clean = result.timestamp.replace('Z', '+00:00') if result.timestamp.endswith('Z') else result.timestamp
+            result_text += f"Time: {datetime.fromisoformat(timestamp_clean).strftime('%Y-%m-%d %H:%M:%S')}\n"
             result_text += f"Project: {result.project_name}\n"
             result_text += f"Role: {result.role}\n"
             result_text += f"Excerpt: {result.excerpt}\n"


### PR DESCRIPTION
# Fix: Timestamp parsing bug with 'Z' suffix in MCP server

## Description

This PR fixes a critical bug where the `reflect_on_past` MCP tool fails with timestamp parsing errors. The issue occurs when processing Claude conversation exports that use ISO timestamps with 'Z' timezone suffix.

**Error fixed:**
```
Failed to search conversations: Invalid isoformat string: '2025-07-26T19:10:28.419Z'
```

This completely restores reflection functionality for users with real Claude conversation data.

## Problem

The issue occurs in `mcp-server/src/server.py` where `datetime.fromisoformat()` is used to parse timestamps from conversation data. Claude conversation exports use ISO timestamps with 'Z' suffix (e.g., `2025-07-26T19:10:28.419Z`), but Python's `fromisoformat()` method cannot parse the 'Z' timezone indicator - it expects `+00:00` format instead.

The error occurs in multiple places where SearchResult objects are created and when formatting results for display.

## Solution

This PR adds timestamp cleaning in 4 locations in `server.py` to convert 'Z' suffix to '+00:00' before parsing:

1. **Native decay search result processing** (lines 225-227)
2. **Client-side decay search result processing** (lines 289-292) 
3. **Standard search result processing** (lines 315-317)
4. **Result formatting for display** (lines 333-334)

## Changes Made

```python
# Before
timestamp=point.payload.get('timestamp', datetime.now().isoformat())

# After
raw_timestamp = point.payload.get('timestamp', datetime.now().isoformat())
clean_timestamp = raw_timestamp.replace('Z', '+00:00') if raw_timestamp.endswith('Z') else raw_timestamp
timestamp=clean_timestamp
```

## Testing

**Testing Environment:**
- **OS**: WSL2 Ubuntu 22.04
- **Python**: 3.10.12  
- **Setup**: Voyage AI embeddings (not local)
- **Qdrant**: Running via Docker on localhost:6333
- **Import Status**: 17 collections, 667 conversation chunks successfully imported
- **MCP**: Installed via npm, connected to Claude Code

**Before fix:**
```
Failed to search conversations: Invalid isoformat string: '2025-07-26T19:10:28.419Z'
```

**After fix:**
```
Found 3 relevant conversation(s) for 'python':
**Result 1** (Score: 0.604)
Time: 2025-07-26 19:10:28
[... proper results displayed ...]
```

## Impact

- **Fixes**: Complete failure of reflection functionality
- **Compatibility**: Backward compatible, handles both 'Z' and '+00:00' formats
- **Scope**: Affects all users with Claude conversation exports
- **Risk**: Low - purely a parsing fix with no logic changes