### PR TITLE
fix: Docker volume mount failure on npm global install + utilities (v6.0.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,22 +126,23 @@ jobs:
         mkdir "$TEST_DIR" && cd "$TEST_DIR"
         npm install $GITHUB_WORKSPACE/claude-self-reflect-*.tgz
 
-    - name: Verify refactored modules included (regression test for #71)
+    - name: Verify refactored modules included (regression test for #71, v6.0.0 paths)
       run: |
         cd ${{ runner.temp }}/test-install/node_modules/claude-self-reflect
 
-        # Verify refactored modules that were previously missing in v5.0.4/v5.0.5
+        # Verify v6.0.0 production modules in src/runtime/
         MISSING_FILES=()
 
-        # Check main scripts
-        [ -f "scripts/import_strategies.py" ] || MISSING_FILES+=("import_strategies.py")
-        [ -f "scripts/metadata_extractor.py" ] || MISSING_FILES+=("metadata_extractor.py")
-        [ -f "scripts/message_processors.py" ] || MISSING_FILES+=("message_processors.py")
-        [ -f "scripts/embedding_service.py" ] || MISSING_FILES+=("embedding_service.py")
+        # Check main runtime scripts (v6.0.0 paths)
+        [ -f "src/runtime/import_strategies.py" ] || MISSING_FILES+=("src/runtime/import_strategies.py")
+        [ -f "src/runtime/metadata_extractor.py" ] || MISSING_FILES+=("src/runtime/metadata_extractor.py")
+        [ -f "src/runtime/message_processors.py" ] || MISSING_FILES+=("src/runtime/message_processors.py")
+        [ -f "src/runtime/embedding_service.py" ] || MISSING_FILES+=("src/runtime/embedding_service.py")
 
-        # Check other critical files
-        [ -f "scripts/import-conversations-unified.py" ] || MISSING_FILES+=("import-conversations-unified.py")
-        [ -f "scripts/doctor.py" ] || MISSING_FILES+=("doctor.py")
+        # Check other critical files (v6.0.0 paths)
+        [ -f "src/runtime/import-conversations-unified.py" ] || MISSING_FILES+=("src/runtime/import-conversations-unified.py")
+        [ -f "src/runtime/doctor.py" ] || MISSING_FILES+=("src/runtime/doctor.py")
+        [ -f "src/runtime/unified_state_manager.py" ] || MISSING_FILES+=("src/runtime/unified_state_manager.py")
         [ -f "installer/cli.js" ] || MISSING_FILES+=("installer/cli.js")
 
         if [ ${#MISSING_FILES[@]} -gt 0 ]; then
@@ -149,11 +150,11 @@ jobs:
           printf '  - %s\n' "${MISSING_FILES[@]}"
           echo ""
           echo "📦 Package structure:"
-          ls -la scripts/ | head -20
+          ls -la src/runtime/ | head -20
           exit 1
         fi
 
-        echo "✅ All critical files present in package"
+        echo "✅ All critical files present in package (v6.0.0 structure)"
 
     - name: Test CLI works
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,20 @@ jobs:
         }
         echo "✅ CLI execution successful"
 
+  docker-compose-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Validate docker-compose.yaml
+      run: |
+        chmod +x scripts/ci/validate-docker-compose.sh
+        ./scripts/ci/validate-docker-compose.sh
+
   docker-build:
     runs-on: ubuntu-latest
-    needs: [python-test, npm-package-test, npm-pack-smoke-test]
+    needs: [python-test, npm-package-test, npm-pack-smoke-test, docker-compose-validation]
 
     steps:
     - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -175,9 +175,6 @@ Your code quality displayed live as you work:
 3. **Quality Scoring**: Weighted scoring normalized by lines of code
 4. **Statusline Display**: Real-time feedback as you code
 
-> [!TIP]
-> Run `python scripts/session_quality_tracker.py` to analyze your current session quality!
-
 </details>
 
 ## Key Features

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,8 +40,6 @@ services:
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
       - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
-      - ./src:/app/src:ro
-      - ./shared:/app/shared:ro
     environment:
       - QDRANT_URL=http://qdrant:6333
       - STATE_FILE=/config/imported-files.json
@@ -71,8 +69,6 @@ services:
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
       - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
-      - ./src:/app/src:ro
-      - ./shared:/app/shared:ro
       - /tmp:/tmp
     environment:
       - QDRANT_URL=http://qdrant:6333
@@ -103,8 +99,6 @@ services:
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
       - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
-      - ./src:/app/src:ro
-      - ./shared:/app/shared:ro
     environment:
       - QDRANT_URL=http://qdrant:6333
       - STATE_FILE=/config/streaming-state.json  # FIXED: Use streaming-specific state file
@@ -144,8 +138,6 @@ services:
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
       - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
-      - ./src:/app/src:ro
-      - ./shared:/app/shared:ro
     environment:
       - QDRANT_URL=http://qdrant:6333
       - STATE_FILE=/config/imported-files.json
@@ -181,8 +173,6 @@ services:
     volumes:
       - ${CLAUDE_LOGS_PATH:-~/.claude/projects}:/logs:ro
       - ${CONFIG_PATH:-~/.claude-self-reflect/config}:/config
-      - ./src:/app/src:ro
-      - ./shared:/app/shared:ro
     environment:
       - QDRANT_URL=http://qdrant:6333
       - STATE_FILE=/config/csr-watcher.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "5.0.7",
+  "version": "6.0.0",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",

--- a/scripts/ci/validate-docker-compose.sh
+++ b/scripts/ci/validate-docker-compose.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# CI/CD Validation: Docker Compose Configuration
+# Ensures docker-compose.yaml doesn't contain paths that will fail in production
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+
+DOCKER_COMPOSE_FILE="docker-compose.yaml"
+FAILED=0
+
+echo "🔍 Validating Docker Compose Configuration..."
+echo ""
+
+# Check 1: No relative path mounts (./src, ./shared, etc.)
+echo "Checking for invalid relative path mounts..."
+if grep -E "^\s*-\s+\./src:" "$DOCKER_COMPOSE_FILE" > /dev/null 2>&1; then
+    print_error "Found invalid mount: './src:/app/src' - This will fail in npm global installs!"
+    echo "  Reason: /opt/homebrew/lib/ is not a Docker-allowed path on macOS"
+    echo "  Fix: Remove the mount - code should be in Docker image already"
+    FAILED=1
+fi
+
+if grep -E "^\s*-\s+\./shared:" "$DOCKER_COMPOSE_FILE" > /dev/null 2>&1; then
+    print_error "Found invalid mount: './shared:/app/shared' - This will fail in npm global installs!"
+    echo "  Reason: /opt/homebrew/lib/ is not a Docker-allowed path on macOS"
+    echo "  Fix: Remove the mount - code should be in Docker image already"
+    FAILED=1
+fi
+
+# Check 2: Validate environment variable mounts use correct syntax
+echo "Checking environment variable mounts..."
+INVALID_MOUNTS=$(grep -E "^\s*-\s+\\\$\{[A-Z_]+\}:" "$DOCKER_COMPOSE_FILE" || true)
+if [ -n "$INVALID_MOUNTS" ]; then
+    print_error "Found invalid mount syntax: \${VAR}:/path"
+    echo "  Use: \${VAR:-~/default}:/path (with default value)"
+    echo "$INVALID_MOUNTS"
+    FAILED=1
+fi
+
+# Check 3: Ensure CONFIG_PATH has proper defaults
+echo "Checking CONFIG_PATH usage..."
+if ! grep -E "CONFIG_PATH:-~/\.claude-self-reflect/config" "$DOCKER_COMPOSE_FILE" > /dev/null; then
+    print_warning "CONFIG_PATH should have default: \${CONFIG_PATH:-~/.claude-self-reflect/config}"
+fi
+
+# Check 4: Ensure CLAUDE_LOGS_PATH has proper defaults
+echo "Checking CLAUDE_LOGS_PATH usage..."
+if ! grep -E "CLAUDE_LOGS_PATH:-~/\.claude/projects" "$DOCKER_COMPOSE_FILE" > /dev/null; then
+    print_warning "CLAUDE_LOGS_PATH should have default: \${CLAUDE_LOGS_PATH:-~/.claude/projects}"
+fi
+
+# Check 5: No absolute paths outside allowed Docker directories (macOS)
+echo "Checking for macOS Docker path restrictions..."
+RESTRICTED_PATHS=$(grep -E "^\s*-\s+/(opt|usr/local|Library)/" "$DOCKER_COMPOSE_FILE" | grep -v "/tmp" || true)
+if [ -n "$RESTRICTED_PATHS" ]; then
+    print_error "Found mounts to restricted paths (not allowed by Docker Desktop on macOS):"
+    echo "$RESTRICTED_PATHS"
+    echo "  Allowed: /Users, /Volumes, /private, /tmp"
+    echo "  Fix: Use \${VAR:-~/.local/path} syntax to mount from user home"
+    FAILED=1
+fi
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+    print_success "✅ Docker Compose validation passed!"
+    exit 0
+else
+    print_error "❌ Docker Compose validation failed!"
+    echo ""
+    echo "Common fixes:"
+    echo "  1. Remove ./src and ./shared mounts (code is in Docker images)"
+    echo "  2. Use environment variables with defaults: \${VAR:-~/path}"
+    echo "  3. Keep mounts within Docker-allowed directories"
+    exit 1
+fi

--- a/scripts/setup/uninstall.sh
+++ b/scripts/setup/uninstall.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Claude Self-Reflect - Complete Uninstallation Script
+# Removes all CSR components, data, and configurations
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+echo -e "${RED}"
+cat << "EOF"
+ _   _       _           _        _ _
+| | | |_ __ (_)_ __  ___| |_ __ _| | |
+| | | | '_ \| | '_ \/ __| __/ _` | | |
+| |_| | | | | | | | \__ \ || (_| | | |
+ \___/|_| |_|_|_| |_|___/\__\__,_|_|_|
+
+ Claude Self-Reflect
+EOF
+echo -e "${NC}"
+
+# Ask for confirmation
+echo ""
+print_warning "This will remove ALL Claude Self-Reflect components:"
+echo "  • Docker containers and volumes"
+echo "  • Configuration files (~/.claude-self-reflect)"
+echo "  • MCP server registration from Claude Desktop"
+echo "  • Qdrant vector database and ALL stored conversations"
+echo ""
+read -p "Are you sure you want to continue? (yes/no) " -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy][Ee][Ss]$ ]]; then
+    print_info "Uninstall cancelled"
+    exit 0
+fi
+
+# Option to keep conversation data
+KEEP_DATA=false
+read -p "Do you want to keep your conversation data for backup? (y/n) " -n 1 -r
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    KEEP_DATA=true
+    BACKUP_DIR="$HOME/claude-self-reflect-backup-$(date +%Y%m%d-%H%M%S)"
+    print_info "Creating backup at $BACKUP_DIR"
+    mkdir -p "$BACKUP_DIR"
+
+    # Backup Qdrant data if running
+    if docker ps | grep -q claude-reflection-qdrant; then
+        print_info "Backing up Qdrant data..."
+        docker run --rm \
+            --volumes-from claude-reflection-qdrant \
+            -v "$BACKUP_DIR:/backup" \
+            alpine tar czf /backup/qdrant-data.tar.gz /qdrant/storage 2>/dev/null || true
+    fi
+
+    # Backup config files
+    if [ -d "$HOME/.claude-self-reflect" ]; then
+        cp -r "$HOME/.claude-self-reflect" "$BACKUP_DIR/config" 2>/dev/null || true
+    fi
+
+    print_success "Backup created at $BACKUP_DIR"
+fi
+
+# Stop and remove Docker containers
+print_info "Stopping Docker containers..."
+docker stop claude-reflection-qdrant 2>/dev/null || true
+docker stop claude-reflection-safe-watcher 2>/dev/null || true
+docker stop claude-reflection-streaming 2>/dev/null || true
+docker stop claude-reflection-async 2>/dev/null || true
+docker stop claude-reflection-watcher 2>/dev/null || true
+docker stop claude-reflection-importer 2>/dev/null || true
+docker stop claude-reflection-mcp 2>/dev/null || true
+
+print_info "Removing Docker containers..."
+docker rm claude-reflection-qdrant 2>/dev/null || true
+docker rm claude-reflection-safe-watcher 2>/dev/null || true
+docker rm claude-reflection-streaming 2>/dev/null || true
+docker rm claude-reflection-async 2>/dev/null || true
+docker rm claude-reflection-watcher 2>/dev/null || true
+docker rm claude-reflection-importer 2>/dev/null || true
+docker rm claude-reflection-mcp 2>/dev/null || true
+
+# Remove Docker volumes unless keeping data
+if [ "$KEEP_DATA" = false ]; then
+    print_info "Removing Docker volumes..."
+    docker volume rm claude-self-reflect_qdrant_data 2>/dev/null || true
+fi
+
+# Remove Docker network
+print_info "Removing Docker network..."
+docker network rm claude-reflection-network 2>/dev/null || true
+
+# Remove Docker images
+read -p "Remove Docker images? (saves disk space) (y/n) " -n 1 -r
+echo ""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    print_info "Removing Docker images..."
+    docker rmi qdrant/qdrant:v1.15.1 2>/dev/null || true
+    docker images | grep claude-reflection | awk '{print $3}' | xargs docker rmi -f 2>/dev/null || true
+fi
+
+# Remove configuration directory unless keeping data
+if [ "$KEEP_DATA" = false ]; then
+    print_info "Removing configuration directory..."
+    rm -rf "$HOME/.claude-self-reflect"
+else
+    print_warning "Keeping configuration directory (backed up)"
+fi
+
+# Remove MCP server from Claude Desktop
+print_info "Removing MCP server from Claude Desktop..."
+CLAUDE_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+if [ ! -f "$CLAUDE_CONFIG" ]; then
+    CLAUDE_CONFIG="$HOME/.config/Claude/claude_desktop_config.json"
+fi
+
+if [ -f "$CLAUDE_CONFIG" ]; then
+    # Backup current config
+    cp "$CLAUDE_CONFIG" "$CLAUDE_CONFIG.backup-$(date +%Y%m%d-%H%M%S)"
+
+    # Remove claude-self-reflect entry using Python
+    python3 -c "
+import json
+import sys
+try:
+    with open('$CLAUDE_CONFIG', 'r') as f:
+        config = json.load(f)
+    if 'mcpServers' in config and 'claude-self-reflect' in config['mcpServers']:
+        del config['mcpServers']['claude-self-reflect']
+        with open('$CLAUDE_CONFIG', 'w') as f:
+            json.dump(config, f, indent=2)
+        print('Removed claude-self-reflect from MCP servers')
+    else:
+        print('claude-self-reflect not found in MCP servers')
+except Exception as e:
+    print(f'Error updating config: {e}', file=sys.stderr)
+    sys.exit(1)
+" && print_success "MCP server removed from Claude Desktop config" || print_warning "Could not update Claude Desktop config"
+fi
+
+# Remove local repository (if running from repo)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [ -d "$SCRIPT_DIR/.git" ]; then
+    echo ""
+    read -p "Remove local repository at $SCRIPT_DIR? (y/n) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        cd "$HOME"
+        print_info "Removing repository..."
+        rm -rf "$SCRIPT_DIR"
+    fi
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+print_success "Claude Self-Reflect has been uninstalled! 🗑️"
+echo ""
+
+if [ "$KEEP_DATA" = true ]; then
+    echo "📦 Your data backup is saved at:"
+    echo "   $BACKUP_DIR"
+    echo ""
+fi
+
+echo "📋 Next Steps:"
+echo "  • Restart Claude Desktop to clear MCP server"
+if [ "$KEEP_DATA" = true ]; then
+    echo "  • To restore: reinstall and copy backup data back to ~/.claude-self-reflect"
+fi
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/setup/version.sh
+++ b/scripts/setup/version.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Claude Self-Reflect - Version Information Script
+# Shows current version and checks for updates
+
+set -e
+
+# Colors
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+
+echo -e "${BLUE}"
+cat << "EOF"
+  ____ ____  ____   __     __            _
+ / ___/ ___||  _ \  \ \   / /__ _ __ ___(_) ___  _ __
+| |   \___ \| |_) |  \ \ / / _ \ '__/ __| |/ _ \| '_ \
+| |___ ___) |  _ <    \ V /  __/ |  \__ \ | (_) | | | |
+ \____|____/|_| \_\    \_/ \___|_|  |___/_|\___/|_| |_|
+EOF
+echo -e "${NC}"
+
+# Get package version
+PACKAGE_JSON="$(dirname "${BASH_SOURCE[0]}")/../../package.json"
+if [ -f "$PACKAGE_JSON" ]; then
+    VERSION=$(grep '"version"' "$PACKAGE_JSON" | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+    echo "📦 Claude Self-Reflect Version: ${GREEN}${VERSION}${NC}"
+else
+    print_warning "package.json not found - checking npm global install..."
+    VERSION=$(npm list -g claude-self-reflect --depth=0 2>/dev/null | grep claude-self-reflect | sed 's/.*@\(.*\)/\1/' || echo "unknown")
+    echo "📦 Claude Self-Reflect Version: ${GREEN}${VERSION}${NC}"
+fi
+
+echo ""
+
+# Check Docker containers status
+print_info "Docker Containers Status:"
+echo ""
+docker ps -a --filter "name=claude-reflection" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || print_warning "No containers found"
+
+echo ""
+
+# Check for updates (optional)
+if command -v npm &> /dev/null; then
+    print_info "Checking for updates..."
+    LATEST=$(npm show claude-self-reflect version 2>/dev/null || echo "unknown")
+    if [ "$LATEST" != "unknown" ] && [ "$VERSION" != "$LATEST" ]; then
+        print_warning "Update available: ${VERSION} → ${LATEST}"
+        echo "  Run: npm install -g claude-self-reflect@latest"
+    elif [ "$VERSION" = "$LATEST" ]; then
+        print_success "You're on the latest version!"
+    fi
+fi
+
+echo ""
+echo "📚 Documentation: https://github.com/ram-senth/claude-self-reflect"
+echo "🐛 Issues: https://github.com/ram-senth/claude-self-reflect/issues"


### PR DESCRIPTION
## 🐛 Critical Bug Fix

Fixes Docker volume mount error when CSR is installed globally via `npm install -g`. On macOS, Docker Desktop restricts mounts to `/Users`, `/Volumes`, `/private`, `/tmp` - but npm global installs to `/opt/homebrew/lib/` which is NOT allowed.

### Problem
```
Error: Path /opt/homebrew/lib/node_modules/claude-self-reflect/src
       is not shared from the host and is not known to Docker.
```

### Root Cause
`docker-compose.yaml` had development-only volume mounts:
```yaml
volumes:
  - ./src:/app/src:ro       # ❌ Fails on global npm install
  - ./shared:/app/shared:ro # ❌ Fails on global npm install
```

When installed globally, `./src` resolves to `/opt/homebrew/lib/.../src` which Docker rejects.

### Solution
✅ **Remove development-only mounts** - Code is already in Docker images via `Dockerfile.*` builds
✅ **Keep user config mounts** - These use `${CONFIG_PATH:-~/.claude-self-reflect/config}` which expands to `/Users/...`

## 🎁 New Features

### 1. Uninstall Command
```bash
./scripts/setup/uninstall.sh
```
- Complete removal of all CSR components
- Optional data backup before uninstall
- Auto-deregister from Claude Desktop MCP servers
- Safe cleanup with confirmation prompts

### 2. Version Command
```bash
./scripts/setup/version.sh
```
- Show current installed version
- Check for updates from npm registry
- Display Docker container status
- Quick health check

## 🛡️ CI/CD Improvements

### New Validation Job: `docker-compose-validation`
Prevents this issue from recurring:
- ✅ Detects invalid `./src` and `./shared` mounts
- ✅ Validates `CONFIG_PATH` and `CLAUDE_LOGS_PATH` defaults
- ✅ Enforces macOS Docker path restrictions
- ✅ Runs before `docker-build` in CI pipeline

**Script:** `scripts/ci/validate-docker-compose.sh`

## 📋 Testing

- ✅ Docker compose validation: Passed
- ✅ Quality gate validation: Passed  
- ✅ Local validation script: Passed
- ⏳ CI/CD pipeline: Running

## 📦 Files Changed

| File | Change | Purpose |
|------|--------|---------|
| `docker-compose.yaml` | Modified | Removed `./src` and `./shared` mounts from all services |
| `scripts/setup/uninstall.sh` | New | Complete uninstall with backup option |
| `scripts/setup/version.sh` | New | Version check and update notifications |
| `scripts/ci/validate-docker-compose.sh` | New | CI validation to prevent regression |
| `.github/workflows/ci.yml` | Modified | Added `docker-compose-validation` job |
| `package.json` | Modified | Version bump: 6.0.0 → 6.0.1 |

## 🎯 Impact

### Before
- ❌ Global npm install fails on macOS
- ❌ MCP server won't start after fresh install
- ❌ No way to uninstall cleanly
- ❌ No version checking

### After
- ✅ Global npm install works on macOS  
- ✅ MCP server starts immediately
- ✅ Clean uninstall with data backup
- ✅ Easy version checking and updates
- ✅ CI prevents this class of bugs

## 🚀 Release Plan

1. ✅ Create PR (this PR)
2. ⏳ Wait for CI/CD to pass
3. ⏳ CodeRabbit review
4. ⏳ Merge to main
5. ⏳ Create GitHub release v6.0.1
6. ⏳ Auto-publish to npm registry

## 🔍 Validation Checklist

- [x] Fix tested locally
- [x] Docker validation script passes
- [x] Quality gates pass
- [x] Version bumped correctly
- [x] Comprehensive commit message
- [ ] CI/CD tests pass
- [ ] CodeRabbit review complete
- [ ] Ready to merge

---

**User Report:** "I just installed latest CSR on new machine and /src could not be mounted with message the path /opt/homebrew/lib/ is not shared from host"

**Resolution:** This PR completely fixes the issue and adds safeguards to prevent recurrence.