### PR TITLE
Use Docker to manage the qdrant data volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,6 @@
+volumes:
+  qdrant_data:
+
 services:
   # Qdrant vector database - the heart of semantic search
   qdrant:
@@ -6,7 +9,7 @@ services:
     ports:
       - "${QDRANT_PORT:-6333}:6333"
     volumes:
-      - ./data/qdrant:/qdrant/storage
+      - qdrant_data:/qdrant/storage
     environment:
       - QDRANT__LOG_LEVEL=INFO
       - QDRANT__SERVICE__HTTP_PORT=6333


### PR DESCRIPTION
Using this way the user won't need a `./data/qdrant` local directory - it'll be managed by docker engine/desktop