### PR TITLE
fix(cache): prevent HNSW index cache bloat — 60GB→109MB

### DIFF
--- a/csr-engine/src/engine.rs
+++ b/csr-engine/src/engine.rs
@@ -178,6 +178,9 @@ impl Engine {
             search
         };
 
+        // Clean stale numbered HNSW files from previous sessions (crash resilience)
+        crate::search::cleanup_stale_index_files(&index_dir);
+
         Ok(Self {
             storage,
             embeddings,

--- a/csr-engine/src/search/mod.rs
+++ b/csr-engine/src/search/mod.rs
@@ -314,17 +314,24 @@ impl SearchEngine {
             .lock_exclusive()
             .map_err(|e| anyhow::anyhow!("failed to acquire index lock for dump: {}", e))?;
 
-        // Dump HNSW graph + data files (skip empty indices — file_dump fails on empty)
+        // Dump HNSW graph + data files (skip empty indices — file_dump fails on empty).
+        // hnsw_rs may return a numbered basename (e.g. "chunks-7905") when mmap is active
+        // (after load_from_disk). We promote it to the canonical name so load_from_disk
+        // always finds "chunks.hnsw.data" / "reflections.hnsw.data".
         if !self.chunk_id_map.is_empty() {
-            self.chunk_index
+            let basename = self
+                .chunk_index
                 .file_dump(dir, "chunks")
                 .map_err(|e| anyhow::anyhow!("chunk index dump failed: {}", e))?;
+            promote_to_canonical(dir, &basename, "chunks");
         }
 
         if !self.reflection_id_map.is_empty() {
-            self.reflection_index
+            let basename = self
+                .reflection_index
                 .file_dump(dir, "reflections")
                 .map_err(|e| anyhow::anyhow!("reflection index dump failed: {}", e))?;
+            promote_to_canonical(dir, &basename, "reflections");
         }
 
         // Write manifest atomically (tmp + rename)
@@ -343,6 +350,11 @@ impl SearchEngine {
         let final_path = dir.join("manifest.json");
         std::fs::write(&tmp_path, &manifest_json)?;
         std::fs::rename(&tmp_path, &final_path)?;
+
+        // Clean stale numbered HNSW files from previous dumps.
+        // hnsw_rs creates numbered files (e.g. chunks-7905.hnsw.data) when mmap is active
+        // on the old files (after load_from_disk). These are orphaned after each new dump.
+        cleanup_stale_index_files(dir);
 
         // Lock is released when lock_file is dropped
         self.dirty = false;
@@ -476,5 +488,141 @@ impl SearchEngine {
             active_reflection_count: active_count,
             dirty: false,
         })
+    }
+}
+
+/// If `file_dump` returned a numbered basename (e.g. "chunks-7905"), rename its files
+/// to the canonical name (e.g. "chunks.hnsw.data") so `load_from_disk` can find them.
+/// This happens when the Hnsw was loaded via `load_hnsw` (mmap active → `overwrite=false`).
+fn promote_to_canonical(dir: &Path, returned_basename: &str, canonical: &str) {
+    if returned_basename == canonical {
+        return; // Already canonical, nothing to do
+    }
+    for ext in &[".hnsw.data", ".hnsw.graph"] {
+        let src = dir.join(format!("{}{}", returned_basename, ext));
+        let dst = dir.join(format!("{}{}", canonical, ext));
+        if src.exists() {
+            let _ = std::fs::rename(&src, &dst);
+        }
+    }
+}
+
+/// Remove stale numbered HNSW files from the index directory.
+/// hnsw_rs creates numbered files (e.g. `chunks-7905.hnsw.data`) when mmap is active.
+/// After `dump_to_disk` promotes them to canonical names, the numbered copies are gone.
+/// This function catches any stragglers from crashes, concurrent processes, or old sessions.
+///
+/// Called after every `dump_to_disk` and at engine startup.
+/// Must be called while holding `index.lock` (dump_to_disk) or at startup before serving.
+pub fn cleanup_stale_index_files(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Match pattern: chunks-NNN.hnsw.data/graph or reflections-NNN.hnsw.data/graph
+        // Keep: chunks.hnsw.data, reflections.hnsw.graph, manifest.json, index.lock
+        if (name.starts_with("chunks-") || name.starts_with("reflections-"))
+            && (name.ends_with(".hnsw.data") || name.ends_with(".hnsw.graph"))
+        {
+            let _ = std::fs::remove_file(entry.path());
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(removed, "cleaned stale numbered HNSW files");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cleanup_removes_numbered_keeps_base() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Create stale numbered files
+        std::fs::write(dir.join("chunks-100.hnsw.data"), "old").unwrap();
+        std::fs::write(dir.join("chunks-100.hnsw.graph"), "old").unwrap();
+        std::fs::write(dir.join("chunks-200.hnsw.data"), "old").unwrap();
+        std::fs::write(dir.join("reflections-50.hnsw.data"), "old").unwrap();
+        std::fs::write(dir.join("reflections-50.hnsw.graph"), "old").unwrap();
+
+        // Create base files that should be kept
+        std::fs::write(dir.join("chunks.hnsw.data"), "current").unwrap();
+        std::fs::write(dir.join("chunks.hnsw.graph"), "current").unwrap();
+        std::fs::write(dir.join("reflections.hnsw.data"), "current").unwrap();
+        std::fs::write(dir.join("reflections.hnsw.graph"), "current").unwrap();
+        std::fs::write(dir.join("manifest.json"), "{}").unwrap();
+        std::fs::write(dir.join("index.lock"), "").unwrap();
+
+        cleanup_stale_index_files(dir);
+
+        // Numbered files should be gone
+        assert!(!dir.join("chunks-100.hnsw.data").exists());
+        assert!(!dir.join("chunks-200.hnsw.data").exists());
+        assert!(!dir.join("reflections-50.hnsw.data").exists());
+
+        // Base files should remain
+        assert!(dir.join("chunks.hnsw.data").exists());
+        assert!(dir.join("chunks.hnsw.graph").exists());
+        assert!(dir.join("reflections.hnsw.data").exists());
+        assert!(dir.join("manifest.json").exists());
+        assert!(dir.join("index.lock").exists());
+    }
+
+    #[test]
+    fn test_promote_renames_numbered_to_canonical() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Simulate hnsw_rs creating numbered files
+        std::fs::write(dir.join("chunks-4567.hnsw.data"), "new_data").unwrap();
+        std::fs::write(dir.join("chunks-4567.hnsw.graph"), "new_graph").unwrap();
+        // Old canonical files exist
+        std::fs::write(dir.join("chunks.hnsw.data"), "old_data").unwrap();
+        std::fs::write(dir.join("chunks.hnsw.graph"), "old_graph").unwrap();
+
+        promote_to_canonical(dir, "chunks-4567", "chunks");
+
+        // Canonical files should have the new content
+        assert_eq!(
+            std::fs::read_to_string(dir.join("chunks.hnsw.data")).unwrap(),
+            "new_data"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.join("chunks.hnsw.graph")).unwrap(),
+            "new_graph"
+        );
+        // Numbered files should be gone (renamed)
+        assert!(!dir.join("chunks-4567.hnsw.data").exists());
+        assert!(!dir.join("chunks-4567.hnsw.graph").exists());
+    }
+
+    #[test]
+    fn test_promote_noop_when_already_canonical() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("chunks.hnsw.data"), "data").unwrap();
+
+        promote_to_canonical(dir, "chunks", "chunks"); // should not panic or corrupt
+        assert_eq!(
+            std::fs::read_to_string(dir.join("chunks.hnsw.data")).unwrap(),
+            "data"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_no_panic_on_empty_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        cleanup_stale_index_files(tmp.path()); // should not panic
+    }
+
+    #[test]
+    fn test_cleanup_no_panic_on_nonexistent_dir() {
+        cleanup_stale_index_files(Path::new("/nonexistent/path")); // should not panic
     }
 }

