### PR TITLE
docs: add What's New v8.2.0 card to docs-site

### DIFF
--- a/docs-site/src/index.css
+++ b/docs-site/src/index.css
@@ -656,9 +656,10 @@ body {
 .card--install { grid-column: 4 / -1; grid-row: 3; }
 .card--ask { grid-column: 1 / -1; grid-row: 4; }
 .card--arch { grid-column: 1 / -1; grid-row: 5; }
-.card--flatfile { grid-column: 1 / span 4; grid-row: 7; }
-.card--kgraph { grid-column: 5 / span 4; grid-row: 7; }
-.card--hosted { grid-column: 9 / span 4; grid-row: 7; }
+.card--whatsnew { grid-column: 1 / -1; grid-row: 6; }
+.card--flatfile { grid-column: 1 / span 4; grid-row: 8; }
+.card--kgraph { grid-column: 5 / span 4; grid-row: 8; }
+.card--hosted { grid-column: 9 / span 4; grid-row: 8; }
 
 /* AST card internals */
 .ast-layout {
@@ -1057,6 +1058,29 @@ body {
   background:
     radial-gradient(circle at 72% 38%, rgba(220,232,207,0.34), transparent 46%),
     rgba(255,255,255,0.76);
+}
+
+.card--whatsnew {
+  background:
+    radial-gradient(circle at 30% 50%, rgba(200,210,240,0.25), transparent 50%),
+    rgba(255,255,255,0.82);
+}
+.whatsnew-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.whatsnew-list li {
+  flex: 1 1 280px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-body);
+}
+.whatsnew-list strong {
+  color: var(--color-heading);
 }
 
 .card--install {

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -814,6 +814,24 @@ function KnowledgeGraphCard() {
   )
 }
 
+function WhatsNewCard() {
+  return (
+    <BentoCard className="card--whatsnew" delay={560} id="whats-new">
+      <CardKicker number="—" label="LATEST RELEASE" accent="purple" />
+      <h2 className="type-hl-sm">What's New in v8.2.0</h2>
+      <ul className="whatsnew-list">
+        <li>
+          <strong>Tool safety annotations</strong> — all 12 MCP tools declare read-only, idempotent, and destructive hints so Claude Code calls them with confidence
+        </li>
+        <li>
+          <strong>Index reconciliation</strong> — HNSW cache now reconciles against DB on startup, eliminating phantom search results from deleted reflections
+        </li>
+      </ul>
+      <a className="cite-link" href="https://github.com/ramakay/claude-self-reflect/releases/tag/v8.2.0" target="_blank" rel="noopener noreferrer">Full release notes →</a>
+    </BentoCard>
+  )
+}
+
 function HostedMemoryCard() {
   return (
     <BentoCard className="card--hosted" delay={960}>
@@ -1157,7 +1175,7 @@ export default function Landing() {
 
       <main className="landing-main">
         <p className="type-dateline landing-dateline" style={{ opacity: datelineVisible ? 1 : 0 }}>
-          Claude Self-Reflect / v8.0 / Rust Engine / Local Memory Archive
+          Claude Self-Reflect / v8.2 / Rust Engine / Local Memory Archive
         </p>
 
         <section className="bento-grid" aria-label="Claude Self-Reflect overview">
@@ -1185,6 +1203,7 @@ export default function Landing() {
           <InstallCard />
           <WhatYouAskCard />
           <ArchCard />
+          <WhatsNewCard />
           <div className="bento-section-header">
             <span />
             <h2>How others do it</h2>


### PR DESCRIPTION
## Summary
- Add a "What's New in v8.2.0" card to the GitHub Pages landing page
- Highlights tool safety annotations and HNSW reconciliation fix
- Links to full release notes on GitHub
- Updates dateline version from v8.0 to v8.2

## Test plan
- [ ] `npm run build` in docs-site (no JS errors)
- [ ] Card renders correctly on landing page
- [ ] Release notes link works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "What's New in v8.2.0" section to the landing page highlighting key features including tool safety annotations and HNSW cache index reconciliation, with links to the complete release notes.

* **Style**
  * Updated card grid layouts for improved spacing and introduced new styling for the What's New card variant and its associated list elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->