### PR TITLE
fix: Include scripts/ralph/** in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.9",
+  "version": "7.1.10",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",
@@ -39,6 +39,7 @@
     "scripts/auto-migrate.cjs",
     "scripts/migrate-to-unified-state.py",
     "scripts/csr-status",
+    "scripts/ralph/**",
     "mcp-server/src/**/*.py",
     "mcp-server/pyproject.toml",
     "mcp-server/run-mcp.sh",


### PR DESCRIPTION
## Summary
CRITICAL FIX: The install_hooks.sh script was missing from the npm package.

## Problem
- package.json files array only had `src/**/*.sh`
- `scripts/ralph/install_hooks.sh` was NOT being packaged
- Setup wizard calls `install_hooks.sh` but file was missing
- Ralph hook installation failed for all npm users of v7.1.9

## Fix
Added `"scripts/ralph/**"` to the files array in package.json.

## Test plan
- [x] Verified with `npm pack --dry-run` - install_hooks.sh now included
- [x] Version bumped to 7.1.10

## Files Changed
- `package.json` - Added scripts/ralph/** to files array, bumped version

## Impact
All users who ran `claude-self-reflect setup` on v7.1.9 would have failed to install Ralph hooks. This patch fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 7.1.10.
  * Updated package distribution to include additional script files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->