### PR TITLE
fix: correct GoatCounter subdomain

### DIFF
--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -15,7 +15,7 @@
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
     <!-- GoatCounter: privacy-friendly analytics (no cookies, GDPR-safe, open source) -->
-    <script data-goatcounter="https://claude-self-reflect.goatcounter.com/count"
+    <script data-goatcounter="https://csr.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fix analytics URL: claude-self-reflect.goatcounter.com → csr.goatcounter.com