### PR TITLE
fix: environment mismatch - use 'prod' to match npmjs.com trusted publisher

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 2
-max_iterations: 5
-completion_promise: "Release completed"
-started_at: "2026-01-04T20:20:34Z"
----
-
-Prepare for release, to do this check all sub-agents and their prompts do they satisfy all ralph related checks including runaway loops, run all subagents that test the system, then ensure that coderabbit and other claude ci/cd checks are run sleep and fix them, then prepare for a gh release - review the github ci.yml it should publish to npm automatically since i just now setup trusted publishing but make sure subagent understands this and can prove a npm release occurred.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'created'
     # Environment name MUST match what's configured on npmjs.com Trusted Publisher
-    environment: npm
+    # npmjs.com shows: ramakay/claude-self-reflect, ci.yml, environment: prod
+    environment: prod
 
     steps:
     - uses: actions/checkout@v5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.7",
+  "version": "7.1.8",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Root Cause Found

The npmjs.com Trusted Publisher was configured with:
- Repository: `ramakay/claude-self-reflect`
- Workflow: `ci.yml`
- **Environment: `prod`**

But our workflow used `environment: npm` - this mismatch caused OIDC authentication to fail!

## Changes
- Changed workflow environment from `npm` to `prod`
- Created `prod` environment in GitHub repo
- Bumped version to 7.1.8

## Expected Result
npm publish should now succeed with OIDC trusted publishing.

## Verification
After merge and release:
```bash
npm view claude-self-reflect version  # Should show 7.1.8
```