### PR TITLE
fix(cache): lock startup GC + propagate promote errors

### DIFF
--- a/csr-engine/src/engine.rs
+++ b/csr-engine/src/engine.rs
@@ -178,8 +178,19 @@ impl Engine {
             search
         };
 
-        // Clean stale numbered HNSW files from previous sessions (crash resilience)
-        crate::search::cleanup_stale_index_files(&index_dir);
+        // Clean stale numbered HNSW files from previous sessions (crash resilience).
+        // Acquire exclusive lock to avoid racing with concurrent dump_to_disk writers.
+        if let Ok(lock_file) = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(index_dir.join("index.lock"))
+        {
+            if fs2::FileExt::lock_exclusive(&lock_file).is_ok() {
+                crate::search::cleanup_stale_index_files(&index_dir);
+            }
+            // lock released on drop
+        }
 
         Ok(Self {
             storage,

--- a/csr-engine/src/search/mod.rs
+++ b/csr-engine/src/search/mod.rs
@@ -323,7 +323,7 @@ impl SearchEngine {
                 .chunk_index
                 .file_dump(dir, "chunks")
                 .map_err(|e| anyhow::anyhow!("chunk index dump failed: {}", e))?;
-            promote_to_canonical(dir, &basename, "chunks");
+            promote_to_canonical(dir, &basename, "chunks")?;
         }
 
         if !self.reflection_id_map.is_empty() {
@@ -331,7 +331,7 @@ impl SearchEngine {
                 .reflection_index
                 .file_dump(dir, "reflections")
                 .map_err(|e| anyhow::anyhow!("reflection index dump failed: {}", e))?;
-            promote_to_canonical(dir, &basename, "reflections");
+            promote_to_canonical(dir, &basename, "reflections")?;
         }
 
         // Write manifest atomically (tmp + rename)
@@ -494,17 +494,25 @@ impl SearchEngine {
 /// If `file_dump` returned a numbered basename (e.g. "chunks-7905"), rename its files
 /// to the canonical name (e.g. "chunks.hnsw.data") so `load_from_disk` can find them.
 /// This happens when the Hnsw was loaded via `load_hnsw` (mmap active → `overwrite=false`).
-fn promote_to_canonical(dir: &Path, returned_basename: &str, canonical: &str) {
+fn promote_to_canonical(dir: &Path, returned_basename: &str, canonical: &str) -> Result<()> {
     if returned_basename == canonical {
-        return; // Already canonical, nothing to do
+        return Ok(()); // Already canonical, nothing to do
     }
     for ext in &[".hnsw.data", ".hnsw.graph"] {
         let src = dir.join(format!("{}{}", returned_basename, ext));
         let dst = dir.join(format!("{}{}", canonical, ext));
         if src.exists() {
-            let _ = std::fs::rename(&src, &dst);
+            std::fs::rename(&src, &dst).map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to promote {} to {}: {}",
+                    src.display(),
+                    dst.display(),
+                    e
+                )
+            })?;
         }
     }
+    Ok(())
 }
 
 /// Remove stale numbered HNSW files from the index directory.


### PR DESCRIPTION
Addresses CodeRabbit review comments on #201:

1. **Startup GC locked** — `cleanup_stale_index_files` now acquires exclusive `index.lock` to prevent racing with concurrent `dump_to_disk` writers
2. **Promote errors propagated** — `promote_to_canonical` returns `Result<()>`, rename failures now abort `dump_to_disk` instead of being silently swallowed

398 tests pass, clippy clean.