### PR TITLE
feat: v8.3.0 — MCP completions, tasks, SwiftBar, injection quality

### DIFF
--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -3190,6 +3190,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Claude Self-Reflect: Rust MCP server with embedded vector search"
 
 [dependencies]
-rmcp = { version = "1.6", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "1.6", features = ["server", "transport-io", "macros", "elicitation"] }
 fastembed = "5.9"
 hnsw_rs = "0.3"
 rusqlite = { version = "0.38", features = ["bundled", "vtab"] }

--- a/csr-engine/src/hooks/prompt_submit.rs
+++ b/csr-engine/src/hooks/prompt_submit.rs
@@ -249,7 +249,8 @@ async fn search_chunks_with_vec(
                 // Prevents stale conversations from winning on semantic similarity alone
                 if let Some(ts) = crate::temporal::parse_timestamp(&chunk.timestamp) {
                     let age_days = (now - ts).num_days();
-                    if age_days > MAX_CHUNK_AGE_DAYS {
+                    // Reject future-dated chunks (clock skew) and stale chunks
+                    if !(0..=MAX_CHUNK_AGE_DAYS).contains(&age_days) {
                         continue;
                     }
                 }

--- a/csr-engine/src/hooks/prompt_submit.rs
+++ b/csr-engine/src/hooks/prompt_submit.rs
@@ -34,6 +34,11 @@ const PROMPT_TOKEN_BUDGET: usize = 500;
 /// Minimum prompt length to trigger search (avoids noise from short prompts).
 const MIN_PROMPT_LENGTH: usize = 15;
 
+/// Maximum age (in days) for chunk results. Chunks older than this are filtered out.
+/// Reflections are exempt — they're intentionally stored for long-term recall.
+/// Prevents 3-month-old conversations from winning on semantic similarity alone.
+const MAX_CHUNK_AGE_DAYS: i64 = 21;
+
 /// Handle the prompt-submit hook.
 /// Wrapped in catch-all: ALWAYS returns Ok(()) to never block Claude Code.
 pub async fn handle(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<()> {
@@ -235,10 +240,20 @@ async fn search_chunks_with_vec(
         idx.search_chunks(query_vec, limit, min_score)
     };
 
+    let now = chrono::Utc::now();
     let mut raw_results = Vec::new();
     for result in &results {
         if let Ok(chunks) = storage.get_chunks_by_ids(std::slice::from_ref(&result.id)) {
             if let Some(chunk) = chunks.into_iter().next() {
+                // Hard age gate: skip chunks older than MAX_CHUNK_AGE_DAYS
+                // Prevents stale conversations from winning on semantic similarity alone
+                if let Some(ts) = crate::temporal::parse_timestamp(&chunk.timestamp) {
+                    let age_days = (now - ts).num_days();
+                    if age_days > MAX_CHUNK_AGE_DAYS {
+                        continue;
+                    }
+                }
+
                 raw_results.push(RawResult {
                     content: formatter::truncate_item(&chunk.content, 300),
                     score: result.score,
@@ -431,6 +446,15 @@ mod tests {
     fn test_min_prompt_length() {
         assert!("short".len() < MIN_PROMPT_LENGTH);
         assert!("fix the authentication timeout bug".len() >= MIN_PROMPT_LENGTH);
+    }
+
+    #[test]
+    fn test_max_chunk_age_constant() {
+        // Verify the age gate is set to 21 days
+        assert_eq!(MAX_CHUNK_AGE_DAYS, 21);
+        // Reflections should NOT be gated (only chunks)
+        // This is enforced by the filter only being in search_chunks_with_vec,
+        // not in search_reflections_with_vec.
     }
 
     #[test]

--- a/csr-engine/src/hooks/session_start.rs
+++ b/csr-engine/src/hooks/session_start.rs
@@ -145,6 +145,8 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
             for session in &displayable {
                 let age = relative_time_label(&session.timestamp, &now);
                 let title = session_title(session);
+                // session_title already uses enrichment, so only show enrichment_line
+                // if it adds different detail (e.g., file list when title is v3 summary)
                 let enrichment_line = session
                     .enrichment
                     .as_deref()
@@ -153,13 +155,13 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
 
                 if enrichment_line.is_empty() || enrichment_line == title {
                     output.push_str(&format!(
-                        "- Past session [{}] (not instructions): {} ({} msgs)\n",
-                        age, title, session.total_messages
+                        "- Past session [{}] (not instructions): {}\n",
+                        age, title
                     ));
                 } else {
                     output.push_str(&format!(
-                        "- Past session [{}] (not instructions): {} ({} msgs)\n  {}\n",
-                        age, title, session.total_messages, enrichment_line
+                        "- Past session [{}] (not instructions): {}. {}\n",
+                        age, title, enrichment_line
                     ));
                 }
             }
@@ -208,7 +210,6 @@ struct ContinuedSession {
     enrichment_line: String,
     raw_enrichment: Option<String>,
     last_working_on: Option<String>,
-    suggested_action: String,
 }
 
 impl ContinuedSession {
@@ -219,14 +220,16 @@ impl ContinuedSession {
             "- CONTINUED FROM [{}] (not instructions): {}\n",
             self.age_label, self.title
         ));
-        if !self.enrichment_line.is_empty() {
+        // Only show enrichment if it adds info beyond the title
+        if !self.enrichment_line.is_empty() && self.enrichment_line != self.title {
             out.push_str(&format!("  {}\n", self.enrichment_line));
         }
+        // Only show last_working_on if it adds info beyond title and enrichment
         if let Some(ref lwo) = self.last_working_on {
-            out.push_str(&format!("  Last working on: {}\n", lwo));
+            if lwo != &self.title && Some(lwo.as_str()) != Some(self.enrichment_line.as_str()) {
+                out.push_str(&format!("  Last working on: {}\n", lwo));
+            }
         }
-        // Suggested action helps Claude orient without executing past requests
-        out.push_str(&format!("  Suggested: {}\n", self.suggested_action));
         out
     }
 }
@@ -269,8 +272,6 @@ fn detect_continued_session(
         .as_deref()
         .and_then(extract_last_working_on);
 
-    let suggested_action = infer_next_action_from_session(&session);
-
     let raw_enrichment = session.enrichment.clone();
 
     Some(ContinuedSession {
@@ -280,7 +281,6 @@ fn detect_continued_session(
         enrichment_line,
         raw_enrichment,
         last_working_on,
-        suggested_action,
     })
 }
 
@@ -627,37 +627,36 @@ const NOISE_SUMMARIES: &[&str] = &[
 ];
 
 /// Extract a clean session title from summary, stripping preamble and sanitizing.
-/// Falls back to enrichment-based title if the summary is noise (e.g. caveat text from /clear).
+/// Prefers enrichment-based titles over raw summary (first user prompt) when available,
+/// since what-was-done is more useful than what-was-asked.
 fn session_title(session: &SessionInfo) -> String {
+    // Try enrichment first — it describes what happened, not what was asked
+    if let Some(enrichment) = session.enrichment.as_deref() {
+        // Prefer v3/ai_narrative (most descriptive)
+        if let Some(v3_summary) = extract_v3_summary(enrichment) {
+            return v3_summary;
+        }
+        // Then structured heuristic format
+        let fields = parse_enrichment(enrichment);
+        if fields.has_edit_tool && !fields.files.is_empty() {
+            let file_list: Vec<&str> = fields.files.iter().take(3).map(|s| s.as_str()).collect();
+            return format!("Edited {}", file_list.join(", "));
+        }
+        if !fields.tools.is_empty() {
+            let tool_summary: Vec<&str> = fields.tools.iter().take(3).map(|s| s.as_str()).collect();
+            return format!("Session using {}", tool_summary.join(", "));
+        }
+    }
+
+    // Fall back to summary (first user prompt)
     let raw = session.summary.as_deref().unwrap_or("(no summary)");
     let stripped = strip_preamble(raw);
     let sanitized = sanitize_preview(stripped);
 
-    // Detect noise: if the sanitized summary matches known noise patterns,
-    // try to extract a title from enrichment data instead
+    // Detect noise: caveat text, system-reminders, etc.
     let lower = sanitized.to_lowercase();
     let is_noise = NOISE_SUMMARIES.iter().any(|p| lower.starts_with(p));
-
     if is_noise {
-        // Try enrichment-based title from any enrichment format
-        if let Some(enrichment) = session.enrichment.as_deref() {
-            // Try heuristic format: structured tools/files
-            let fields = parse_enrichment(enrichment);
-            if fields.has_edit_tool && !fields.files.is_empty() {
-                let file_list: Vec<&str> =
-                    fields.files.iter().take(3).map(|s| s.as_str()).collect();
-                return format!("Edited {}", file_list.join(", "));
-            }
-            if !fields.tools.is_empty() {
-                let tool_summary: Vec<&str> =
-                    fields.tools.iter().take(3).map(|s| s.as_str()).collect();
-                return format!("Session using {}", tool_summary.join(", "));
-            }
-            // Try v3/ai_narrative format: extract search summary
-            if let Some(v3_summary) = extract_v3_summary(enrichment) {
-                return v3_summary;
-            }
-        }
         return "(session)".to_string();
     }
 
@@ -845,6 +844,7 @@ fn format_session_line(session: &SessionInfo, now: &DateTime<Utc>) -> String {
 
 /// Infer a suggested next action from enrichment data.
 /// Uses structured enrichment fields for better accuracy than keyword matching.
+#[allow(dead_code)]
 fn infer_next_action_from_session(session: &SessionInfo) -> String {
     // Try enrichment-based inference first
     if let Some(enrichment) = session.enrichment.as_deref() {
@@ -1299,7 +1299,8 @@ mod tests {
     // --- session_title tests ---
 
     #[test]
-    fn test_session_title_strips_preamble() {
+    fn test_session_title_strips_preamble_no_enrichment() {
+        // When no enrichment, falls back to summary with preamble stripped
         let session = SessionInfo {
             conversation_id: "abc".to_string(),
             project_name: "test".to_string(),
@@ -1312,6 +1313,23 @@ mod tests {
         let title = session_title(&session);
         assert!(!title.contains("Implement the following plan"));
         assert!(title.contains("Fix the timeline bugs"));
+    }
+
+    #[test]
+    fn test_session_title_prefers_enrichment_over_summary() {
+        // When enrichment has v3 summary, use it instead of raw prompt
+        let session = SessionInfo {
+            conversation_id: "abc".to_string(),
+            project_name: "test".to_string(),
+            timestamp: "2026-02-15T10:00:00Z".to_string(),
+            total_messages: 50,
+            chunk_count: 2,
+            summary: Some("Please fix the auth bug and make it work".to_string()),
+            enrichment: Some("## Search Summary\nFixed authentication timeout by increasing JWT expiry\n\n## Other".to_string()),
+        };
+        let title = session_title(&session);
+        assert!(title.contains("authentication timeout"));
+        assert!(!title.contains("Please fix"));
     }
 
     #[test]
@@ -1369,7 +1387,7 @@ mod tests {
     }
 
     #[test]
-    fn test_session_title_system_reminder_noise() {
+    fn test_session_title_system_reminder_with_enrichment() {
         let session = SessionInfo {
             conversation_id: "abc".to_string(),
             project_name: "test".to_string(),
@@ -1383,7 +1401,7 @@ mod tests {
             enrichment: Some("[Heuristic] Project: test\nTools: Bash, Read".to_string()),
         };
         let title = session_title(&session);
-        // Should fall back to enrichment tools since summary is noise
+        // Enrichment is now preferred over summary (not just a fallback)
         assert!(title.contains("Session using"));
         assert!(title.contains("Bash"));
     }
@@ -1626,15 +1644,16 @@ mod tests {
             title: "Seedance API video generation".to_string(),
             enrichment_line: "Tools: Edit, Bash | Files: api/seedance.ts, lib/video.ts".to_string(),
             raw_enrichment: Some("[Heuristic] Project: test\nTools: Edit, Bash\nFiles: api/seedance.ts, lib/video.ts".to_string()),
-            last_working_on: Some("api/seedance.ts, lib/video.ts".to_string()),
-            suggested_action: "Continue work on api/seedance.ts".to_string(),
+            last_working_on: Some("editing api/seedance.ts, lib/video.ts".to_string()),
         };
         let header = cont.format_header();
         assert!(header.contains("SESSION CONTINUITY DETECTED"));
         assert!(header.contains("CONTINUED FROM [12m ago]"));
         assert!(header.contains("Seedance API video generation"));
         assert!(header.contains("Tools: Edit, Bash"));
-        assert!(header.contains("Last working on: api/seedance.ts"));
+        assert!(header.contains("Last working on: editing"));
+        // Suggested line should NOT be present (removed as noise)
+        assert!(!header.contains("Suggested:"));
     }
 
     #[test]
@@ -1646,12 +1665,29 @@ mod tests {
             enrichment_line: String::new(),
             raw_enrichment: None,
             last_working_on: None,
-            suggested_action: "Continue where you left off — ask what's next".to_string(),
         };
         let header = cont.format_header();
         assert!(header.contains("CONTINUED FROM [5m ago]"));
         assert!(header.contains("Quick fix"));
         assert!(!header.contains("Last working on"));
+        assert!(!header.contains("Suggested:"));
+    }
+
+    #[test]
+    fn test_continued_session_skips_redundant_enrichment() {
+        // When enrichment_line equals title, don't repeat it
+        let cont = ContinuedSession {
+            conversation_id: "abc".to_string(),
+            age_label: "3m ago".to_string(),
+            title: "Edited main.rs, lib.rs".to_string(),
+            enrichment_line: "Edited main.rs, lib.rs".to_string(),
+            raw_enrichment: None,
+            last_working_on: Some("editing main.rs, lib.rs".to_string()),
+        };
+        let header = cont.format_header();
+        // Title appears once in CONTINUED FROM line
+        let count = header.matches("Edited main.rs, lib.rs").count();
+        assert_eq!(count, 1, "enrichment should not repeat title");
     }
 
     #[test]

--- a/csr-engine/src/injection/predictor.rs
+++ b/csr-engine/src/injection/predictor.rs
@@ -3,7 +3,8 @@
 //! Raw semantic similarity alone isn't enough — recency, file overlap,
 //! and error pattern matching improve relevance for injection.
 //!
-//! Scoring formula: `final = semantic * 0.5 + recency * 0.2 + file_overlap * 0.2 + error_match * 0.1`
+//! Scoring formula: weighted combination via LAPI phase profiles (see weights.rs).
+//! Recency decay: 2^(-age/14) — 14-day half-life to suppress stale results.
 
 use std::collections::HashSet;
 
@@ -149,7 +150,9 @@ fn score_result(
 }
 
 /// Compute recency boost: 1.0 for today, decaying with age.
-/// Uses formula: 2^(-age_days / 30) — halves every 30 days.
+/// Uses formula: 2^(-age_days / 14) — halves every 14 days (steeper decay).
+/// Previous: 30-day half-life let 3-month-old results dominate on semantic alone.
+/// Now: 14d=0.5, 30d=0.23, 60d=0.05 — stale content gets crushed.
 fn compute_recency_boost(timestamp: Option<&str>) -> f32 {
     let ts = match timestamp {
         Some(ts) => ts,
@@ -164,8 +167,8 @@ fn compute_recency_boost(timestamp: Option<&str>) -> f32 {
     let now = chrono::Utc::now();
     let age_days = (now - parsed).num_days().max(0) as f64;
 
-    // 2^(-age/30): 1.0 today, 0.5 at 30 days, 0.25 at 60 days
-    (2.0_f64.powf(-age_days / 30.0)) as f32
+    // 2^(-age/14): 1.0 today, 0.5 at 14 days, 0.23 at 30 days, 0.05 at 60 days
+    (2.0_f64.powf(-age_days / 14.0)) as f32
 }
 
 /// Compute file overlap: fraction of current session files that appear in result.
@@ -280,7 +283,8 @@ mod tests {
     #[test]
     fn test_recency_boost() {
         let now = chrono::Utc::now().to_rfc3339();
-        let old = "2025-01-01T00:00:00Z".to_string();
+        // Use a timestamp ~60 days ago (clearly old, will have very low recency)
+        let old = (chrono::Utc::now() - chrono::Duration::days(60)).to_rfc3339();
 
         let results = vec![
             RawResult {

--- a/csr-engine/src/injection/weights.rs
+++ b/csr-engine/src/injection/weights.rs
@@ -34,8 +34,8 @@ impl WeightProfile {
                 phase_boost: 0.40,
             },
             HookPhase::PromptSubmit => Self {
-                semantic: 0.40,
-                recency: 0.15,
+                semantic: 0.30,
+                recency: 0.25,
                 file_overlap: 0.20,
                 error_match: 0.10,
                 phase_boost: 0.15,
@@ -139,11 +139,19 @@ mod tests {
     }
 
     #[test]
-    fn test_prompt_submit_prefers_semantic() {
+    fn test_prompt_submit_balances_semantic_and_recency() {
         let w = WeightProfile::for_phase(HookPhase::PromptSubmit);
         assert!(
             w.semantic >= w.phase_boost,
-            "PromptSubmit should weight semantic match highest"
+            "PromptSubmit should weight semantic above phase_boost"
+        );
+        assert!(
+            w.recency >= w.phase_boost,
+            "PromptSubmit should weight recency above phase_boost"
+        );
+        assert!(
+            w.semantic + w.recency > 0.5,
+            "semantic + recency should dominate PromptSubmit scoring"
         );
     }
 

--- a/csr-engine/src/main.rs
+++ b/csr-engine/src/main.rs
@@ -52,11 +52,14 @@ enum Commands {
         #[arg(long)]
         anthropic_key: Option<String>,
     },
-    /// Show system status (JSON by default, --compact for statusline)
+    /// Show system status (JSON by default, --compact for statusline, --swiftbar for menu bar)
     Status {
         /// One-line output for statusline integration
         #[arg(long)]
         compact: bool,
+        /// SwiftBar-compatible output for macOS menu bar plugin
+        #[arg(long)]
+        swiftbar: bool,
     },
     /// Handle Claude Code hook events
     Hook {
@@ -140,8 +143,8 @@ async fn main() -> Result<()> {
         return csr_engine::setup::handle(&args.db_path, &args.projects_dir, anthropic_key).await;
     }
 
-    if let Some(Commands::Status { compact }) = args.command {
-        return csr_engine::status::handle(&args.db_path, &args.projects_dir, compact);
+    if let Some(Commands::Status { compact, swiftbar }) = args.command {
+        return csr_engine::status::handle(&args.db_path, &args.projects_dir, compact, swiftbar);
     }
 
     if let Some(Commands::Daemon {

--- a/csr-engine/src/mcp/completions.rs
+++ b/csr-engine/src/mcp/completions.rs
@@ -1,0 +1,160 @@
+//! MCP Completions — autocomplete for tool arguments.
+//!
+//! Implements `ServerHandler::complete()` to provide prefix-filtered suggestions
+//! for tool parameters like project names, file paths, time ranges, etc.
+//!
+//! Static parameters (time_range, group_by, granularity) use hardcoded lists.
+//! Dynamic parameters (project, file_path, session_id) query the database.
+//! Concept uses semantic nearest-neighbor search from the index.
+
+use rmcp::model::{CompleteRequestParams, CompleteResult, CompletionInfo};
+use std::sync::Arc;
+
+use crate::storage::Storage;
+
+/// Maximum completions to return per request (MCP spec limit).
+const MAX_COMPLETIONS: usize = 100;
+
+/// Static time_range values offered for autocomplete.
+const TIME_RANGE_VALUES: &[&str] = &[
+    "today",
+    "yesterday",
+    "last week",
+    "last 2 weeks",
+    "last month",
+    "last 3 months",
+    "last 6 months",
+];
+
+/// Static group_by values.
+const GROUP_BY_VALUES: &[&str] = &["conversation", "day", "session"];
+
+/// Static granularity values.
+const GRANULARITY_VALUES: &[&str] = &["hour", "day", "week", "month"];
+
+/// Handle a completion request by routing based on the argument name.
+pub fn handle_complete(
+    params: &CompleteRequestParams,
+    storage: &Arc<Storage>,
+) -> Result<CompleteResult, rmcp::ErrorData> {
+    let arg_name = &params.argument.name;
+    let current_value = &params.argument.value;
+
+    let values = match arg_name.as_str() {
+        "project" => complete_project(storage, current_value),
+        "file_path" => complete_file_path(storage, current_value),
+        "time_range" => complete_static(TIME_RANGE_VALUES, current_value),
+        "group_by" => complete_static(GROUP_BY_VALUES, current_value),
+        "granularity" => complete_static(GRANULARITY_VALUES, current_value),
+        "session_id" => complete_session_id(storage, current_value),
+        "concept" => complete_static(&[], current_value), // No static suggestions for concepts
+        _ => Vec::new(),
+    };
+
+    let total = values.len() as u32;
+    let has_more = values.len() >= MAX_COMPLETIONS;
+    let truncated: Vec<String> = values.into_iter().take(MAX_COMPLETIONS).collect();
+
+    let completion = if has_more {
+        CompletionInfo::with_pagination(truncated, Some(total), true)
+    } else {
+        CompletionInfo::new(truncated)
+    }
+    .map_err(|e| rmcp::ErrorData::internal_error(e, None))?;
+
+    Ok(CompleteResult::new(completion))
+}
+
+/// Complete project names from the database.
+fn complete_project(storage: &Arc<Storage>, prefix: &str) -> Vec<String> {
+    storage
+        .list_project_names(prefix, MAX_COMPLETIONS)
+        .unwrap_or_default()
+}
+
+/// Complete file paths from the database.
+fn complete_file_path(storage: &Arc<Storage>, prefix: &str) -> Vec<String> {
+    storage
+        .list_file_paths(prefix, MAX_COMPLETIONS)
+        .unwrap_or_default()
+}
+
+/// Complete session IDs from the database.
+fn complete_session_id(storage: &Arc<Storage>, prefix: &str) -> Vec<String> {
+    storage
+        .list_session_ids(prefix, MAX_COMPLETIONS)
+        .unwrap_or_default()
+}
+
+/// Complete from a static list of values using prefix filtering.
+fn complete_static(values: &[&str], prefix: &str) -> Vec<String> {
+    if prefix.is_empty() {
+        return values.iter().map(|s| s.to_string()).collect();
+    }
+    let lower_prefix = prefix.to_lowercase();
+    values
+        .iter()
+        .filter(|v| v.to_lowercase().starts_with(&lower_prefix))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_complete_static_empty_prefix() {
+        let values = complete_static(TIME_RANGE_VALUES, "");
+        assert_eq!(values.len(), TIME_RANGE_VALUES.len());
+    }
+
+    #[test]
+    fn test_complete_static_prefix_filter() {
+        let values = complete_static(TIME_RANGE_VALUES, "last");
+        assert!(values.iter().all(|v| v.starts_with("last")));
+        assert!(values.contains(&"last week".to_string()));
+        assert!(values.contains(&"last month".to_string()));
+        assert!(!values.contains(&"today".to_string()));
+    }
+
+    #[test]
+    fn test_complete_static_case_insensitive() {
+        let values = complete_static(TIME_RANGE_VALUES, "LAST");
+        assert!(!values.is_empty());
+        assert!(values.contains(&"last week".to_string()));
+    }
+
+    #[test]
+    fn test_complete_static_no_match() {
+        let values = complete_static(TIME_RANGE_VALUES, "xyz");
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn test_complete_group_by() {
+        let values = complete_static(GROUP_BY_VALUES, "");
+        assert_eq!(values, vec!["conversation", "day", "session"]);
+    }
+
+    #[test]
+    fn test_complete_granularity_prefix() {
+        let values = complete_static(GRANULARITY_VALUES, "d");
+        assert_eq!(values, vec!["day"]);
+    }
+
+    #[test]
+    fn test_complete_project_with_db() {
+        let storage = Arc::new(Storage::open_memory().unwrap());
+        // Empty DB should return empty results
+        let values = complete_project(&storage, "");
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn test_complete_session_id_with_db() {
+        let storage = Arc::new(Storage::open_memory().unwrap());
+        let values = complete_session_id(&storage, "abc");
+        assert!(values.is_empty());
+    }
+}

--- a/csr-engine/src/mcp/elicitation.rs
+++ b/csr-engine/src/mcp/elicitation.rs
@@ -1,8 +1,12 @@
 //! MCP Elicitation — confirmation flow for store_reflection.
 //!
-//! When `store_reflection` receives content >500 chars, it asks the client
+//! When `store_reflection` receives content >2000 chars, it asks the client
 //! to confirm before storing. Uses rmcp's form-based elicitation with a
 //! simple { confirm: boolean } schema.
+//!
+//! Threshold is 2000 chars (not 500) to avoid annoying prompts on normal
+//! reflections. Only truly large content (paste accidents, verbose dumps)
+//! triggers the dialog.
 //!
 //! Graceful fallback: if the client doesn't support elicitation, proceeds
 //! without confirmation (the tool still works, just no guard rail).
@@ -14,7 +18,9 @@ use rmcp::service::RequestContext;
 use rmcp::RoleServer;
 
 /// Content length threshold that triggers confirmation.
-const CONFIRMATION_THRESHOLD: usize = 500;
+/// Set to 2000 to avoid noise on normal reflections — only fires for
+/// unusually large content (paste accidents, verbose log dumps).
+const CONFIRMATION_THRESHOLD: usize = 2000;
 
 /// Check if content should trigger a confirmation dialog.
 pub fn needs_confirmation(content: &str) -> bool {
@@ -64,16 +70,17 @@ mod tests {
     fn test_needs_confirmation_short() {
         assert!(!needs_confirmation("short content"));
         assert!(!needs_confirmation(&"a".repeat(500)));
+        assert!(!needs_confirmation(&"a".repeat(2000)));
     }
 
     #[test]
     fn test_needs_confirmation_long() {
-        assert!(needs_confirmation(&"a".repeat(501)));
-        assert!(needs_confirmation(&"a".repeat(1000)));
+        assert!(needs_confirmation(&"a".repeat(2001)));
+        assert!(needs_confirmation(&"a".repeat(5000)));
     }
 
     #[test]
     fn test_threshold_constant() {
-        assert_eq!(CONFIRMATION_THRESHOLD, 500);
+        assert_eq!(CONFIRMATION_THRESHOLD, 2000);
     }
 }

--- a/csr-engine/src/mcp/elicitation.rs
+++ b/csr-engine/src/mcp/elicitation.rs
@@ -1,0 +1,79 @@
+//! MCP Elicitation — confirmation flow for store_reflection.
+//!
+//! When `store_reflection` receives content >500 chars, it asks the client
+//! to confirm before storing. Uses rmcp's form-based elicitation with a
+//! simple { confirm: boolean } schema.
+//!
+//! Graceful fallback: if the client doesn't support elicitation, proceeds
+//! without confirmation (the tool still works, just no guard rail).
+
+use rmcp::model::{
+    CreateElicitationRequestParams, CreateElicitationResult, ElicitationAction, ElicitationSchema,
+};
+use rmcp::service::RequestContext;
+use rmcp::RoleServer;
+
+/// Content length threshold that triggers confirmation.
+const CONFIRMATION_THRESHOLD: usize = 500;
+
+/// Check if content should trigger a confirmation dialog.
+pub fn needs_confirmation(content: &str) -> bool {
+    content.len() > CONFIRMATION_THRESHOLD
+}
+
+/// Request confirmation from the client for a large reflection.
+/// Returns `true` if confirmed (or if client doesn't support elicitation).
+/// Returns `false` if the user declined or cancelled.
+pub async fn request_confirmation(content: &str, context: &RequestContext<RoleServer>) -> bool {
+    let char_count = content.chars().count();
+    let preview: String = content.chars().take(100).collect();
+    let message = format!(
+        "Store reflection ({} chars)?\n\nPreview: {}...",
+        char_count, preview
+    );
+
+    let schema = ElicitationSchema::builder()
+        .required_bool("confirm")
+        .optional_string("tags")
+        .build();
+
+    let schema = match schema {
+        Ok(s) => s,
+        Err(_) => return true, // Schema build failed, proceed without confirmation
+    };
+
+    let params = CreateElicitationRequestParams::FormElicitationParams {
+        meta: None,
+        message,
+        requested_schema: schema,
+    };
+
+    let result: Result<CreateElicitationResult, _> = context.peer.create_elicitation(params).await;
+
+    match result {
+        Ok(response) => matches!(response.action, ElicitationAction::Accept),
+        Err(_) => true, // Client doesn't support elicitation — proceed without confirmation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_needs_confirmation_short() {
+        assert!(!needs_confirmation("short content"));
+        assert!(!needs_confirmation(&"a".repeat(500)));
+    }
+
+    #[test]
+    fn test_needs_confirmation_long() {
+        assert!(needs_confirmation(&"a".repeat(501)));
+        assert!(needs_confirmation(&"a".repeat(1000)));
+    }
+
+    #[test]
+    fn test_threshold_constant() {
+        assert_eq!(CONFIRMATION_THRESHOLD, 500);
+    }
+}

--- a/csr-engine/src/mcp/mod.rs
+++ b/csr-engine/src/mcp/mod.rs
@@ -1,3 +1,4 @@
+pub mod completions;
 pub mod resources;
 pub mod tools;
 
@@ -563,6 +564,7 @@ impl ServerHandler for CsrServer {
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
+                .enable_completions()
                 .build(),
         )
         .with_instructions(
@@ -572,6 +574,14 @@ impl ServerHandler for CsrServer {
             "csr-engine",
             env!("CARGO_PKG_VERSION"),
         ))
+    }
+
+    async fn complete(
+        &self,
+        request: CompleteRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CompleteResult, rmcp::ErrorData> {
+        completions::handle_complete(&request, &self.storage)
     }
 
     async fn list_resources(

--- a/csr-engine/src/mcp/mod.rs
+++ b/csr-engine/src/mcp/mod.rs
@@ -1,4 +1,5 @@
 pub mod completions;
+pub mod elicitation;
 pub mod resources;
 pub mod tasks;
 pub mod tools;
@@ -252,9 +253,19 @@ impl CsrServer {
     async fn store_reflection(
         &self,
         params: Parameters<StoreReflectionParams>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let p = params.0;
         let tags = p.tags.unwrap_or_default();
+
+        // Elicitation: confirm before storing large reflections
+        if elicitation::needs_confirmation(&p.content)
+            && !elicitation::request_confirmation(&p.content, &context).await
+        {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "Reflection storage declined by user.",
+            )]));
+        }
 
         let result = tools::store_reflection(
             &self.storage,

--- a/csr-engine/src/mcp/mod.rs
+++ b/csr-engine/src/mcp/mod.rs
@@ -1,5 +1,6 @@
 pub mod completions;
 pub mod resources;
+pub mod tasks;
 pub mod tools;
 
 use std::path::PathBuf;
@@ -162,6 +163,7 @@ pub struct CsrServer {
     projects_dir: PathBuf,
     index_dir: PathBuf,
     db_path: String,
+    task_manager: tasks::TaskManager,
 }
 
 #[tool_router]
@@ -187,6 +189,7 @@ impl CsrServer {
             projects_dir,
             index_dir,
             db_path,
+            task_manager: tasks::TaskManager::new(),
         }
     }
 
@@ -565,6 +568,7 @@ impl ServerHandler for CsrServer {
                 .enable_tools()
                 .enable_resources()
                 .enable_completions()
+                .enable_tasks()
                 .build(),
         )
         .with_instructions(
@@ -582,6 +586,82 @@ impl ServerHandler for CsrServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<CompleteResult, rmcp::ErrorData> {
         completions::handle_complete(&request, &self.storage)
+    }
+
+    async fn enqueue_task(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CreateTaskResult, rmcp::ErrorData> {
+        let tool_name = request.name.to_string();
+
+        if !tasks::is_taskable(&tool_name) {
+            return Err(rmcp::ErrorData::invalid_request(
+                format!("Tool '{}' does not support async task execution", tool_name),
+                None,
+            ));
+        }
+
+        // Clone what we need for the spawned task
+        let server = self.clone();
+        let ctx = context;
+
+        let task = self
+            .task_manager
+            .enqueue(&tool_name, async move {
+                // Delegate to the normal call_tool handler
+                server.call_tool(request, ctx).await
+            })
+            .await;
+
+        Ok(CreateTaskResult::new(task))
+    }
+
+    async fn list_tasks(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListTasksResult, rmcp::ErrorData> {
+        // Clean up expired tasks on each list call
+        self.task_manager.cleanup_expired().await;
+        let tasks = self.task_manager.list_tasks().await;
+        Ok(ListTasksResult::new(tasks))
+    }
+
+    async fn get_task_info(
+        &self,
+        request: GetTaskInfoParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetTaskResult, rmcp::ErrorData> {
+        let task = self
+            .task_manager
+            .get_task_info(&request.task_id)
+            .await
+            .ok_or_else(|| {
+                rmcp::ErrorData::invalid_request(
+                    format!("Task '{}' not found", request.task_id),
+                    None,
+                )
+            })?;
+        Ok(GetTaskResult { meta: None, task })
+    }
+
+    async fn get_task_result(
+        &self,
+        request: GetTaskResultParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetTaskPayloadResult, rmcp::ErrorData> {
+        let value = self
+            .task_manager
+            .get_task_result(&request.task_id)
+            .await
+            .ok_or_else(|| {
+                rmcp::ErrorData::invalid_request(
+                    format!("Task '{}' not found or not completed", request.task_id),
+                    None,
+                )
+            })?;
+        Ok(GetTaskPayloadResult::new(value))
     }
 
     async fn list_resources(

--- a/csr-engine/src/mcp/tasks.rs
+++ b/csr-engine/src/mcp/tasks.rs
@@ -1,0 +1,315 @@
+//! MCP Tasks — async wrappers for heavy search operations.
+//!
+//! Wraps slow tools (reflect_on_past, search_by_concept, search_insights,
+//! search_by_recency) in tokio tasks with status tracking. Clients can
+//! poll progress or cancel running operations.
+//!
+//! Task lifecycle: Working → Completed | Failed | Cancelled
+//! Default TTL: 30 seconds after completion.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use rmcp::model::{CallToolResult, Content, Task, TaskStatus};
+
+/// Default TTL for completed tasks (30 seconds in milliseconds).
+const DEFAULT_TTL_MS: u64 = 30_000;
+
+/// Default poll interval suggestion (500ms).
+const DEFAULT_POLL_MS: u64 = 500;
+
+/// Tools eligible for async task execution.
+const TASKABLE_TOOLS: &[&str] = &[
+    "csr_reflect_on_past",
+    "csr_search_by_concept",
+    "csr_search_insights",
+    "search_by_recency",
+];
+
+/// Check if a tool name is eligible for async task execution.
+pub fn is_taskable(tool_name: &str) -> bool {
+    TASKABLE_TOOLS.contains(&tool_name)
+}
+
+/// Internal state for a managed task.
+#[derive(Debug)]
+struct ManagedTask {
+    task: Task,
+    result: Option<CallToolResult>,
+    cancel_token: tokio::sync::watch::Sender<bool>,
+}
+
+/// Task manager that tracks async tool executions.
+#[derive(Clone)]
+pub struct TaskManager {
+    tasks: Arc<Mutex<HashMap<String, ManagedTask>>>,
+    counter: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl Default for TaskManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskManager {
+    pub fn new() -> Self {
+        Self {
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+            counter: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        }
+    }
+
+    /// Generate a unique task ID.
+    fn next_id(&self) -> String {
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        format!("csr-task-{}", n)
+    }
+
+    /// Enqueue a tool call as an async task. Returns the Task immediately.
+    /// The actual work runs in a spawned tokio task.
+    pub async fn enqueue<F>(&self, tool_name: &str, work: F) -> Task
+    where
+        F: std::future::Future<Output = Result<CallToolResult, rmcp::ErrorData>> + Send + 'static,
+    {
+        let task_id = self.next_id();
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let task = Task::new(task_id.clone(), TaskStatus::Working, now.clone(), now)
+            .with_ttl(DEFAULT_TTL_MS)
+            .with_poll_interval(DEFAULT_POLL_MS)
+            .with_status_message(format!("Running {}", tool_name));
+
+        let (cancel_tx, mut cancel_rx) = tokio::sync::watch::channel(false);
+
+        let managed = ManagedTask {
+            task: task.clone(),
+            result: None,
+            cancel_token: cancel_tx,
+        };
+
+        self.tasks.lock().await.insert(task_id.clone(), managed);
+
+        // Spawn the actual work
+        let tasks = self.tasks.clone();
+        let tid = task_id.clone();
+        tokio::spawn(async move {
+            // Use changed() instead of wait_for() to avoid !Send Ref across await
+            let outcome = tokio::select! {
+                result = work => Some(result),
+                _ = async {
+                    loop {
+                        if cancel_rx.changed().await.is_err() { break; }
+                        if *cancel_rx.borrow() { break; }
+                    }
+                } => None,
+            };
+
+            let mut map = tasks.lock().await;
+            if let Some(mt) = map.get_mut(&tid) {
+                let now = chrono::Utc::now().to_rfc3339();
+                match outcome {
+                    Some(Ok(result)) => {
+                        mt.task.status = TaskStatus::Completed;
+                        mt.task.status_message = Some("Done".to_string());
+                        mt.result = Some(result);
+                    }
+                    Some(Err(e)) => {
+                        mt.task.status = TaskStatus::Failed;
+                        mt.task.status_message = Some(format!("Error: {}", e.message));
+                        mt.result = Some(CallToolResult::error(vec![Content::text(
+                            e.message.clone(),
+                        )]));
+                    }
+                    None => {
+                        mt.task.status = TaskStatus::Cancelled;
+                        mt.task.status_message = Some("Cancelled by client".to_string());
+                    }
+                }
+                mt.task.last_updated_at = now;
+            }
+        });
+
+        task
+    }
+
+    /// List all tasks (for `tasks/list`).
+    pub async fn list_tasks(&self) -> Vec<Task> {
+        let map = self.tasks.lock().await;
+        map.values().map(|mt| mt.task.clone()).collect()
+    }
+
+    /// Get info for a specific task (for `tasks/get`).
+    pub async fn get_task_info(&self, task_id: &str) -> Option<Task> {
+        let map = self.tasks.lock().await;
+        map.get(task_id).map(|mt| mt.task.clone())
+    }
+
+    /// Get the result of a completed task (for `tasks/result`).
+    pub async fn get_task_result(&self, task_id: &str) -> Option<serde_json::Value> {
+        let map = self.tasks.lock().await;
+        let mt = map.get(task_id)?;
+        if mt.task.status != TaskStatus::Completed {
+            return None;
+        }
+        let result = mt.result.as_ref()?;
+        serde_json::to_value(result).ok()
+    }
+
+    /// Cancel a running task.
+    pub async fn cancel_task(&self, task_id: &str) -> Option<Task> {
+        let map = self.tasks.lock().await;
+        let mt = map.get(task_id)?;
+        if mt.task.status == TaskStatus::Working {
+            let _ = mt.cancel_token.send(true);
+        }
+        Some(mt.task.clone())
+    }
+
+    /// Clean up expired tasks (TTL-based). Call periodically.
+    pub async fn cleanup_expired(&self) {
+        let now = chrono::Utc::now();
+        let mut map = self.tasks.lock().await;
+        map.retain(|_, mt| {
+            // Only clean up terminal states
+            if matches!(
+                mt.task.status,
+                TaskStatus::Working | TaskStatus::InputRequired
+            ) {
+                return true;
+            }
+            // Check TTL
+            if let Some(ttl_ms) = mt.task.ttl {
+                if let Ok(updated) = mt
+                    .task
+                    .last_updated_at
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                {
+                    let age_ms = (now - updated).num_milliseconds();
+                    return age_ms < ttl_ms as i64;
+                }
+            }
+            true // Keep if we can't determine age
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_is_taskable() {
+        assert!(is_taskable("csr_reflect_on_past"));
+        assert!(is_taskable("search_by_recency"));
+        assert!(!is_taskable("store_reflection"));
+        assert!(!is_taskable("csr_quick_check"));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_and_complete() {
+        let mgr = TaskManager::new();
+
+        // Enqueue a task that completes immediately
+        let task = mgr
+            .enqueue("csr_reflect_on_past", async {
+                Ok(CallToolResult::success(vec![Content::text("found it")]))
+            })
+            .await;
+
+        assert_eq!(task.status, TaskStatus::Working);
+        assert!(task.task_id.starts_with("csr-task-"));
+
+        // Wait for completion
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let info = mgr.get_task_info(&task.task_id).await.unwrap();
+        assert_eq!(info.status, TaskStatus::Completed);
+
+        let result = mgr.get_task_result(&task.task_id).await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_and_fail() {
+        let mgr = TaskManager::new();
+
+        let task = mgr
+            .enqueue("csr_reflect_on_past", async {
+                Err(rmcp::ErrorData::internal_error("search failed", None))
+            })
+            .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let info = mgr.get_task_info(&task.task_id).await.unwrap();
+        assert_eq!(info.status, TaskStatus::Failed);
+        assert!(info.status_message.unwrap().contains("search failed"));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_task() {
+        let mgr = TaskManager::new();
+
+        // Enqueue a slow task
+        let task = mgr
+            .enqueue("csr_reflect_on_past", async {
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                Ok(CallToolResult::success(vec![Content::text("done")]))
+            })
+            .await;
+
+        // Cancel it
+        let cancelled = mgr.cancel_task(&task.task_id).await.unwrap();
+        assert_eq!(cancelled.status, TaskStatus::Working); // Still working at cancel time
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let info = mgr.get_task_info(&task.task_id).await.unwrap();
+        assert_eq!(info.status, TaskStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks() {
+        let mgr = TaskManager::new();
+
+        mgr.enqueue("csr_reflect_on_past", async {
+            Ok(CallToolResult::success(vec![Content::text("a")]))
+        })
+        .await;
+
+        mgr.enqueue("search_by_recency", async {
+            Ok(CallToolResult::success(vec![Content::text("b")]))
+        })
+        .await;
+
+        let tasks = mgr.list_tasks().await;
+        assert_eq!(tasks.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_unique_ids() {
+        let mgr = TaskManager::new();
+        let t1 = mgr
+            .enqueue("csr_reflect_on_past", async {
+                Ok(CallToolResult::success(vec![]))
+            })
+            .await;
+        let t2 = mgr
+            .enqueue("csr_reflect_on_past", async {
+                Ok(CallToolResult::success(vec![]))
+            })
+            .await;
+        assert_ne!(t1.task_id, t2.task_id);
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent_task() {
+        let mgr = TaskManager::new();
+        assert!(mgr.get_task_info("no-such-task").await.is_none());
+        assert!(mgr.get_task_result("no-such-task").await.is_none());
+    }
+}

--- a/csr-engine/src/status.rs
+++ b/csr-engine/src/status.rs
@@ -235,7 +235,7 @@ fn print_swiftbar(report: &StatusReport) {
     println!("---");
     println!("Refresh | refresh=true");
     println!(
-        "Open DB in Terminal | bash=sqlite3 param1={} terminal=true",
+        "Open DB in Terminal | bash=sqlite3 param1=\"{}\" terminal=true",
         report.db_path
     );
 }

--- a/csr-engine/src/status.rs
+++ b/csr-engine/src/status.rs
@@ -40,10 +40,12 @@ pub struct EnrichmentBreakdown {
 }
 
 /// Run status check — opens SQLite directly (no EmbeddingEngine needed).
-pub fn handle(db_path: &Path, projects_dir: &Path, compact: bool) -> Result<()> {
+pub fn handle(db_path: &Path, projects_dir: &Path, compact: bool, swiftbar: bool) -> Result<()> {
     let report = gather_status(db_path, projects_dir)?;
 
-    if compact {
+    if swiftbar {
+        print_swiftbar(&report);
+    } else if compact {
         print_compact(&report);
     } else {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -139,6 +141,151 @@ fn count_jsonl_files(projects_dir: &Path) -> usize {
         }
     }
     count
+}
+
+/// Print SwiftBar-compatible output for macOS menu bar.
+///
+/// SwiftBar format:
+/// - First line = menu bar title (always visible)
+/// - `---` = separator between title and dropdown
+/// - Subsequent lines = dropdown items
+/// - `| color=...` = styling
+/// - `| href=...` = clickable URL
+/// - `--` prefix = submenu item
+fn print_swiftbar(report: &StatusReport) {
+    // Menu bar title: health indicator + chunk count
+    let icon = if report.healthy { "🧠" } else { "⚠️" };
+    let focus = read_current_focus().unwrap_or_default();
+    if focus.is_empty() {
+        println!("{} {}c {}r", icon, report.chunks, report.reflections);
+    } else {
+        // Truncate focus to 30 chars for menu bar
+        let short: String = focus.chars().take(30).collect();
+        println!("{} {}", icon, short);
+    }
+
+    println!("---");
+
+    // Section: Index Stats
+    println!("Index | size=14 color=#888888");
+    println!("--Chunks: {} | font=Menlo", report.chunks);
+    println!("--Reflections: {} | font=Menlo", report.reflections);
+    println!("--Conversations: {} | font=Menlo", report.conversations);
+    println!("--Projects: {} | font=Menlo", report.projects);
+
+    // Section: Import Progress
+    let bar_filled = (report.import_percent / 10.0).round() as usize;
+    let bar_empty = 10_usize.saturating_sub(bar_filled);
+    let bar: String = "█".repeat(bar_filled) + &"░".repeat(bar_empty);
+    println!("---");
+    println!(
+        "Import: {} {:.0}% ({}/{}) | font=Menlo",
+        bar, report.import_percent, report.imported_files, report.total_jsonl_files
+    );
+
+    // Section: Enrichment
+    let total_enriched = report.enrichment.heuristic_completed
+        + report.enrichment.extracted_v3_completed
+        + report.enrichment.ai_narrative_completed;
+    if total_enriched > 0 {
+        println!("---");
+        println!("Enrichment | size=14 color=#888888");
+        println!(
+            "--Heuristic: {} | font=Menlo",
+            report.enrichment.heuristic_completed
+        );
+        println!(
+            "--V3 Extraction: {} | font=Menlo",
+            report.enrichment.extracted_v3_completed
+        );
+        println!(
+            "--AI Narrative: {} | font=Menlo",
+            report.enrichment.ai_narrative_completed
+        );
+        if report.enrichment.ai_narrative_processing > 0 {
+            println!(
+                "--Processing: {} | font=Menlo color=orange",
+                report.enrichment.ai_narrative_processing
+            );
+        }
+    }
+
+    // Section: Health
+    println!("---");
+    let health_label = if report.healthy {
+        "DB: healthy ✓ | color=green"
+    } else {
+        "DB: unhealthy ✗ | color=red"
+    };
+    println!("{}", health_label);
+    let db_mb = report.db_size_bytes as f64 / 1_048_576.0;
+    println!("Size: {:.1} MB | font=Menlo", db_mb);
+    if let Some(ref ts) = report.newest_chunk {
+        let age = format_age(ts);
+        println!("Latest: {} | font=Menlo", age);
+    }
+
+    // Section: Current Focus (from session_start hook)
+    if !focus.is_empty() {
+        println!("---");
+        println!("Focus: {} | font=Menlo", focus);
+    }
+
+    // Section: Quick Actions
+    println!("---");
+    println!("Refresh | refresh=true");
+    println!(
+        "Open DB in Terminal | bash=sqlite3 param1={} terminal=true",
+        report.db_path
+    );
+}
+
+/// Read the current focus file written by session_start hook.
+/// Strips framing prefixes like "[project] SESSION CONTINUITY..." to extract clean focus.
+fn read_current_focus() -> Option<String> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".claude-self-reflect").join("current-focus.txt");
+    let content = std::fs::read_to_string(&path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Strip "[project] " prefix if present
+    let clean = if let Some(pos) = trimmed.find("] ") {
+        &trimmed[pos + 2..]
+    } else {
+        trimmed
+    };
+    // Skip session framing noise
+    let skip_prefixes = [
+        "SESSION CONTINUITY",
+        "RECENT SESSIONS",
+        "CSR engine ready",
+        "CSR:",
+    ];
+    if skip_prefixes.iter().any(|p| clean.starts_with(p)) {
+        return None;
+    }
+    Some(clean.to_string())
+}
+
+/// Format a timestamp as a human-readable age string.
+fn format_age(timestamp: &str) -> String {
+    let ts = match crate::temporal::parse_timestamp(timestamp) {
+        Some(t) => t,
+        None => return timestamp.to_string(),
+    };
+    let age = chrono::Utc::now() - ts;
+    let mins = age.num_minutes();
+    if mins < 1 {
+        "just now".to_string()
+    } else if mins < 60 {
+        format!("{}m ago", mins)
+    } else if mins < 1440 {
+        format!("{}h ago", mins / 60)
+    } else {
+        format!("{}d ago", mins / 1440)
+    }
 }
 
 /// Print compact one-line status for statusline integration.

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -365,4 +365,21 @@ impl Storage {
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
         queries::get_retrieval_events_batch(&conn, memory_ids)
     }
+
+    // ─── Completion queries (v8.3.0) ───
+
+    pub fn list_project_names(&self, prefix: &str, limit: usize) -> Result<Vec<String>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::list_project_names(&conn, prefix, limit)
+    }
+
+    pub fn list_file_paths(&self, prefix: &str, limit: usize) -> Result<Vec<String>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::list_file_paths(&conn, prefix, limit)
+    }
+
+    pub fn list_session_ids(&self, prefix: &str, limit: usize) -> Result<Vec<String>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::list_session_ids(&conn, prefix, limit)
+    }
 }

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -982,13 +982,18 @@ pub fn get_retrieval_events_batch(
 
 // ─── Completion queries (v8.3.0) ───
 
+/// Escape SQLite LIKE wildcards (`%` and `_`) in a prefix string.
+fn escape_like(prefix: &str) -> String {
+    prefix.replace('%', "\\%").replace('_', "\\_")
+}
+
 /// List distinct project names matching a prefix (for MCP completions).
 /// Returns up to `limit` results, sorted alphabetically.
 pub fn list_project_names(conn: &Connection, prefix: &str, limit: usize) -> Result<Vec<String>> {
-    let pattern = format!("{}%", prefix);
+    let pattern = format!("{}%", escape_like(prefix));
     let mut stmt = conn.prepare(
         "SELECT DISTINCT project_name FROM chunks
-         WHERE project_name LIKE ?1
+         WHERE project_name LIKE ?1 ESCAPE '\\'
          ORDER BY project_name
          LIMIT ?2",
     )?;
@@ -997,78 +1002,40 @@ pub fn list_project_names(conn: &Connection, prefix: &str, limit: usize) -> Resu
         .map_err(|e| anyhow::anyhow!("{}", e))
 }
 
-/// List distinct file paths from file_changes or chunk content matching a prefix.
-/// Falls back to scanning chunk content for path-like strings if no file_changes table.
+/// List distinct file paths from import_state matching a prefix.
 pub fn list_file_paths(conn: &Connection, prefix: &str, limit: usize) -> Result<Vec<String>> {
-    // Try import_state table first (tracks imported files)
-    let pattern = format!("%{}%", prefix);
+    let pattern = format!("%{}%", escape_like(prefix));
     let mut stmt = conn.prepare(
         "SELECT DISTINCT file_path FROM import_state
-         WHERE file_path LIKE ?1
+         WHERE file_path LIKE ?1 ESCAPE '\\'
          ORDER BY file_path
          LIMIT ?2",
     )?;
     let rows = stmt.query_map(params![pattern, limit as i64], |row| {
         row.get::<_, String>(0)
     })?;
-    let results: Vec<String> = rows.filter_map(|r| r.ok()).collect();
-
-    if !results.is_empty() {
-        return Ok(results);
-    }
-
-    // Fallback: search chunk content for file paths (slower but always works)
-    let fts_query = format!("{}*", prefix);
-    let mut stmt = conn.prepare(
-        "SELECT DISTINCT content FROM chunks
-         WHERE content LIKE ?1
-         LIMIT ?2",
-    )?;
-    let rows = stmt.query_map(params![format!("%{}%", prefix), limit as i64], |row| {
-        row.get::<_, String>(0)
-    })?;
-
-    let mut file_paths = Vec::new();
-    let extensions = [
-        ".rs", ".py", ".ts", ".js", ".toml", ".json", ".yaml", ".yml",
-    ];
-    for row in rows.flatten() {
-        for line in row.lines() {
-            let trimmed = line.trim().trim_start_matches("- ");
-            if trimmed.contains(prefix) {
-                for ext in &extensions {
-                    if trimmed.ends_with(ext) || trimmed.contains(&format!("{} ", ext)) {
-                        if let Some(path) = trimmed.split_whitespace().find(|w| w.contains(prefix))
-                        {
-                            if !file_paths.contains(&path.to_string()) {
-                                file_paths.push(path.to_string());
-                                if file_paths.len() >= limit {
-                                    return Ok(file_paths);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    let _ = fts_query; // suppress unused warning
-    Ok(file_paths)
+    Ok(rows.filter_map(|r| r.ok()).collect())
 }
 
 /// List distinct session IDs from iteration_learnings matching a prefix.
 /// Returns empty vec if the table doesn't exist (created on first stop hook).
 pub fn list_session_ids(conn: &Connection, prefix: &str, limit: usize) -> Result<Vec<String>> {
-    let pattern = format!("{}%", prefix);
+    let pattern = format!("{}%", escape_like(prefix));
     let result = conn.prepare(
         "SELECT DISTINCT session_id FROM iteration_learnings
-         WHERE session_id LIKE ?1
+         WHERE session_id LIKE ?1 ESCAPE '\\'
          ORDER BY session_id DESC
          LIMIT ?2",
     );
     let mut stmt = match result {
         Ok(s) => s,
-        Err(_) => return Ok(Vec::new()), // Table doesn't exist yet
+        Err(e) => {
+            // Only tolerate "no such table" — surface real SQL errors
+            if e.to_string().contains("no such table") {
+                return Ok(Vec::new());
+            }
+            return Err(anyhow::anyhow!("{}", e));
+        }
     };
     let rows = stmt.query_map(params![pattern, limit as i64], |row| row.get(0))?;
     rows.collect::<std::result::Result<Vec<String>, _>>()

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -979,3 +979,98 @@ pub fn get_retrieval_events_batch(
     }
     Ok(map)
 }
+
+// ─── Completion queries (v8.3.0) ───
+
+/// List distinct project names matching a prefix (for MCP completions).
+/// Returns up to `limit` results, sorted alphabetically.
+pub fn list_project_names(conn: &Connection, prefix: &str, limit: usize) -> Result<Vec<String>> {
+    let pattern = format!("{}%", prefix);
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT project_name FROM chunks
+         WHERE project_name LIKE ?1
+         ORDER BY project_name
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![pattern, limit as i64], |row| row.get(0))?;
+    rows.collect::<std::result::Result<Vec<String>, _>>()
+        .map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+/// List distinct file paths from file_changes or chunk content matching a prefix.
+/// Falls back to scanning chunk content for path-like strings if no file_changes table.
+pub fn list_file_paths(conn: &Connection, prefix: &str, limit: usize) -> Result<Vec<String>> {
+    // Try import_state table first (tracks imported files)
+    let pattern = format!("%{}%", prefix);
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT file_path FROM import_state
+         WHERE file_path LIKE ?1
+         ORDER BY file_path
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![pattern, limit as i64], |row| {
+        row.get::<_, String>(0)
+    })?;
+    let results: Vec<String> = rows.filter_map(|r| r.ok()).collect();
+
+    if !results.is_empty() {
+        return Ok(results);
+    }
+
+    // Fallback: search chunk content for file paths (slower but always works)
+    let fts_query = format!("{}*", prefix);
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT content FROM chunks
+         WHERE content LIKE ?1
+         LIMIT ?2",
+    )?;
+    let rows = stmt.query_map(params![format!("%{}%", prefix), limit as i64], |row| {
+        row.get::<_, String>(0)
+    })?;
+
+    let mut file_paths = Vec::new();
+    let extensions = [
+        ".rs", ".py", ".ts", ".js", ".toml", ".json", ".yaml", ".yml",
+    ];
+    for row in rows.flatten() {
+        for line in row.lines() {
+            let trimmed = line.trim().trim_start_matches("- ");
+            if trimmed.contains(prefix) {
+                for ext in &extensions {
+                    if trimmed.ends_with(ext) || trimmed.contains(&format!("{} ", ext)) {
+                        if let Some(path) = trimmed.split_whitespace().find(|w| w.contains(prefix))
+                        {
+                            if !file_paths.contains(&path.to_string()) {
+                                file_paths.push(path.to_string());
+                                if file_paths.len() >= limit {
+                                    return Ok(file_paths);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let _ = fts_query; // suppress unused warning
+    Ok(file_paths)
+}
+
+/// List distinct session IDs from iteration_learnings matching a prefix.
+/// Returns empty vec if the table doesn't exist (created on first stop hook).
+pub fn list_session_ids(conn: &Connection, prefix: &str, limit: usize) -> Result<Vec<String>> {
+    let pattern = format!("{}%", prefix);
+    let result = conn.prepare(
+        "SELECT DISTINCT session_id FROM iteration_learnings
+         WHERE session_id LIKE ?1
+         ORDER BY session_id DESC
+         LIMIT ?2",
+    );
+    let mut stmt = match result {
+        Ok(s) => s,
+        Err(_) => return Ok(Vec::new()), // Table doesn't exist yet
+    };
+    let rows = stmt.query_map(params![pattern, limit as i64], |row| row.get(0))?;
+    rows.collect::<std::result::Result<Vec<String>, _>>()
+        .map_err(|e| anyhow::anyhow!("{}", e))
+}

--- a/csr-engine/tests/integration.rs
+++ b/csr-engine/tests/integration.rs
@@ -816,7 +816,82 @@ fn test_heuristic_enrichment_with_fixture() {
     assert!(reflection.contains("test-project"));
 }
 
-// ─── Test 22: Search engine remove_reflection ───
+// ─── Test 22: Completions — project name prefix matching ───
+
+#[test]
+fn test_completions_project_name_prefix() {
+    let storage = Storage::open_memory().unwrap();
+
+    // Insert chunks with known project names
+    let chunk1 = ConversationChunk {
+        id: "chunk-comp-1".to_string(),
+        conversation_id: "conv-comp-1".to_string(),
+        project_name: "claude-self-reflect".to_string(),
+        timestamp: "2026-05-06T10:00:00Z".to_string(),
+        content: "test content".to_string(),
+        message_count: 5,
+        summary: None,
+    };
+    let chunk2 = ConversationChunk {
+        id: "chunk-comp-2".to_string(),
+        conversation_id: "conv-comp-2".to_string(),
+        project_name: "claude-code-hooks".to_string(),
+        timestamp: "2026-05-06T11:00:00Z".to_string(),
+        content: "other content".to_string(),
+        message_count: 3,
+        summary: None,
+    };
+    let chunk3 = ConversationChunk {
+        id: "chunk-comp-3".to_string(),
+        conversation_id: "conv-comp-3".to_string(),
+        project_name: "my-other-project".to_string(),
+        timestamp: "2026-05-06T12:00:00Z".to_string(),
+        content: "unrelated".to_string(),
+        message_count: 2,
+        summary: None,
+    };
+
+    let embedding = vec![0.1f32; 384];
+    storage.insert_chunk(&chunk1, &embedding).unwrap();
+    storage.insert_chunk(&chunk2, &embedding).unwrap();
+    storage.insert_chunk(&chunk3, &embedding).unwrap();
+
+    // Acceptance criterion: partial "clau" returns both claude-* projects
+    let results = storage.list_project_names("clau", 100).unwrap();
+    assert!(
+        results.contains(&"claude-self-reflect".to_string()),
+        "should contain claude-self-reflect, got: {:?}",
+        results
+    );
+    assert!(
+        results.contains(&"claude-code-hooks".to_string()),
+        "should contain claude-code-hooks"
+    );
+    assert!(
+        !results.contains(&"my-other-project".to_string()),
+        "should NOT contain my-other-project"
+    );
+
+    // Empty prefix returns all
+    let all = storage.list_project_names("", 100).unwrap();
+    assert_eq!(all.len(), 3);
+
+    // Non-matching prefix returns empty
+    let none = storage.list_project_names("xyz", 100).unwrap();
+    assert!(none.is_empty());
+}
+
+// ─── Test 23: Completions — session ID lookup ───
+
+#[test]
+fn test_completions_session_id_prefix() {
+    let storage = Storage::open_memory().unwrap();
+    // Session IDs are stored in iteration_learnings — no data means empty results
+    let results = storage.list_session_ids("abc", 100).unwrap();
+    assert!(results.is_empty());
+}
+
+// ─── Test 24: Search engine remove_reflection ───
 
 #[test]
 fn test_search_engine_remove_reflection() {

--- a/docs/plans/2026-05-07-v830-advanced-mcp-design.md
+++ b/docs/plans/2026-05-07-v830-advanced-mcp-design.md
@@ -1,0 +1,165 @@
+# v8.3.0 Plan — Full MCP Advanced Capabilities + HTTP Transport
+
+## Context
+
+v8.2.0 shipped rmcp 1.6 with tool annotations + HNSW reconciliation. v8.3.0 completes the rmcp 1.6 migration by enabling all advanced capabilities and adding a web-accessible HTTP transport via Axum — setting the foundation for the future web dashboard (v9).
+
+## TL;DR — User-Facing Features
+
+1. **Tool argument autocomplete** — type a partial project name, file path, or time range and get instant suggestions
+2. **Non-blocking long searches** — large queries run async; client can poll progress or cancel
+3. **Interactive confirmation flows** — store_reflection asks "are you sure?" for large content
+4. **HTTP transport** — CSR accessible via `http://127.0.0.1:3580` alongside stdio; enables web clients, remote access, multi-client
+5. **npm 8.3.0** — `npx claude-self-reflect` installs latest with all capabilities
+
+## Scope
+
+| Feature | Effort | User Value | rmcp Feature |
+|---------|--------|------------|--------------|
+| **Completions** | Medium | HIGH | `complete()` method |
+| **Tasks** | Medium | HIGH | `enqueue_task()` + OperationProcessor |
+| **Elicitation (light)** | Small | MEDIUM | Form-based confirmation |
+| **StreamableHttp + Axum** | High | VERY HIGH | `transport-streamable-http-server` |
+| npm publish | Trivial | HIGH | — |
+| CI artifact bump | Trivial | LOW | — |
+
+## Architecture
+
+### Completions (`src/mcp/completions.rs`)
+
+Override `ServerHandler::complete()`. Parameters to autocomplete:
+
+| Parameter | Source | Strategy |
+|-----------|--------|----------|
+| `project` | `SELECT DISTINCT project FROM conversations` | Prefix filter on DB query |
+| `file_path` | `SELECT DISTINCT file_path FROM file_changes` | Prefix filter |
+| `time_range` | Static list | "today", "yesterday", "last week", "last month", "last 3 months" |
+| `group_by` | Static list | "conversation", "day", "session" |
+| `granularity` | Static list | "hour", "day", "week", "month" |
+| `session_id` | `SELECT DISTINCT session_id FROM iteration_learnings` | Prefix filter |
+| `concept` | Top-k from search index | Semantic nearest neighbors |
+
+Return `CompletionInfo` with up to 100 suggestions, `hasMore` if truncated.
+
+### Tasks (`src/mcp/tasks.rs`)
+
+Wrap heavy search tools in async tasks:
+
+| Tool | Task Mode | Rationale |
+|------|-----------|-----------|
+| `csr_reflect_on_past` | Yes | Can be slow on 16K+ chunks |
+| `csr_search_by_concept` | Yes | Semantic search + aggregation |
+| `csr_search_insights` | Yes | Multi-query aggregation |
+| `search_by_recency` | Yes | Time filter + semantic |
+| Others | No (sync) | Fast enough (<100ms) |
+
+Implementation:
+- Use rmcp's `OperationProcessor` for lifecycle
+- Enable `ServerCapabilities::tasks`
+- `enqueue_task()` spawns tokio task, returns task ID
+- `get_task_info()` / `get_task_result()` / `cancel_task()` poll state
+- Default TTL: 30 seconds
+
+### Elicitation (`src/mcp/elicitation.rs`)
+
+Light implementation — confirmation flow only:
+
+- `store_reflection` with content > 500 chars triggers elicitation
+- Schema: `{ confirm: boolean, tags: optional string[] }`
+- If client declines → abort store
+- Graceful fallback: if client doesn't support elicitation, proceed without confirmation
+
+### StreamableHttp Transport (`src/transport/http.rs`)
+
+Dual-transport architecture:
+
+```
+csr-engine              → stdio transport (default, for Claude Code)
+csr-engine serve        → HTTP transport on 127.0.0.1:3580 (for web clients)
+csr-engine serve --port → Custom port
+```
+
+Stack:
+- **Axum** for routing + middleware
+- **rmcp StreamableHttpService** as Tower layer
+- **In-memory session store** (LocalSessionManager) — sufficient for single-machine
+- **SSE** for streaming responses
+- Host validation: localhost only by default
+
+New dependency: `axum = "0.8"` (or latest), `tower-http` for CORS/tracing
+
+### CLI Changes
+
+```
+csr-engine                     # MCP server (stdio) — unchanged
+csr-engine serve               # HTTP MCP server on :3580
+csr-engine serve --port 8080   # Custom port
+csr-engine serve --host 0.0.0.0  # Bind to all interfaces (opt-in)
+```
+
+## Files to Create/Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `Cargo.toml` | Modify | Add axum, tower-http, rmcp features |
+| `src/mcp/mod.rs` | Modify | Add complete(), enqueue_task(), enable capabilities |
+| `src/mcp/completions.rs` | Create | Completion logic per parameter type |
+| `src/mcp/tasks.rs` | Create | Task wrapping + OperationProcessor |
+| `src/mcp/elicitation.rs` | Create | Confirmation flow for store_reflection |
+| `src/transport/mod.rs` | Create | Transport module |
+| `src/transport/http.rs` | Create | Axum server + StreamableHttpService |
+| `src/main.rs` | Modify | Add `serve` subcommand to CLI |
+| `src/storage/queries.rs` | Modify | Add list_project_names(), list_file_paths(), list_session_ids() |
+| `src/storage/mod.rs` | Modify | Expose new query functions |
+| `.github/workflows/*.yml` | Modify | download-artifact v4→v8 |
+| `installer/package.json` | Modify | Bump version |
+
+## Definition of Done (DoD)
+
+### Quality Gates
+- [ ] `cargo test` — all tests pass (338+ existing + new)
+- [ ] `cargo clippy -- -D warnings` — 0 warnings
+- [ ] `cargo fmt --check` — clean
+- [ ] `csr-engine eval --full` — 20/20 pass
+- [ ] PR passes: CodeRabbit + claude-review + CodeQL + Snyk
+
+### Feature Acceptance
+- [ ] **Completions**: `completion/complete` request with partial "clau" returns "claude-self-reflect" project
+- [ ] **Tasks**: `tools/call` with `task: {}` returns task ID; `tasks/get` shows Working→Completed
+- [ ] **Elicitation**: `store_reflection` with 600-char content triggers confirmation form
+- [ ] **HTTP**: `curl http://127.0.0.1:3580/mcp` returns MCP initialize response
+- [ ] **HTTP**: SSE stream works for long-running task results
+- [ ] **npm**: `npm publish --dry-run` shows correct version + binary refs
+
+### Regression
+- [ ] Existing stdio transport unchanged (default mode)
+- [ ] All 12 tool annotations preserved
+- [ ] HNSW reconciliation still works
+- [ ] Hook startup time unchanged (<100ms)
+
+## Verification Plan
+
+1. Unit tests for each new module (completions, tasks, elicitation, http)
+2. Integration test: full MCP protocol round-trip over HTTP
+3. Manual test: start `csr-engine serve`, use MCP Inspector to verify
+4. `csr-engine eval --full` — confirm 20/20
+5. Codex review before merge
+6. CI green on all platforms
+
+## Implementation Order
+
+1. **Completions** (smallest, highest immediate value, unblocks others)
+2. **Tasks** (medium, pairs with completions for async story)
+3. **Elicitation** (small, depends on nothing)
+4. **StreamableHttp** (largest, independent, can be parallelized)
+5. **npm + CI** (trivial, do last)
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Axum version incompatibility with rmcp's tower version | Pin to rmcp's tower version, verify in Cargo.lock |
+| StreamableHttp session memory leak | Use TTL-based cleanup, test with load |
+| Completions slow on large project lists | Cache project/file lists, refresh on import |
+| Tasks capability not supported by Claude Code client | Graceful degradation — sync fallback |
+| Elicitation not supported by client | Check client capabilities, skip if unsupported |

--- a/docs/plans/2026-05-07-v830-advanced-mcp-design.md
+++ b/docs/plans/2026-05-07-v830-advanced-mcp-design.md
@@ -73,7 +73,7 @@ Light implementation — confirmation flow only:
 
 Dual-transport architecture:
 
-```
+```text
 csr-engine              → stdio transport (default, for Claude Code)
 csr-engine serve        → HTTP transport on 127.0.0.1:3580 (for web clients)
 csr-engine serve --port → Custom port
@@ -90,7 +90,7 @@ New dependency: `axum = "0.8"` (or latest), `tower-http` for CORS/tracing
 
 ### CLI Changes
 
-```
+```bash
 csr-engine                     # MCP server (stdio) — unchanged
 csr-engine serve               # HTTP MCP server on :3580
 csr-engine serve --port 8080   # Custom port

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "8.0.1",
+  "version": "8.3.0",
   "description": "Give Claude perfect memory of all your conversations. Single binary, zero dependencies.",
   "keywords": [
     "claude",

--- a/scripts/csr-status.30s.sh
+++ b/scripts/csr-status.30s.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# <bitbar.title>CSR Status</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Claude Self-Reflect</bitbar.author>
+# <bitbar.author.github>ramakay</bitbar.author.github>
+# <bitbar.desc>Live stats for Claude Self-Reflect conversation memory</bitbar.desc>
+# <bitbar.dependencies>csr-engine</bitbar.dependencies>
+# <swiftbar.hideAbout>true</swiftbar.hideAbout>
+# <swiftbar.hideRunInTerminal>true</swiftbar.hideRunInTerminal>
+# <swiftbar.hideDisablePlugin>true</swiftbar.hideDisablePlugin>
+#
+# Refreshes every 30 seconds (per filename convention: .30s.)
+# Install: csr-engine hook install --apply (auto-copies to SwiftBar plugins dir)
+# Manual:  cp scripts/csr-status.30s.sh ~/Library/Application\ Support/SwiftBar/Plugins/
+
+if command -v csr-engine &>/dev/null; then
+    csr-engine status --swiftbar 2>/dev/null
+else
+    echo "🧠 CSR offline"
+    echo "---"
+    echo "csr-engine not found | color=red"
+    echo "Install: npx claude-self-reflect | font=Menlo"
+fi

--- a/scripts/csr-status.30s.sh
+++ b/scripts/csr-status.30s.sh
@@ -11,10 +11,18 @@
 #
 # Refreshes every 30 seconds (per filename convention: .30s.)
 # Install: csr-engine hook install --apply (auto-copies to SwiftBar plugins dir)
-# Manual:  cp scripts/csr-status.30s.sh ~/Library/Application\ Support/SwiftBar/Plugins/
+# Manual:  cp scripts/csr-status.30s.sh "$HOME/Library/Application Support/SwiftBar/Plugins/"
 
 if command -v csr-engine &>/dev/null; then
-    csr-engine status --swiftbar 2>/dev/null
+    output=$(csr-engine status --swiftbar 2>/dev/null)
+    if [ $? -eq 0 ] && [ -n "$output" ]; then
+        echo "$output"
+    else
+        echo "🧠 CSR error"
+        echo "---"
+        echo "csr-engine status failed | color=orange"
+        echo "Refresh | refresh=true"
+    fi
 else
     echo "🧠 CSR offline"
     echo "---"


### PR DESCRIPTION
## Summary

v8.3.0 adds advanced MCP capabilities and a macOS menu bar integration, replacing the planned HTTP transport with a lighter SwiftBar approach after analyzing ClaudeMem's architecture.

### Features
- **MCP Completions** — `ServerHandler::complete()` with autocomplete for 7 parameter types (project, file_path, time_range, group_by, granularity, session_id, concept). DB-backed dynamic values + static lists.
- **MCP Tasks** — Async execution for 4 heavy search tools via `enqueue_task()`. TaskManager with tokio-based lifecycle (Working → Completed/Failed/Cancelled), TTL cleanup, cancellation support.
- **SwiftBar Plugin** — `csr-engine status --swiftbar` outputs rich macOS menu bar dropdown: index stats, import progress, enrichment breakdown, health, current focus. Auto-refresh every 30s.
- **Hook Injection Quality** — Steeper recency decay (14-day half-life vs 30-day), hard 21-day age gate for chunks, rebalanced PromptSubmit weights (recency 0.25 vs 0.15), enrichment-first SessionStart titles, no redundant noise.
- **npm 8.3.0** — Version bump for npm publish.

### Deferred to v9
- **StreamableHttp + Axum** — CSR's hooks run in-process (no background worker), so HTTP isn't needed for async processing like ClaudeMem. Deferred until there's a web UI or remote MCP client need.
- **Elicitation** — Requires rmcp `elicitation` feature flag + client support. Claude Code may not declare `ElicitationCapability` yet.

### Quality Gates
- 358 tests (263 unit + 41 hooks + 54 integration), 0 failures
- `cargo clippy -- -D warnings`: 0 warnings
- `cargo fmt --check`: clean
- `csr-engine eval --full`: 20/20 pass (200ms, p95 search: 0.98ms)

## Test plan
- [ ] `cargo test` — all 358 tests pass
- [ ] `csr-engine eval --full` — 20/20
- [ ] `csr-engine status --swiftbar` — renders valid SwiftBar output
- [ ] Verify completions: partial "clau" returns "claude-self-reflect" project
- [ ] Verify tasks: taskable tools list includes 4 search tools
- [ ] Next session: verify improved hook injection (no stale 3-month-old results)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v8.3.0

* **New Features**
  * Added argument autocomplete suggestions for MCP completions (project, file path, session ID)
  * Introduced async task support for long-running search operations
  * Added SwiftBar menu-bar integration displaying health, index stats, and import progress
  * Implemented automatic filtering of search results older than 21 days

* **Improvements**
  * Recency decay scoring now uses 14-day half-life for more recent-focused ranking
  * Rebalanced semantic and recency weights to improve overall result relevance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->