### PR TITLE
fix: configure npm for OIDC-based trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,17 +264,24 @@ jobs:
     needs: [python-test, npm-package-test, npm-pack-smoke-test, docker-build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'created'
-    
+    environment: npm-publish
+
     steps:
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-    
+
     - uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        registry-url: 'https://registry.npmjs.org'
-    
+
+    - name: Configure npm for OIDC-based trusted publishing
+      run: |
+        # Remove any existing .npmrc that might have old token references
+        rm -f ~/.npmrc
+        # Configure npm registry without static token (OIDC will handle auth)
+        npm config set registry https://registry.npmjs.org
+
     - name: Publish to npm with provenance (trusted publishing)
       run: |
         npm publish --provenance --access public


### PR DESCRIPTION
## Summary
Fix npm publish to use true OIDC-based authentication without legacy tokens.

## Changes
- Remove `registry-url` from setup-node (prevents automatic .npmrc with token reference)
- Add `environment: npm-publish` for OIDC authentication flow
- Add step to clean up any existing .npmrc before publish
- Configure npm registry without static token

## Why
v7.1.2 publish failed because the old NPM_TOKEN secret (even though not referenced in code) was being auto-injected by setup-node's registry-url option. This change enables true tokenless publishing via GitHub OIDC.

## Note
This requires the "npm-publish" environment to be created in GitHub repository settings if not already present.