### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,14 @@ volumes:
   qdrant_data:
 
 services:
+  # Fix permissions for config directory
+  init-permissions:
+    image: alpine
+    command: chown -R 1000:1000 /config
+    volumes:
+      - ./config:/config
+    profiles: ["watch", "mcp"]
+
   # Qdrant vector database - the heart of semantic search
   qdrant:
     image: qdrant/qdrant:v1.15.1
@@ -51,6 +59,7 @@ services:
       dockerfile: Dockerfile.watcher
     container_name: claude-reflection-watcher
     depends_on:
+      - init-permissions
       - qdrant
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro


### PR DESCRIPTION
Problem:
- Watcher service fails to save state file due to permission errors, causing 800%+ CPU usage from re-processing all files every 60 seconds.

Solution:
- Added init-permissions container that runs before watcher to fix /config directory ownership.

Changes:
- Added init-permissions service using Alpine
image
- Added dependency in watcher service to ensure init runs first
- Fixes [Errno 13] Permission denied: '/config/imported-files.json.tmp' errors

Testing:
Verified with manual import showing proper state tracking and skip functionality.

Before fix:
```bash
2025-07-31 07:16:05,189 - INFO - Loaded state with 0 previously imported files
2025-07-31 07:16:05,394 - ERROR - Failed to save state file: [Errno 13] Permission denied: '/config/imported-files.json.tmp'
```
After fix:
```bash
2025-07-31 08:37:00,496 - INFO - Loaded state with 218 previously imported files
2025-07-31 08:37:00,502 - INFO - Skipping unchanged file: 09ed902b-caa3-4d51-a746-709cd8ef0869.jsonl
```