--- a/docs/plans/2026-05-14-hnsw-cache-cleanup-hotfix.md
+++ b/docs/plans/2026-05-14-hnsw-cache-cleanup-hotfix.md
@@ -1,0 +1,183 @@
+# HNSW Cache Bloat Prevention — Hotfix
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent the 60GB index cache bloat that causes 14s cold-start rebuilds and blocks MCP tool calls.
+
+**Architecture:** Three fixes: (1) clean stale numbered HNSW files after every `dump_to_disk`, (2) cap file retention to last 2 dumps, (3) add startup cache GC that runs before first tool call. All changes in `search/mod.rs` with zero API changes.
+
+**Tech Stack:** Rust, hnsw_rs, std::fs, glob patterns
+
+---
+
+## Task 1: Clean Stale Files After dump_to_disk
+
+hnsw_rs `file_dump` creates new numbered files (chunks-7905.hnsw.data) each call without removing old ones. Fix: after successful dump, remove all numbered files that aren't the ones we just created.
+
+**Files:**
+- Modify: `csr-engine/src/search/mod.rs:299-350` (dump_to_disk)
+
+**Step 1: Write failing test**
+
+In `csr-engine/src/search/mod.rs` (bottom of file, in `#[cfg(test)] mod tests`):
+
+```rust
+#[test]
+fn test_dump_cleans_stale_files() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path();
+    // Create fake stale files
+    std::fs::write(dir.join("chunks-100.hnsw.data"), "old").unwrap();
+    std::fs::write(dir.join("chunks-100.hnsw.graph"), "old").unwrap();
+    std::fs::write(dir.join("chunks-200.hnsw.data"), "old").unwrap();
+    std::fs::write(dir.join("chunks-200.hnsw.graph"), "old").unwrap();
+    std::fs::write(dir.join("reflections-50.hnsw.data"), "old").unwrap();
+    std::fs::write(dir.join("reflections-50.hnsw.graph"), "old").unwrap();
+
+    // Create a minimal SearchEngine and dump
+    let mut engine = SearchEngine::new(10);
+    // Insert one item so dump actually writes files
+    engine.insert_chunk("test_chunk".to_string(), vec![0.1; 384]);
+    engine.insert_reflection("test_refl".to_string(), vec![0.2; 384]);
+    engine.dump_to_disk(dir, 1, 1).unwrap();
+
+    // Stale numbered files should be gone
+    assert!(!dir.join("chunks-100.hnsw.data").exists());
+    assert!(!dir.join("chunks-200.hnsw.data").exists());
+    assert!(!dir.join("reflections-50.hnsw.data").exists());
+    // Current files should exist (chunks.hnsw.data or a new numbered one)
+    let remaining: Vec<_> = std::fs::read_dir(dir).unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.contains(".hnsw."))
+        .collect();
+    // Should have exactly the fresh dump files (2 for chunks + 2 for reflections)
+    assert!(remaining.len() <= 6, "stale files not cleaned: {:?}", remaining);
+}
+```
+
+**Step 2: Implement cleanup in dump_to_disk**
+
+After the manifest write (line 345), before setting `self.dirty = false`, add:
+
+```rust
+// Clean stale numbered HNSW files from previous dumps.
+// hnsw_rs file_dump creates new numbered files each call without removing old ones.
+// Keep only the unnumbered files (chunks.hnsw.data) which are the latest dump.
+if let Ok(entries) = std::fs::read_dir(dir) {
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Match pattern: chunks-NNN.hnsw.data/graph or reflections-NNN.hnsw.data/graph
+        if (name.starts_with("chunks-") || name.starts_with("reflections-"))
+            && (name.ends_with(".hnsw.data") || name.ends_with(".hnsw.graph"))
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+```
+
+**Step 3: Run test**
+
+Run: `cd csr-engine && cargo test --lib search::tests::test_dump_cleans_stale_files`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add csr-engine/src/search/mod.rs
+git commit -m "fix(cache): clean stale numbered HNSW files after dump — prevents 60GB bloat"
+```
+
+---
+
+## Task 2: Startup Cache GC
+
+Add a lightweight GC at engine startup that removes numbered HNSW files older than the manifest. This catches cases where dump_to_disk doesn't fire (crash, kill, etc).
+
+**Files:**
+- Modify: `csr-engine/src/engine.rs:58-100` (Engine::new, after load_from_disk)
+
+**Step 1: Add cleanup_stale_index_files function**
+
+In `csr-engine/src/search/mod.rs`, add a public function:
+
+```rust
+/// Remove stale numbered HNSW files from the index directory.
+/// Called at startup to clean up files from previous sessions that didn't
+/// get cleaned during dump_to_disk (crash, SIGKILL, etc).
+pub fn cleanup_stale_index_files(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if (name.starts_with("chunks-") || name.starts_with("reflections-"))
+            && (name.ends_with(".hnsw.data") || name.ends_with(".hnsw.graph"))
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+```
+
+**Step 2: Call it in Engine::new**
+
+In `engine.rs`, after the `load_from_disk` / rebuild logic completes, add:
+
+```rust
+// Clean stale numbered index files from previous sessions
+crate::search::cleanup_stale_index_files(&index_dir);
+```
+
+**Step 3: Run full tests**
+
+Run: `cd csr-engine && cargo test`
+Expected: All pass
+
+**Step 4: Commit**
+
+```bash
+git add csr-engine/src/search/mod.rs csr-engine/src/engine.rs
+git commit -m "fix(cache): add startup GC for stale HNSW files — resilient to crashes"
+```
+
+---
+
+## Task 3: Full Build Verification + Release
+
+**Step 1: Full test suite**
+
+```bash
+cd csr-engine && cargo test
+cd csr-engine && cargo test --test hooks_integration
+cd csr-engine && cargo test --test integration
+```
+
+**Step 2: Clippy + fmt**
+
+```bash
+cargo fmt && cargo clippy
+```
+
+**Step 3: Release build + install + eval**
+
+```bash
+cargo build --release
+cp target/release/csr-engine /usr/local/bin/csr-engine
+csr-engine eval
+```
+
+**Step 4: Commit if needed, tag**
+
+```bash
+git tag -a v9.0.1 -m "hotfix: HNSW cache bloat prevention (60GB → 109MB)"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (dump cleanup) — standalone
+Task 2 (startup GC) — uses same helper, depends on Task 1
+Task 3 (verification) — depends on all above
+```


### PR DESCRIPTION
## Summary
- **Root cause**: hnsw_rs `file_dump` creates numbered files (`chunks-7905.hnsw.data`) when mmap is active after `load_from_disk`, but `load_from_disk` expects canonical names (`chunks.hnsw.data`). Numbered files accumulated to **60GB / 7,654 files** in production, causing 14s cold-start rebuilds that blocked MCP tool calls.
- **Fix**: Capture `file_dump` return value, atomically rename numbered files to canonical names (`promote_to_canonical`), then clean any remaining stale numbered files
- **Startup GC**: `cleanup_stale_index_files` runs at engine startup for crash resilience
- **Codex xhigh review**: CRITICAL finding (numbered vs canonical mismatch) identified and fixed before implementation

## Codex Review Findings Applied
| Severity | Issue | Fix |
|----------|-------|-----|
| CRITICAL | `file_dump` returns numbered basename but code ignores it | Capture return value, `promote_to_canonical()` |
| HIGH | Plan assumed unnumbered = latest (false for cache-load path) | Promote first, then clean |
| HIGH | Cleanup not protected by `index.lock` | Cleanup runs inside lock scope in `dump_to_disk` |

## Test plan
- [x] 398 tests pass (303 unit + 41 hooks + 54 integration)
- [x] 5 new tests: promote rename, promote noop, cleanup removes numbered, cleanup empty dir, cleanup nonexistent dir
- [x] cargo clippy clean, cargo fmt clean
- [x] Release build + install + eval 5/5
- [x] Production validated: 60GB → 109MB after manual cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine startup now automatically cleans up stale index cache files from previous sessions and crashes, improving system resilience and preventing cache bloat.
  * Index cache management enhanced with improved file naming and dedicated cleanup routines for more reliable cache operations.

* **Documentation**
  * Added documentation for the cache cleanup strategy and implementation plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramakay/claude-self-reflect/pull/201)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->