### PR TITLE
feat: add demo GIF card to docs-site landing page

### DIFF
--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -1168,6 +1168,20 @@ export default function Landing() {
           <OneBinaryCard />
           <PipelineCard />
           <PrivacyCard />
+          <BentoCard className="card--demo" delay={700}>
+            <CardKicker number="—" label="SEE IT IN ACTION" />
+            <h2 className="type-hl-md">The Demo</h2>
+            <p className="type-dateline mt-2">Real queries, real results — from actual sessions</p>
+            <img
+              src="/claude-self-reflect/images/csr-demo.gif"
+              alt="CSR demo showing semantic search, cross-project search, and activity timeline"
+              className="demo-gif"
+              loading="lazy"
+              width={800}
+              height={448}
+              style={{ width: '100%', height: 'auto', borderRadius: 6, marginTop: 12 }}
+            />
+          </BentoCard>
           <InstallCard />
           <WhatYouAskCard />
           <ArchCard />


### PR DESCRIPTION
## Summary
- Adds a demo GIF bento card to the docs-site landing page after the Forgetting Problem card
- Shows real CSR queries in action (semantic search, cross-project search, activity timeline)
- Uses the same GIF already in the README

## Test plan
- [ ] Verify card renders on docs-site landing page
- [ ] GIF loads and plays correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new demo showcase on the landing page with visual content, optimized performance, and improved accessibility features to help users explore the platform's capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->