### PR TITLE
chore: v7.1.3 release - OIDC publishing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",


### PR DESCRIPTION
Version bump to 7.1.3 to test OIDC-based npm trusted publishing workflow.