### PR TITLE
chore: v7.1.4 - verify OIDC trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",


### PR DESCRIPTION
Version bump to test npm OIDC trusted publishing now that Trusted Publisher is configured on npmjs.com.