### PR TITLE
fix: CI workflow smoke test for v6.0.0 src/runtime paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,22 +126,23 @@ jobs:
         mkdir "$TEST_DIR" && cd "$TEST_DIR"
         npm install $GITHUB_WORKSPACE/claude-self-reflect-*.tgz
 
-    - name: Verify refactored modules included (regression test for #71)
+    - name: Verify refactored modules included (regression test for #71, v6.0.0 paths)
       run: |
         cd ${{ runner.temp }}/test-install/node_modules/claude-self-reflect
 
-        # Verify refactored modules that were previously missing in v5.0.4/v5.0.5
+        # Verify v6.0.0 production modules in src/runtime/
         MISSING_FILES=()
 
-        # Check main scripts
-        [ -f "scripts/import_strategies.py" ] || MISSING_FILES+=("import_strategies.py")
-        [ -f "scripts/metadata_extractor.py" ] || MISSING_FILES+=("metadata_extractor.py")
-        [ -f "scripts/message_processors.py" ] || MISSING_FILES+=("message_processors.py")
-        [ -f "scripts/embedding_service.py" ] || MISSING_FILES+=("embedding_service.py")
+        # Check main runtime scripts (v6.0.0 paths)
+        [ -f "src/runtime/import_strategies.py" ] || MISSING_FILES+=("src/runtime/import_strategies.py")
+        [ -f "src/runtime/metadata_extractor.py" ] || MISSING_FILES+=("src/runtime/metadata_extractor.py")
+        [ -f "src/runtime/message_processors.py" ] || MISSING_FILES+=("src/runtime/message_processors.py")
+        [ -f "src/runtime/embedding_service.py" ] || MISSING_FILES+=("src/runtime/embedding_service.py")
 
-        # Check other critical files
-        [ -f "scripts/import-conversations-unified.py" ] || MISSING_FILES+=("import-conversations-unified.py")
-        [ -f "scripts/doctor.py" ] || MISSING_FILES+=("doctor.py")
+        # Check other critical files (v6.0.0 paths)
+        [ -f "src/runtime/import-conversations-unified.py" ] || MISSING_FILES+=("src/runtime/import-conversations-unified.py")
+        [ -f "src/runtime/doctor.py" ] || MISSING_FILES+=("src/runtime/doctor.py")
+        [ -f "src/runtime/unified_state_manager.py" ] || MISSING_FILES+=("src/runtime/unified_state_manager.py")
         [ -f "installer/cli.js" ] || MISSING_FILES+=("installer/cli.js")
 
         if [ ${#MISSING_FILES[@]} -gt 0 ]; then
@@ -149,11 +150,11 @@ jobs:
           printf '  - %s\n' "${MISSING_FILES[@]}"
           echo ""
           echo "📦 Package structure:"
-          ls -la scripts/ | head -20
+          ls -la src/runtime/ | head -20
           exit 1
         fi
 
-        echo "✅ All critical files present in package"
+        echo "✅ All critical files present in package (v6.0.0 structure)"
 
     - name: Test CLI works
       run: |


### PR DESCRIPTION
## Problem

The v6.0.0 release created in #101 is blocked because the `npm-pack-smoke-test` CI job is failing. The smoke test checks for production files at old v5.0.x paths (`scripts/`) but v6.0.0 moved all production code to `src/runtime/`.

**Failing workflow**: https://github.com/ramakay/claude-self-reflect/actions/runs/18254838071

## Changes

Updated `.github/workflows/ci.yml` smoke test to check v6.0.0 paths:

### Before (v5.0.x paths):
```bash
[ -f "scripts/import_strategies.py" ]
[ -f "scripts/metadata_extractor.py" ]
[ -f "scripts/message_processors.py" ]
[ -f "scripts/embedding_service.py" ]
[ -f "scripts/import-conversations-unified.py" ]
[ -f "scripts/doctor.py" ]
```

### After (v6.0.0 paths):
```bash
[ -f "src/runtime/import_strategies.py" ]
[ -f "src/runtime/metadata_extractor.py" ]
[ -f "src/runtime/message_processors.py" ]
[ -f "src/runtime/embedding_service.py" ]
[ -f "src/runtime/import-conversations-unified.py" ]
[ -f "src/runtime/doctor.py" ]
[ -f "src/runtime/unified_state_manager.py" ]
```

Also updated the error message to list `src/runtime/` instead of `scripts/` for better debugging.

## Impact

This unblocks the v6.0.0 release workflow, allowing npm publish to complete successfully.

## Testing

- ✅ Local package test passes: `python tests/test_npm_package_contents.py`
- ✅ All v6.0.0 files confirmed in package via `npm pack --dry-run`
- 🔄 CI will validate the fix when PR is created

## Related

- PR #101: Convention-based packaging v6.0.0
- Issue #97: src/ restructuring
- Release: https://github.com/ramakay/claude-self-reflect/releases/tag/v6.0.0