### PR TITLE
fix: batch watcher re-queue loop causing repeated API spend

### DIFF
--- a/src/runtime/batch_watcher.py
+++ b/src/runtime/batch_watcher.py
@@ -291,10 +291,10 @@ class BatchWatcher:
         logger.info(f"   Files: {len(batch_files)}")
         logger.info(f"{'='*60}\n")
 
-        try:
-            import subprocess
+        import subprocess
 
-            # Run batch import script with configurable timeout
+        # Step 1: Run the batch import
+        try:
             result = subprocess.run(
                 [sys.executable, str(BATCH_IMPORT_SCRIPT)],
                 capture_output=True,
@@ -306,29 +306,35 @@ class BatchWatcher:
             logger.info("\n✅ Batch triggered successfully")
             logger.info("   Output:\n%s", result.stdout)
 
-            # Mark files as processed
-            for entry in batch_files:
-                self.state_manager.add_imported_file(
-                    file_path=entry["file_path"],
-                    chunks=0,  # Will be updated by batch import
-                    metadata={"batch_queued": True}
-                )
-
         except subprocess.CalledProcessError as cpe:
             logger.error("❌ Batch import failed (rc=%s)", cpe.returncode)
             logger.error("   Stdout: %s", cpe.stdout)
             logger.error("   Stderr: %s", cpe.stderr)
 
-            # Re-queue failed files
+            # Re-queue only on actual batch failure
             for entry in batch_files:
                 self.batch_queue.add(entry["file_path"], entry["project"])
+            return
 
-        except Exception as e:
-            logger.error("❌ Error triggering batch: %s", e, exc_info=True)
+        except subprocess.TimeoutExpired as te:
+            logger.error("❌ Batch import timed out after %ss", SUBPROCESS_TIMEOUT_SECONDS)
 
-            # Re-queue failed files
+            # Re-queue on timeout
             for entry in batch_files:
                 self.batch_queue.add(entry["file_path"], entry["project"])
+            return
+
+        # Step 2: Mark files as processed (batch succeeded, don't re-queue on failure here)
+        for entry in batch_files:
+            try:
+                self.state_manager.add_imported_file(
+                    file_path=entry["file_path"],
+                    chunks=0,
+                    importer="batch",
+                    status="completed"
+                )
+            except Exception as e:
+                logger.warning("⚠️ Failed to mark %s as processed: %s", entry["file_path"], e)
 
     def _hot_cycle(self):
         """Fast cycle to check for HOT files only."""


### PR DESCRIPTION
## Summary

- Fixed invalid `metadata` kwarg in `add_imported_file()` call that caused TypeError after every successful batch
- Separated batch execution from state tracking so state failures don't re-queue already-processed files
- Added explicit `TimeoutExpired` handling

## Root Cause

`_trigger_batch()` called `state_manager.add_imported_file(metadata={"batch_queued": True})` but the method doesn't accept a `metadata` parameter (valid params: `importer`, `collection`, `embedding_mode`, `status`). This caused every batch run to:

1. Process conversations successfully (spending ~$1.13/run)
2. Crash on the state-tracking call
3. Re-queue all files via the generic exception handler
4. Repeat every ~15 minutes

**Impact**: ~87 redundant batch runs over 8 days, reprocessing the same ~60 conversations each time.

## Test plan

- [x] Unit test: `add_imported_file(importer="batch")` succeeds
- [x] Unit test: `add_imported_file(metadata=...)` raises TypeError (confirms old bug)
- [x] Control flow: batch success + state success -> queue empty
- [x] Control flow: batch failure -> files re-queued
- [x] Control flow: batch success + state failure -> queue empty (the fix)
- [x] Control flow: batch timeout -> files re-queued
- [x] Docker image rebuilt and `--once` run completes without errors
- [x] Quality gate passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved batch import error handling with automatic retry of failed batches
  * Enhanced tracking of successfully imported files with more reliable completion marking
  * More robust failure recovery in batch processing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->