### PR TITLE
docs: v9.3.0 docs-site update + task backlog folder

### DIFF
--- a/docs-site/src/content/cli.md
+++ b/docs-site/src/content/cli.md
@@ -15,8 +15,8 @@ csr-engine setup
 
 ### status
 ```bash
-csr-engine status           # Full JSON
-csr-engine status --compact  # One-line for statusbar
+csr-engine status           # Full JSON (incl. "narratives" block: AI calls/tokens today + total)
+csr-engine status --compact  # One-line for statusbar, e.g. "AI 3c/12.4k tok today" or "AI off"
 ```
 
 ### hook
@@ -66,7 +66,8 @@ csr-engine quality src/main.rs
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| ANTHROPIC_API_KEY | (none) | Required for Layer 3 |
+| CSR_NARRATIVE_MODEL | (none) | Override AI narrative model (chain: this → `haiku` → CLI default) |
+| CSR_NO_AI_NARRATIVES | (none) | Set to `1` to disable AI narratives |
 | CSR_DB_PATH | ~/.claude-self-reflect/csr-engine.db | DB location |
 
 ## Data Locations

--- a/docs-site/src/content/configuration.md
+++ b/docs-site/src/content/configuration.md
@@ -17,8 +17,11 @@ Configured in `~/.claude/settings.json` via `csr-engine hook install --apply`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| ANTHROPIC_API_KEY | — | For Layer 3 AI narratives |
+| CSR_NARRATIVE_MODEL | — | Override model for AI narratives (falls back to `haiku`, then CLI default) |
+| CSR_NO_AI_NARRATIVES | — | Set to `1` to disable AI narrative generation entirely |
 | CSR_DB_PATH | ~/.claude-self-reflect/csr-engine.db | Custom DB path |
+
+AI narratives run through the Claude Code CLI (`claude -p`) — no API key required.
 
 ## Database
 

--- a/docs-site/src/content/enrichment.md
+++ b/docs-site/src/content/enrichment.md
@@ -26,9 +26,9 @@ Project: my-api | 45 min, 34 messages
 - Separate liveness and readiness probes
 ```
 
-## Layer 3: AI Narrative (optional, ~$0.012/conv)
+## Layer 3: AI Narrative (optional)
 
-Uses Anthropic Batch API (50% discount). Generates rich narratives.
+Generated locally via the Claude Code CLI (`claude -p`) — no API key, billed through your existing Claude subscription. Generates rich narratives.
 
 | Metric | Without AI | With AI |
 |--------|-----------|---------|
@@ -38,17 +38,35 @@ Uses Anthropic Batch API (50% discount). Generates rich narratives.
 ### Enable
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...
 csr-engine daemon
 ```
 
-### Cost Estimates
+### Model Selection (v9.3)
 
-| Conversations | Cost |
-|---------------|------|
-| 100 | ~$1.20 |
-| 500 | ~$6.00 |
-| 1,000 | ~$12.00 |
+Narratives resolve the model through a chain — no dated model pin to go stale:
+
+1. `CSR_NARRATIVE_MODEL` (if set)
+2. `haiku` alias (cheapest tier)
+3. CLI default (only if the alias itself is unavailable)
+
+The chain only advances on a real model-not-found error, never on transient failures.
+
+### Cost Controls (v9.3)
+
+Every narrative call is metered — including failures and timeouts:
+
+```bash
+csr-engine status            # "narratives" block: calls/tokens today + total
+csr-engine status --compact  # "AI 3c/12.4k tok today" or "AI off"
+```
+
+Kill switch:
+
+```bash
+export CSR_NO_AI_NARRATIVES=1   # disables all AI narrative generation
+```
+
+The session briefing is also content-hash cached — it only regenerates when episode content actually changes.
 
 > **Tip**: Start without AI narratives. Free Layer 1+2 provides good search. Add Layer 3 later for best recall.
 
@@ -57,4 +75,5 @@ csr-engine daemon
 ```bash
 csr-engine status
 # enrichment.heuristic_completed, extracted_v3_completed, ai_narrative_completed
+# narratives.calls_today, narratives.tokens_today, narratives.disabled
 ```

--- a/docs-site/src/content/hooks.md
+++ b/docs-site/src/content/hooks.md
@@ -16,7 +16,7 @@ This is what separates CSR from passive memory tools. **Context finds you.**
 
 Fires when you start a conversation. Injects three things:
 
