### PR TITLE
refactor: extract classify_attempt for model-404 chain-walk testability

### DIFF
--- a/csr-engine/src/hooks/session_briefing.rs
+++ b/csr-engine/src/hooks/session_briefing.rs
@@ -239,12 +239,11 @@ fn invoke_narrative_briefing(prompt: &str) -> Result<crate::narrative::ParsedNar
         }
 
         let output = child.wait_with_output()?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-            if crate::narrative::is_model_not_found(&stderr)
-                || crate::narrative::is_model_not_found(&stdout)
-            {
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        match crate::narrative::classify_attempt(output.status.success(), &stdout, &stderr) {
+            crate::narrative::AttemptOutcome::Parsed(parsed) => return Ok(parsed),
+            crate::narrative::AttemptOutcome::ModelNotFound => {
                 tracing::warn!(model = ?candidate, "narrative model unavailable — trying next candidate");
                 last_err = Some(anyhow::anyhow!(
                     "model unavailable: {}",
@@ -252,17 +251,7 @@ fn invoke_narrative_briefing(prompt: &str) -> Result<crate::narrative::ParsedNar
                 ));
                 continue; // walk the chain ONLY on model-not-found
             }
-            anyhow::bail!("claude -p failed: {}", stderr);
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        match crate::narrative::parse_claude_json(&stdout) {
-            Some(parsed) => return Ok(parsed),
-            None if crate::narrative::is_model_not_found(&stdout) => {
-                last_err = Some(anyhow::anyhow!("model unavailable (json error result)"));
-                continue;
-            }
-            None => anyhow::bail!("claude -p returned unparseable/error JSON"),
+            crate::narrative::AttemptOutcome::Failed(msg) => anyhow::bail!("{}", msg),
         }
     }
 

--- a/csr-engine/src/narrative.rs
+++ b/csr-engine/src/narrative.rs
@@ -30,6 +30,7 @@ pub fn model_candidates() -> Vec<Option<String>> {
     chain
 }
 
+#[derive(Debug)]
 pub struct ParsedNarrative {
     pub text: String,
     pub model: String,
@@ -90,6 +91,36 @@ pub fn is_model_not_found(stderr_or_json: &str) -> bool {
     (s.contains("issue with the selected model") || s.contains("may not exist"))
         || (s.contains("\"api_error_status\":404") && s.contains("model"))
         || (s.contains("model") && (s.contains("not found") || s.contains("invalid model")))
+}
+
+/// Outcome of one `claude -p` attempt. Decides whether the model chain
+/// walks to the next candidate (ModelNotFound) or stops (Failed).
+#[derive(Debug)]
+pub enum AttemptOutcome {
+    /// Exit success and stdout parsed as a narrative result.
+    Parsed(ParsedNarrative),
+    /// The requested model does not exist / is inaccessible — walk the chain.
+    ModelNotFound,
+    /// Any other failure (rate limit, network, garbage output) — stop; never
+    /// burn remaining candidates on non-model errors.
+    Failed(String),
+}
+
+pub fn classify_attempt(status_success: bool, stdout: &str, stderr: &str) -> AttemptOutcome {
+    if status_success {
+        match parse_claude_json(stdout) {
+            Some(p) => AttemptOutcome::Parsed(p),
+            None if is_model_not_found(stdout) => AttemptOutcome::ModelNotFound,
+            None => AttemptOutcome::Failed("claude -p returned unparseable/error JSON".to_string()),
+        }
+    } else if is_model_not_found(stderr) || is_model_not_found(stdout) {
+        AttemptOutcome::ModelNotFound
+    } else {
+        AttemptOutcome::Failed(format!(
+            "claude -p failed: {}",
+            if stderr.is_empty() { stdout } else { stderr }
+        ))
+    }
 }
 
 /// FNV-1a 64-bit. Deterministic across processes and versions (unlike
@@ -183,5 +214,67 @@ mod tests {
         std::env::set_var("CSR_NO_AI_NARRATIVES", "0");
         assert!(!narratives_disabled());
         std::env::remove_var("CSR_NO_AI_NARRATIVES");
+    }
+
+    #[test]
+    fn test_classify_attempt_success_fixture() {
+        match classify_attempt(true, FIXTURE, "") {
+            AttemptOutcome::Parsed(p) => assert!(!p.text.is_empty()),
+            other => panic!("expected Parsed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_classify_attempt_model_404_json_on_failure() {
+        let json = r#"{"is_error":true,"api_error_status":404,"result":"There's an issue with the selected model (zz9). It may not exist or you may not have access to it."}"#;
+        assert!(matches!(
+            classify_attempt(false, json, ""),
+            AttemptOutcome::ModelNotFound
+        ));
+        assert!(matches!(
+            classify_attempt(false, "", json),
+            AttemptOutcome::ModelNotFound
+        ));
+    }
+
+    #[test]
+    fn test_classify_attempt_model_404_wording_on_success_status() {
+        let json = r#"{"is_error":true,"result":"There's an issue with the selected model (zz9). It may not exist."}"#;
+        assert!(matches!(
+            classify_attempt(true, json, ""),
+            AttemptOutcome::ModelNotFound
+        ));
+    }
+
+    #[test]
+    fn test_classify_attempt_rate_limit_is_failed() {
+        assert!(matches!(
+            classify_attempt(false, "", "rate limit exceeded"),
+            AttemptOutcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_attempt_network_error_is_failed() {
+        assert!(matches!(
+            classify_attempt(false, "network error: connection refused", ""),
+            AttemptOutcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_attempt_garbage_on_success_is_failed() {
+        assert!(matches!(
+            classify_attempt(true, "not json at all", ""),
+            AttemptOutcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_attempt_failed_prefers_stderr() {
+        match classify_attempt(false, "stdout noise", "real error") {
+            AttemptOutcome::Failed(msg) => assert!(msg.contains("real error")),
+            other => panic!("expected Failed, got {:?}", other),
+        }
     }
 }

--- a/csr-engine/src/summarizer.rs
+++ b/csr-engine/src/summarizer.rs
@@ -126,27 +126,19 @@ async fn call_claude_headless(prompt: &str) -> Option<crate::narrative::ParsedNa
         .await;
 
         match attempt {
-            Ok(Some(output)) if output.status.success() => {
+            Ok(Some(output)) => {
                 let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                match crate::narrative::parse_claude_json(&stdout) {
-                    Some(mut parsed) => {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                match crate::narrative::classify_attempt(output.status.success(), &stdout, &stderr)
+                {
+                    crate::narrative::AttemptOutcome::Parsed(mut parsed) => {
                         // Cap at 1000 chars — stories should be concise
                         parsed.text = parsed.text.chars().take(1000).collect();
                         return Some(parsed);
                     }
-                    None if crate::narrative::is_model_not_found(&stdout) => continue,
-                    None => return None,
+                    crate::narrative::AttemptOutcome::ModelNotFound => continue,
+                    crate::narrative::AttemptOutcome::Failed(_) => return None,
                 }
-            }
-            Ok(Some(output)) => {
-                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                if crate::narrative::is_model_not_found(&stderr)
-                    || crate::narrative::is_model_not_found(&stdout)
-                {
-                    continue; // next candidate
-                }
-                return None; // real failure — don't burn the chain on rate limits
             }
             _ => return None, // timeout or spawn failure
         }


### PR DESCRIPTION
Punch-list item 4 (docs/tasks/punch-list-2026-07-13.md; task spec: docs/tasks/classify-attempt-extraction.md).

Extracts the model-not-found chain-walk decision for `claude -p` attempts into a pure `classify_attempt(status_success, stdout, stderr) -> AttemptOutcome` in `narrative.rs`, and refactors both call sites (`session_briefing.rs`, `summarizer.rs`) to use it. Zero behavior change — the chain walks ONLY on ModelNotFound; rate limits/network errors/timeouts stop immediately, exactly as before.

Adds 7 unit tests over the real CLI 404 fixture wording, success-status error JSON, transient failures, and garbage output — the walk decision is now unit-testable without a subprocess.

Implemented via grok lane; diff reviewed line-by-line and verification re-run by controller: `cargo fmt --check` / `cargo clippy -D warnings` clean, `cargo test` 504+43+57 green (497→504 unit tests).

https://claude.ai/code/session_0125jUYpBd7RhtNzcSx5mUeN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved narrative generation when a selected model is unavailable by automatically trying the next available option.
  * Improved handling of command-line errors, malformed responses, rate limits, and network failures.
  * Standardized error detection and reporting across narrative briefings and summaries.
* **Reliability**
  * Successful responses are now processed more consistently, while unrecoverable failures stop promptly instead of producing misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->