### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Claude Self-Reflect
+
+[![Run in Smithery](https://smithery.ai/badge/skills/ramakay)](https://smithery.ai/skills?ns=ramakay&utm_source=github&utm_medium=badge)
+
 <div align="center">
 <img src="https://repobeats.axiom.co/api/embed/e45aa7276c6b2d1fbc46a9a3324e2231718787bb.svg" alt="Repobeats analytics image" />
 </div>


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/ramakay)](https://smithery.ai/skills?ns=ramakay&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a badge to the README for quick access to Smithery.
  * Improved formatting with enhanced spacing for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->