### PR TITLE
chore(deps): pin rmcp ~1.6, defer rmcp 1.7 and ast-grep 0.43 migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
       - "rust"
     commit-message:
       prefix: "deps(cargo)"
+    ignore:
+      # rmcp 1.7 breaks Content/RawResource API — migration deferred (#203)
+      - dependency-name: "rmcp"
+        versions: [">=1.7"]
+      # ast-grep 0.43 breaks Language trait API — migration deferred (#207/#208)
+      - dependency-name: "ast-grep-core"
+        versions: [">=0.43"]
+      - dependency-name: "ast-grep-language"
+        versions: [">=0.43"]
 
   # npm installer shim
   - package-ecosystem: "npm"

--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 description = "Claude Self-Reflect: Rust MCP server with embedded vector search"
 
 [dependencies]
-rmcp = { version = "1.6", features = ["server", "transport-io", "macros", "elicitation"] }
+# ~1.6: rmcp 1.7 moved Content/RawResource and made structs non-exhaustive — migration deferred (see #203)
+rmcp = { version = "~1.6", features = ["server", "transport-io", "macros", "elicitation"] }
 fastembed = "5.9"
 hnsw_rs = "0.3"
 rusqlite = { version = "0.38", features = ["bundled", "vtab"] }


### PR DESCRIPTION
Closes the two deferred-migration threads from today's dependency triage (grok-advisor consulted twice, defer verdict both times):

- **rmcp 1.7** (#203): moved `Content`/`RawResource`, non-exhaustive structs — breaks `src/mcp` compile. Only win is a -32700-vs-hangup nicety on malformed stdio. Unforced protocol-core rewrite, deferred.
- **ast-grep 0.43** (#207/#208): `Language` trait API change breaks AST module. No RustSec advisory on 0.42. Deferred.

Hazard closed: caret `"1.6"` already permitted 1.7, so plain `cargo update` could silently break the build — `~1.6` prevents that. ast-grep `"0.42"` is already `<0.43` under 0.x caret rules; it only needed dependabot ignore entries.

Closes #203, #207, #208.

https://claude.ai/code/session_01KQfg4Ti4EcrG1g6DSewDQs