-- **CONTINUUM** — last session's state: what was asked, where it ended (LAST), what's next (NEXT), and how many code anchors are still intact
+- **CONTINUUM** — last session's state: what was asked, where it ended (LAST), what's next (NEXT), and how many code anchors are still intact. Anchors are AST symbols in the six parsed languages, with whole-file fallback anchors for everything else (v9.3) — Swift, Kotlin, any language
 - **EPISODE INDEX** — recent sessions as a pickup menu, newest first, each with its outcome and a one-call lookup
 - **Anti-patterns** from incomplete past sessions
 
@@ -33,11 +33,12 @@ EPISODE INDEX — earlier threads, newest first:
 
 Fires every prompt. Routes first, then scores.
 
-**Intent routing (v9.2)** — a semantic classifier (exemplar embeddings over the same local MiniLM model, no extra model shipped) detects two intents:
+**Intent routing (v9.2, extended v9.3)** — a semantic classifier (exemplar embeddings over the same local MiniLM model, no extra model shipped) detects three intents:
 
 | Route | Intent | Threshold | Action |
 |-------|--------|-----------|--------|
 | A | Continue / StateRecall ("pick up where we left off", "what were we doing?") | 0.60 / 0.55 | Inject the matching episode's state directly |
+| A | Explore ("how does the ring navigation work?") | 0.55 | Inject a **CODE MAP** — file pointers from the conversation that built the feature, plus a ready-to-run recall call — before the agent re-maps the codebase |
 | B | Topic correlation | recency-weighted, 7-day half-life | Match prompt to a past episode; surface it as a pickup pointer |
 
 Everything else falls through to multi-signal scoring:
@@ -53,7 +54,7 @@ Everything else falls through to multi-signal scoring:
 
 ## SessionEnd — Automatic Narrative
 
