### PR TITLE
fix(landing): demo card grid placement

### DIFF
--- a/docs-site/src/index.css
+++ b/docs-site/src/index.css
@@ -657,6 +657,7 @@ body {
 .card--ask { grid-column: 1 / -1; grid-row: 4; }
 .card--arch { grid-column: 1 / -1; grid-row: 5; }
 .card--whatsnew { grid-column: 1 / -1; grid-row: 6; }
+.card--demo { grid-column: 1 / -1; grid-row: 7; }
 .card--flatfile { grid-column: 1 / span 4; grid-row: 8; }
 .card--kgraph { grid-column: 5 / span 4; grid-row: 8; }
 .card--hosted { grid-column: 9 / span 4; grid-row: 8; }
@@ -2383,7 +2384,8 @@ body {
   }
 
   .card--ask,
-  .card--arch {
+  .card--arch,
+  .card--demo {
     grid-column: 1 / -1;
     grid-row: auto;
   }


### PR DESCRIPTION
Demo card collapsed to a single grid track — no placement rule while all sibling cards are explicitly placed. Screenshot-reported.

https://claude.ai/code/session_01Jkdi1Sf7aQokp66XsEau1u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the docs site card layout so the “demo” card spans the full width in its designated grid row.
  * Improved the responsive layout so the “demo” card also expands to full width on smaller screens, matching the behavior of other wide cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->