### PR TITLE
fix: npm OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,5 +99,3 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Give Claude perfect memory of all your conversations. Single binary, zero dependencies.",
   "keywords": [
     "claude",


### PR DESCRIPTION
Remove NPM_TOKEN (OIDC handles auth). Bump version to 8.0.1.