-Imports final transcript, runs V3 extraction, synthesizes session story locally (free), falls back to Haiku if needed.
+Imports final transcript, runs V3 extraction, synthesizes session story locally (free), falls back to an AI narrative via `claude -p` if needed (model chain: `CSR_NARRATIVE_MODEL` → `haiku` → CLI default; every call metered, `CSR_NO_AI_NARRATIVES=1` disables).
 
 Stored narrative example:
 ```

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -818,28 +818,25 @@ function WhatsNewCard() {
   return (
     <BentoCard className="card--whatsnew" delay={560} id="whats-new">
       <CardKicker number="—" label="LATEST RELEASE" accent="purple" />
-      <h2 className="type-hl-sm">What's New in v9.2.0</h2>
+      <h2 className="type-hl-sm">What's New in v9.3.0</h2>
       <ul className="whatsnew-list">
         <li>
-          <strong>Episode intelligence</strong> — every session ends as a structured episode; SessionStart opens with a CONTINUUM block and a pickup menu of recent threads
+          <strong>Narrative token accounting</strong> — every AI narrative call is metered, including failures; <code>csr-engine status</code> reports calls and tokens spent today and all-time
         </li>
         <li>
-          <strong>Intent routing</strong> — "pick up where we left off" is detected semantically (exemplar embeddings, zero new models) and answered from episode state
+          <strong>Model chain + kill switch</strong> — narratives resolve <code>CSR_NARRATIVE_MODEL</code> → <code>haiku</code> → CLI default instead of a dated model pin; <code>CSR_NO_AI_NARRATIVES=1</code> turns AI narratives off entirely
         </li>
         <li>
-          <strong>Provenance re-ranking</strong> — recall favors what was decided and done over what was merely proposed; CSR now beats grep on its own founding-conversation benchmark
+          <strong>CODE MAP injection</strong> — exploration prompts ("how does the ring navigation work?") are detected semantically and answered with file pointers from the conversation that built the feature — before the agent re-maps the codebase
         </li>
         <li>
-          <strong>Code graph</strong> — <code>csr_code_graph</code> links functions to the conversations that shaped them via AST anchors
+          <strong>File-level anchors</strong> — code provenance tracking now covers every language via whole-file anchors, not just the six AST-parsed ones
         </li>
         <li>
-          <strong>Full-transcript recall</strong> — tool results are embedded with size-based chunking; coverage went from ~1% of each conversation to effectively all of it
-        </li>
-        <li>
-          <strong>Telemetry dashboard</strong> — <code>csr-engine telemetry</code> with hook latency percentiles, startup stats, and a live TUI
+          <strong>Briefing cache</strong> — the session briefing regenerates only when episode content actually changes, cutting repeat SessionStart cost to zero
         </li>
       </ul>
-      <a className="cite-link" href="https://github.com/ramakay/claude-self-reflect/releases/tag/v9.2.0" target="_blank" rel="noopener noreferrer">Full release notes →</a>
+      <a className="cite-link" href="https://github.com/ramakay/claude-self-reflect/releases/tag/v9.3.0" target="_blank" rel="noopener noreferrer">Full release notes →</a>
     </BentoCard>
   )
 }

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,11 @@
+# Task Backlog
+
+Deferred follow-ups, one file per task. Status: `open` | `watching` | `done` (move done items to git history — delete the file).
+
+| Task | Status | Origin |
+|------|--------|--------|
+| [classify-intent-margin.md](classify-intent-margin.md) | watching | v9.3.0 codegraph pickup |
+| [correlate-episode-memoization.md](correlate-episode-memoization.md) | open | v9.3.0 codegraph pickup |
+| [file-anchor-extension-denylist.md](file-anchor-extension-denylist.md) | watching | v9.3.0 file-level anchors |
+| [classify-attempt-extraction.md](classify-attempt-extraction.md) | open | v9.3.0 narrative cost controls |
+| [reddit-post.md](reddit-post.md) | open | v9.2/v9.3 marketing prep |

--- a/docs/tasks/classify-attempt-extraction.md
+++ b/docs/tasks/classify-attempt-extraction.md
@@ -1,0 +1,10 @@
+# Extract classify_attempt for subprocess-404 testability
+
+**Status:** open
+**Files:** `csr-engine/src/narrative.rs`, `csr-engine/src/hooks/session_briefing.rs`, `csr-engine/src/summarizer.rs`
+
+The model-not-found detector (walks the chain `CSR_NARRATIVE_MODEL` → `haiku` → CLI default) keys off the real `claude -p` failure shape: non-zero exit + error JSON on STDOUT with `api_error_status:404` and wording like "issue with the selected model… may not exist". The detection logic is exercised via the fixture (`tests/fixtures/claude_p_result.json`) but the **attempt/classification step is embedded in the call sites**, so the walk-vs-fail decision isn't unit-testable without spawning a subprocess.
+
+## What to do
+
+Extract a pure function, e.g. `classify_attempt(exit_status, stdout, stderr) -> AttemptOutcome { Success, ModelNotFound, OtherFailure }`, call it from both call sites (briefing + story), and unit-test it against: fixture 404 JSON, transient network error, timeout, success JSON, and garbage output. Guards against the CLI changing its error wording silently.

--- a/docs/tasks/classify-intent-margin.md
+++ b/docs/tasks/classify-intent-margin.md
@@ -1,0 +1,14 @@
+# Watch: classifier has no inter-intent margin
+
+**Status:** watching
+**Files:** `csr-engine/src/hooks/intent.rs` (`classify`, `threshold()`)
+
+`classify` is argmax-over-exemplars with per-intent thresholds (Continue 0.60, StateRecall 0.55, Explore 0.55) but **no margin requirement between the top two intents**. Explore and StateRecall share the 0.55 floor, so a prompt scoring 0.56/0.55 flips routes on embedding noise — StateRecall emits the recency pickup while Explore emits the CODE MAP, so adjacent prompts can get different injection shapes.
+
+## What to do
+
+1. Observe real flips first: run with `CSR_DEBUG_CORRELATE=1` and watch for Explore-vs-StateRecall boundary flips on real prompts.
+2. Only if flips are observed and harmful: add a margin requirement (e.g. top intent must beat runner-up by 0.03–0.05) with abstain-on-tie falling through to Route B correlation.
+3. Calibration is synthetic-only so far — collect real-prompt scores before picking the margin value.
+
+Do NOT add the margin preemptively; both routes inject useful context, so a flip is a quality wobble, not a correctness bug.

--- a/docs/tasks/correlate-episode-memoization.md
+++ b/docs/tasks/correlate-episode-memoization.md
@@ -1,0 +1,12 @@
+# Memoize correlate_episode on Explore-miss path
+
+**Status:** open
+**Files:** `csr-engine/src/hooks/prompt_submit.rs` (`correlate_episode`, intent match arm)
+
+When the classifier returns `Explore` but the correlated episode yields no usable CODE MAP (no anchors / no file pointers), control falls through to Route B topic correlation — which calls `correlate_episode` **a second time** with the same inputs. Each call embeds the prompt and scans episodes, so the miss path pays double.
+
+## What to do
+
+Compute the correlation once (`Option<(Episode, String, f32)>`), reuse the result in both the Explore arm and the Route B fallback. Straightforward refactor; add a test asserting single correlation per prompt (e.g. count via a test hook or instrument the query layer).
+
+Low urgency: hook budget is milliseconds and prompt-submit stays under it, but it is wasted work on every Explore-miss.

--- a/docs/tasks/file-anchor-extension-denylist.md
+++ b/docs/tasks/file-anchor-extension-denylist.md
@@ -1,0 +1,14 @@
+# Extension denylist for file-level anchors (if noisy)
+
+**Status:** watching
+**Files:** `csr-engine/src/extraction/anchors.rs` (`capture_file_anchors`, file-level fallback)
+
+v9.3.0 added file-level fallback anchors (node_kind `"file"`, whole-file hash) for languages outside ast-grep's six. This makes ANCHORS work for Swift/Kotlin/etc., but it anchors **any** edited file — including lockfiles, generated code, JSON blobs, and binary-ish assets — where "modified since checkpoint" is meaningless churn.
+
+## What to do
+
+1. Watch CONTINUUM `ANCHORS: N intact, M modified` lines for noise: if M is dominated by lockfiles/generated files, act.
+2. Add a denylist in `capture_file_anchors`: skip extensions/names like `*.lock`, `package-lock.json`, `Cargo.lock`, `*.min.js`, `*.map`, `*.svg`, `dist/`, `node_modules/`, `target/`.
+3. Keep it a denylist (anchor everything by default), not an allowlist — the whole point of the fallback is any-language coverage.
+
+Only implement after observed noise; current anchor cap (40) already bounds the damage.

--- a/docs/tasks/reddit-post.md
+++ b/docs/tasks/reddit-post.md
@@ -1,0 +1,18 @@
+# Reddit post — scoped claims
+
+**Status:** open (user-gated: draft needs review before posting)
+
+Launch post for CSR, deferred from v9.2/v9.3 prep. Use scoped, defensible claims per the Codex competitive review:
+
+**Lead:** "local-first Claude Code continuity layer" — NOT "killer feature no one else offers".
+
+**Defensible claims:**
+- AST anchors tying conversations to code symbols (lead differentiator)
+- Fully local stack: single Rust binary, local embeddings, SQLite+HNSW, no cloud, no API keys
+- Semantic intent-gated injection at the decision point (SessionStart CONTINUUM + prompt-submit routes)
+- v9.3 token accounting turns the "hidden AI cost" criticism into a feature — every narrative call metered, kill switch documented
+
+**Avoid (would get torn apart):**
+- "beats grep" without caveating single-query eval
+- `supersedes` field claims (never populated)
+- Any "no one else does memory" framing (mem0/letta/zep/claude-mem exist; differentiation is the AST+local+injection combination, not memory per se)


### PR DESCRIPTION
Post-release docs sync for v9.3.0 plus a tracked backlog for deferred follow-ups.

## Docs-site
- Landing "What's New" card: v9.2.0 → v9.3.0 (token accounting, model chain + kill switch, CODE MAP injection, file-level anchors, briefing cache)
- `enrichment.md`: Layer 3 rewritten — narratives run via `claude -p` (removes stale Anthropic Batch API / `ANTHROPIC_API_KEY` instructions), documents model chain, per-call metering, `CSR_NO_AI_NARRATIVES=1` kill switch
- `configuration.md` / `cli.md`: `CSR_NARRATIVE_MODEL` + `CSR_NO_AI_NARRATIVES` env vars; status `narratives` block and compact `AI Nc/N.Nk tok today` / `AI off` output
- `hooks.md`: Explore intent → CODE MAP route added to the intent table; file-level anchor coverage noted

## Task backlog (`docs/tasks/`)
One file per deferred follow-up: intent-margin watch, correlate_episode memoization, file-anchor extension denylist, classify_attempt extraction, Reddit post claim scoping.

Docs + markdown only — no engine code changes. `npm run build` green in docs-site.

https://claude.ai/code/session_0125jUYpBd7RhtNzcSx5mUeN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI and configuration guidance for AI-generated narratives, including model selection and a disable option.
  * Documented local narrative generation, token tracking, caching, and updated status output.
  * Expanded Active Memory Hooks documentation with Explore intent routing, CODE MAP injection, and broader code anchors.
  * Updated the landing page to highlight v9.3.0 features and link to its release notes.
  * Added task backlog entries and follow-up guidance for classification, correlation, anchors, and launch messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->