### PR TITLE
chore: v7.1.5 - npm OIDC publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",


### PR DESCRIPTION
Version bump to test npm OIDC with npm 11.5+ and no registry-url.