### PR TITLE
fix: include docs/design in npm package for Docker builds (#124)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.10",
+  "version": "7.1.11",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",
@@ -53,6 +53,9 @@
     "config/qdrant-config.yaml",
     "docker-compose.yaml",
     "Dockerfile.*",
+    "docs/design/**/*.py",
+    "docs/design/**/*.md",
+    "docs/design/conversation-analyzer/**",
     ".env.example",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
## Summary
- Fix Docker build failure when running `claude-self-reflect setup` from npm install
- Add `docs/design/**/*.py`, `docs/design/**/*.md`, and `docs/design/conversation-analyzer/**` to package.json files array
- Bump version to v7.1.11

## Problem
The `docs/design/` directory containing essential batch processing scripts (including `batch_import_all_projects.py`) was not included in the npm package, causing Docker build failures:

```
=> ERROR [batch-watcher 7/9] COPY docs/design/ ./docs/design/
target batch-watcher: failed to solve: failed to compute cache key:
failed to calculate checksum ...: "/docs/design": not found
```

## Solution
Added the missing `docs/design/` directory to package.json files array.

## Test plan
- [ ] Run `npm pack --dry-run` and verify docs/design files are included
- [ ] Run `npm install -g claude-self-reflect@latest` and `claude-self-reflect setup`
- [ ] Verify Docker build completes successfully

Fixes #124

Reported-by: @uhl-solutions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 7.1.11.
  * Expanded published package contents to include design documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->