### PR TITLE
fix: is_ralph_session() checks active flag, prevents callback loops

### DIFF
--- a/src/runtime/hooks/ralph_state.py
+++ b/src/runtime/hooks/ralph_state.py
@@ -171,16 +171,27 @@ def save_state(state: RalphState, path: Path = None) -> None:
 
 
 def is_ralph_session() -> bool:
-    """Check if current directory has an active Ralph session.
+    """Check if current directory has an ACTIVE Ralph session.
 
     Checks for both:
     - .claude/ralph-loop.local.md (ralph-wiggum plugin)
     - .ralph_state.md (our custom state file)
+
+    Returns False if file exists but active: false.
     """
-    return (
-        Path('.claude/ralph-loop.local.md').exists() or
-        Path('.ralph_state.md').exists()
-    )
+    for path in [Path('.claude/ralph-loop.local.md'), Path('.ralph_state.md')]:
+        if path.exists():
+            try:
+                content = path.read_text()
+                # Check for active: false explicitly
+                if 'active: false' in content:
+                    return False
+                # Check for active: true or assume active if file exists without active flag
+                if 'active: true' in content or 'active:' not in content:
+                    return True
+            except Exception:
+                pass
+    return False
 
 
 def get_ralph_state_path() -> Optional[Path]:


### PR DESCRIPTION
## Summary
- Fix `is_ralph_session()` to properly check `active: true/false` in state files
- Previously only checked if file exists, causing hooks to fire even after loop completion

## Problem
After a Ralph loop completes and sets `active: false`, the hooks would continue firing because `is_ralph_session()` only checked file existence, not the active flag. This caused repeated "callback hook blocking error" messages.

## Solution
Now properly parses file content:
- `active: false` → returns False (loop completed, hooks should not fire)
- `active: true` → returns True (loop active)
- no active flag → returns True (legacy compatibility)

## Test plan
- [x] Start Ralph loop, complete it, verify no more callback errors
- [x] Verify is_ralph_session() returns False when active: false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session state detection to be more robust and explicit about active status. The system now properly handles explicitly inactive sessions, checks multiple state file locations, and gracefully recovers from read errors, ensuring accurate and reliable session status determination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->