### PR TITLE
fix: include requirements.txt in npm package for Docker builds (#124)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "7.1.11",
+  "version": "7.1.12",
   "description": "Give Claude perfect memory of all your conversations - Installation wizard for Python MCP server",
   "keywords": [
     "claude",
@@ -56,6 +56,7 @@
     "docs/design/**/*.py",
     "docs/design/**/*.md",
     "docs/design/conversation-analyzer/**",
+    "requirements.txt",
     ".env.example",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
## Summary
- Fix Docker build failure when running `claude-self-reflect setup` from npm install
- Add `requirements.txt` to package.json files array
- Bump version to v7.1.12

## Problem
The `requirements.txt` file was not included in the npm package, causing Docker build failures:

```
=> ERROR [batch-monitor 4/9] COPY requirements.txt .
failed to compute cache key: failed to calculate checksum ...: "/requirements.txt": not found
```

This is a follow-up to the previous fix for `docs/design/` (v7.1.11).

## Solution
Added `requirements.txt` to package.json files array.

## Test plan
- [ ] Run `npm pack --dry-run` and verify requirements.txt is included
- [ ] Run `npm install -g claude-self-reflect@latest` and `claude-self-reflect setup`
- [ ] Verify Docker build completes successfully

Fixes #124

Reported-by: @uhl-solutions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 7.1.12
  * Updated project packaging configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->