### PR TITLE
fix: include run-mcp-clean.sh in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mcp-server/src/**/*.py",
     "mcp-server/pyproject.toml",
     "mcp-server/run-mcp.sh",
+    "mcp-server/run-mcp-clean.sh",
     "mcp-server/run-mcp-docker.sh",
     "scripts/import-*.py",
     "scripts/delta-metadata-update-safe.py",


### PR DESCRIPTION
## Description
Fixes #47 - The npm package is missing the `run-mcp-clean.sh` file that the setup wizard tries to use.

## Problem
- `run-mcp-clean.sh` exists in the repository (added in commit 397cd24)
- Setup wizard references it in `installer/setup-wizard-docker.js`
- But it's not included in the npm package because it's missing from `package.json` files array

## Solution
Added `mcp-server/run-mcp-clean.sh` to the files array in package.json

## Testing
**Verified the file exists in the repository:**
```bash
$ ls -la mcp-server/run-mcp*.sh
-rwxr-xr-x  1038 mcp-server/run-mcp-clean.sh
-rwxr-xr-x   236 mcp-server/run-mcp-docker.sh
-rwxr-xr-x  2092 mcp-server/run-mcp.sh
```

**Confirmed the fix includes the file in npm package:**
```bash
$ npm pack --json | jq -r '.[0].files[].path' | grep "mcp-server/run-mcp"
mcp-server/run-mcp-clean.sh    # Now included
mcp-server/run-mcp-docker.sh
mcp-server/run-mcp.sh
```

**Verified with npm pack dry-run:**
```bash
$ npm pack --dry-run 2>&1 | grep "mcp-server/run-mcp"
npm notice 1.0kB mcp-server/run-mcp-clean.sh
npm notice 236B mcp-server/run-mcp-docker.sh
npm notice 2.1kB mcp-server/run-mcp.sh
```

## Impact
- Future npm releases will include all necessary MCP server scripts
- Users installing via `npm install -g claude-self-reflect` will get a complete package
- Current workaround (using `run-mcp-docker.sh`) continues to work