### PR TITLE
fix: restore npm token-based publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,8 @@ jobs:
     needs: [python-test, npm-package-test, npm-pack-smoke-test, docker-build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'created'
-    environment: npm-publish
+    # Environment name MUST match what's configured on npmjs.com Trusted Publisher
+    environment: npm
 
     steps:
     - uses: actions/checkout@v5
@@ -273,18 +274,20 @@ jobs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '22.x'  # Node 22 has npm 11.x which supports OIDC trusted publishing
+        registry-url: 'https://registry.npmjs.org'
 
-    - name: Configure npm for OIDC-based trusted publishing
+    - name: Verify npm version for OIDC support
       run: |
-        # Remove any existing .npmrc that might have old token references
-        rm -f ~/.npmrc
-        # Configure npm registry without static token (OIDC will handle auth)
-        npm config set registry https://registry.npmjs.org
+        echo "Node version: $(node --version)"
+        echo "npm version: $(npm --version)"
+        # npm 11.5+ required for OIDC trusted publishing
+        npm --version | grep -E '^1[1-9]\.' || { echo "Warning: npm 11.5+ recommended for OIDC"; }
 
-    - name: Publish to npm with provenance (trusted publishing)
-      run: |
-        npm publish --provenance --access public
+    - name: Publish to npm with OIDC trusted publishing
+      run: npm publish --access public
+      # NO NODE_AUTH_TOKEN - OIDC handles authentication via id-token: write permission
+      # Provenance is automatic with trusted publishing
 
   create-github-release:
     needs: publish-npm


### PR DESCRIPTION
## Summary
Configure proper npm OIDC trusted publishing after classic tokens were deprecated.

## Changes
- Use Node 22.x (has npm 11.x with OIDC support)
- Add `environment: npm` (MUST match npmjs.com Trusted Publisher config)
- Remove NODE_AUTH_TOKEN (OIDC handles auth via id-token: write)
- Add npm version verification step
- Provenance is automatic with trusted publishing (no --provenance flag needed)

## Background
[npm deprecated classic tokens in December 2025](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/). The new approach uses [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers/) which eliminates the need for managing tokens.

## Required: Configure Trusted Publisher on npmjs.com

Before this will work, you must configure Trusted Publisher:

1. Go to [npmjs.com → claude-self-reflect → Settings](https://www.npmjs.com/package/claude-self-reflect/access)
2. Find "Trusted Publisher" section
3. Click "Add GitHub Actions"
4. Configure:
   - **Organization/User**: ramakay
   - **Repository**: claude-self-reflect
   - **Workflow filename**: ci.yml
   - **Environment**: npm

## After Configuration
Create a new release and the npm publish should succeed without any tokens.