### PR TITLE
fix: switch to npm trusted publishing (remove NPM_TOKEN)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,11 +275,9 @@ jobs:
         node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
     
-    - name: Publish to npm with provenance
+    - name: Publish to npm with provenance (trusted publishing)
       run: |
         npm publish --provenance --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-github-release:
     needs: publish-npm


### PR DESCRIPTION
## Summary
- Removes NPM_TOKEN environment variable from publish job
- OIDC-based trusted publishing is now configured on npmjs.com
- The `id-token: write` permission handles authentication automatically

## Why
The previous release v7.1.1 failed to publish to npm because the NPM_TOKEN was expired/revoked. 
With trusted publishing enabled, npm uses GitHub's OIDC provider for authentication instead of static tokens.

## Test Plan
- [ ] CI passes
- [ ] After merge, create release v7.1.2 to verify npm publish works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow infrastructure to improve deployment security and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->