### PR TITLE
perf: memoize correlate_episode on Explore-miss fall-through

### DIFF
--- a/csr-engine/src/hooks/prompt_submit.rs
+++ b/csr-engine/src/hooks/prompt_submit.rs
@@ -119,6 +119,11 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
         }
     };
 
+    // correlate_episode is expensive (semantic search over reflections); the
+    // Explore arm and Route B want the same result for the same prompt, so the
+    // first caller fills this memo and Route B reuses it on the fall-through.
+    let mut correlated_memo: Option<Option<(crate::hooks::stop::Episode, String, f32)>> = None;
+
     // Route A (semantic): nearest-prototype intent classification over the
     // same embedding space. The literal phrase match above catches exact
     // continuations for free; this catches rephrasings ("keep at it",
@@ -183,19 +188,20 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
                         &cwd.to_string_lossy(),
                     )
                     .unwrap_or_default();
-                    if let Some((ep, age, _score)) = correlate_episode(
+                    let corr = correlate_episode(
                         engine,
                         &query_vec,
                         &current_project,
                         input.session_id.as_deref(),
                     )
-                    .await
-                    {
-                        if let Some(map) = format_code_map(&ep, &age) {
+                    .await;
+                    if let Some((ep, age, _score)) = &corr {
+                        if let Some(map) = format_code_map(ep, age) {
                             println!("{}", map);
                             return Ok(());
                         }
                     }
+                    correlated_memo = Some(corr);
                     // No correlated episode or no files — normal flow continues below.
                 }
             }
@@ -245,14 +251,19 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
     // episode with its retrieval handle, framed as prior art to verify (the
     // episode may be stale or the resemblance coincidental — never asserted
     // as the answer).
-    if let Some((ep, age, score)) = correlate_episode(
-        engine,
-        &query_vec,
-        &current_project,
-        input.session_id.as_deref(),
-    )
-    .await
-    {
+    let correlated = match correlated_memo {
+        Some(memo) => memo,
+        None => {
+            correlate_episode(
+                engine,
+                &query_vec,
+                &current_project,
+                input.session_id.as_deref(),
+            )
+            .await
+        }
+    };
+    if let Some((ep, age, score)) = correlated {
         emit_pickup(
             &ep,
             &age,


### PR DESCRIPTION
Punch-list item 5 (docs/tasks/punch-list-2026-07-13.md; task spec: docs/tasks/correlate-episode-memoization.md).

`handle_inner` in prompt_submit.rs called `correlate_episode` twice with identical args when the Explore intent arm missed (no correlated episode or no CODE MAP) and control fell through to Route B — double semantic-search + episode-scan work per Explore-miss prompt. The Explore arm now fills a memo (`Option<Option<(Episode, String, f32)>>`) and Route B reuses it; paths that never ran Explore compute exactly as before. At most one execution per prompt by construction; zero emission/ordering changes.

No new test: the runtime invariant is structural (memo checked before the second call), and a global call counter would be racy across the five parallel `prompt_submit::handle` integration tests (no serial_test dep).

Implemented via grok lane; diff reviewed line-by-line and verification re-run by controller: `cargo fmt --check` / `cargo clippy -D warnings` clean, `cargo test` 497+43+57 green.

https://claude.ai/code/session_0125jUYpBd7RhtNzcSx5mUeN