### PR TITLE
fix: npm OIDC final

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - run: |
-          npm config set registry https://registry.npmjs.org/
-          npm publish --provenance --access public
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
registry-url must be in setup-node (not npm config set). Node 24. No NODE_AUTH_TOKEN. Per https://docs.npmjs.com/trusted-publishers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process infrastructure, including Node.js runtime version update and npm registry configuration improvements to ensure consistent and secure package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->