### PR TITLE
fix: collection name mismatch between import and delta metadata update

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
     environment:
       - QDRANT_URL=http://qdrant:6333
       - STATE_FILE=/config/imported-files.json
+      - LOGS_DIR=/logs
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - VOYAGE_API_KEY=${VOYAGE_API_KEY:-}
       - VOYAGE_KEY=${VOYAGE_KEY:-}

--- a/scripts/delta-metadata-update-safe.py
+++ b/scripts/delta-metadata-update-safe.py
@@ -24,7 +24,8 @@ from qdrant_client.models import Filter, FieldCondition, MatchValue
 # Configuration
 QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
 LOGS_DIR = os.getenv("LOGS_DIR", os.path.expanduser("~/.claude/projects"))
-STATE_FILE = os.getenv("STATE_FILE", "./config/delta-update-state.json")
+# Use /config path if running in Docker, otherwise use ./config
+STATE_FILE = os.getenv("STATE_FILE", "/config/delta-update-state.json" if os.path.exists("/config") else "./config/delta-update-state.json")
 PREFER_LOCAL_EMBEDDINGS = os.getenv("PREFER_LOCAL_EMBEDDINGS", "true").lower() == "true"
 DRY_RUN = os.getenv("DRY_RUN", "false").lower() == "true"
 DAYS_TO_UPDATE = int(os.getenv("DAYS_TO_UPDATE", "7"))
@@ -432,7 +433,7 @@ async def main_async():
     logger.info("=== Delta Update Complete ===")
     logger.info(f"Successfully updated: {success_count} conversations")
     logger.info(f"Failed: {failed_count} conversations")
-    logger.info(f"Total conversations in state: {len(state['updated_conversations'])}")
+    logger.info(f"Total conversations in state: {len(state.get('updated_conversations', {}))}")
 
 def main():
     """Entry point."""

--- a/scripts/import-conversations-unified.py
+++ b/scripts/import-conversations-unified.py
@@ -57,7 +57,9 @@ else:
 
 def normalize_project_name(project_name: str) -> str:
     """Normalize project name for consistency."""
-    return project_name.replace("-Users-ramakrishnanannaswamy-projects-", "").replace("-", "_").lower()
+    # For compatibility with delta-metadata-update, just use the project name as-is
+    # This ensures collection names match between import and delta update scripts
+    return project_name
 
 def get_collection_name(project_path: Path) -> str:
     """Generate collection name from project path."""


### PR DESCRIPTION
- Fixed hardcoded username in import script normalization function
- Changed normalize_project_name to use full project path for consistent hashing
- Added LOGS_DIR environment variable to importer service in docker-compose.yaml
- Fixed state file path detection for Docker vs local execution
- Fixed state dictionary initialization with correct default types

This ensures collections created by import-conversations-unified.py have the same names expected by delta-metadata-update-safe.py, allowing metadata extraction to work correctly.