### PR TITLE
fix(ci): skip claude-review job for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   claude-review:
+    # Skip for dependabot: those runs read Dependabot secrets (empty), not Actions secrets
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Root cause
Dependabot-triggered workflow runs read from **Dependabot secrets**, not Actions secrets, so `CLAUDE_CODE_OAUTH_TOKEN` resolves to empty and the job fails on every dependabot PR. Evidence from run logs: `"anthropic_api_key": ""` under `Secret source: Dependabot`.

## Fix
Job-level `if: github.actor != 'dependabot[bot]'` guard on `claude-review`.

## Note: reverses a previous decision
Commit 394034e (Aug 2025) removed this exact guard in favor of `allowed_bots` + configuring the token in both Actions and Dependabot secret stores. The Dependabot-side secret was never configured, and AI review of lockfile bumps is low value — skipping is the simpler, safer call (no secret exposure to the dependabot context).

Unblocks merge train: #205, #216, #210, #209, #203.

https://claude.ai/code/session_01KQfg4Ti4EcrG1g6DSewDQs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated code reviews are now skipped for Dependabot-generated events.
  * This prevents the standard review workflow from running for those updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->