### PR TITLE
fix: resolve Docker mount permission issues for global npm installs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     image: alpine
     command: chown -R 1000:1000 /config
     volumes:
-      - ./config:/config
+      - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
     profiles: ["watch", "mcp", "import"]
 
   # Qdrant vector database - the heart of semantic search
@@ -36,7 +36,7 @@ services:
       - qdrant
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
-      - ./config:/config
+      - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
       - ./scripts:/scripts:ro
     environment:
       - QDRANT_URL=http://qdrant:6333
@@ -64,7 +64,7 @@ services:
       - qdrant
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
-      - ./config:/config
+      - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
       - ./scripts:/scripts:ro
     environment:
       - QDRANT_URL=http://qdrant:6333


### PR DESCRIPTION
Fixes #13 

This PR addresses Docker mount permission issues that occur when claude-self-reflect is installed globally via npm.

## Problem
When installed globally, Docker on macOS has restrictions on which directories can be mounted, causing the local ./config directory to be inaccessible.

## Solution
- Move config directory to user's home directory (~/.claude-self-reflect/config)
- Add CONFIG_PATH environment variable for configuration
- Implement automatic migration from old to new location
- Maintain backward compatibility with default fallback

## Files Changed
- docker-compose.yaml - Updated volume mounts
- installer/setup-wizard-docker.js - Added config migration logic