### PR TITLE
chore: bump version to 6.0.5 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",


### PR DESCRIPTION
Updates package.json version to 6.0.5 to match the GitHub release.

This enables the npm publish workflow to succeed (previous attempt failed because version 6.0.4 was already published).

**Related:**
- GitHub Release: v6.0.5
- Fixes: npm publish failure in workflow run #18706018684

**Changes:**
- package.json: version 6.0.4 → 6.0.5

**Post-Merge:**
After this is merged, the npm publish will be manually triggered or the release workflow can be re-run.