### PR TITLE
fix: add --provenance flag for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,8 +292,9 @@ jobs:
         rm -f ~/.npmrc
         # Configure registry
         npm config set registry https://registry.npmjs.org
-        # Publish with OIDC (id-token: write permission handles auth)
-        npm publish --access public
+        # Publish with provenance - this ENABLES OIDC authentication + adds SLSA attestation
+        # See: https://docs.npmjs.com/generating-provenance-statements
+        npm publish --access public --provenance
 
   create-github-release:
     needs: publish-npm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.5",
+  "version": "7.1.6",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary
Adds the `--provenance` flag to `npm publish` which enables OIDC authentication for npm trusted publishing.

## Problem
v7.1.5 failed to publish with `ENEEDAUTH` error because npm wasn't using OIDC authentication.

## Solution
The `--provenance` flag enables two things:
1. **OIDC authentication** - Uses GitHub Actions OIDC token instead of npm tokens
2. **SLSA provenance attestation** - Adds verifiable build attestation

## Changes
- Added `--provenance` to npm publish command
- Bumped version to 7.1.6

## References
- https://docs.npmjs.com/generating-provenance-statements
- https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/

## Test Plan
- [ ] CI passes
- [ ] npm publish succeeds with provenance
- [ ] Verify version 7.1.6 on npmjs.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package publishing with provenance statements for improved security and integrity verification
  * Released version 7.1.6

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->