### PR TITLE
fix(ci): bump claude-code-action from @beta to @v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           # Uses Actions secrets for regular PRs, Dependabot secrets for Dependabot PRs
           # Add CLAUDE_CODE_OAUTH_TOKEN to both Actions and Dependabot secrets

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Stale `@beta` ref defaults to retired model `claude-sonnet-4-20250514` → API 404 `not_found_error` on every human-authored PR (observed on #222 run logs). `@v1` is the current stable ref with a current default model.

Note: claude-review on this PR itself will fail with the OIDC workflow-validation error (workflow file differs from main) — same benign self-referential failure as #221, clears after merge.

https://claude.ai/code/session_01KQfg4Ti4EcrG1g6DSewDQs