### PR TITLE
fix(deps): bump react-router to 7.15.x in docs-site

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -10,7 +10,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.6.0",
+        "react-router-dom": "^7.15.0",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1"
       },
@@ -3539,9 +3539,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3561,12 +3561,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.0",
+    "react-router-dom": "^7.15.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "rehype-raw": "^7.0.0",


### PR DESCRIPTION
## Summary

Bumps `react-router-dom` (and transitive `react-router`) in `docs-site` from `7.14.2` to `7.18.1`, resolving the react-router DoS advisory (GHSA-8x6r-g9mw-2r78).

This replaces #215, whose Cargo half (openssl bump) already merged separately via #218. This PR only covers the docs-site half.

## Changes

- `docs-site/package.json` — `react-router-dom` pin `^7.6.0` → `^7.15.0`
- `docs-site/package-lock.json` — `react-router-dom` + `react-router` bumped `7.14.2` → `7.18.1`

No other files touched (no csr-engine/ or Cargo changes).

## Verification

- `cd docs-site && npm run build` — succeeds (vite 6.4.2, 1948 modules, built in ~1.1s)
- `npm ls react-router` / `npm ls react-router-dom` — both report `7.18.1` (>= 7.15.0 required)
- `git diff main --stat` — only the two package files changed

## Notes

- Does not close #215 — leaving that to the maintaining session.
- Not merging this PR — leaving that to the maintaining session.

https://claude.ai/code/session_01KQfg4Ti4EcrG1g6DSewDQs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation site’s routing dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->