### PR TITLE
fix: close CodeRabbit findings from PR #245

### DIFF
--- a/csr-engine/data/RATIFICATION_PROMPT.md
+++ b/csr-engine/data/RATIFICATION_PROMPT.md
@@ -36,7 +36,7 @@ object; never reply with prose.
 
 Output STRICT JSON only — no markdown fences, no commentary:
 
-```
+```json
 {"acts": [{"type": "DIRECTS", "evidence": "<short verbatim quote from the digest>", "msg_hint": "<brief location hint, e.g. 'early' or 'near end'>"}]}
 ```
 

--- a/csr-engine/eval-kit/README.md
+++ b/csr-engine/eval-kit/README.md
@@ -26,7 +26,7 @@ protocol audit: `docs/plans/saga-e2-audit-packet.md`.
 | `prep_ledger.sh` | Extract git/npm/release-train ship ledgers (repo paths = operator's) |
 | `run_extract.sh` | Dual-vendor extraction driver (grok + sonnet, strict consensus) |
 | `map_helper.py` | Metadata-only origin mapping helper (literal LIKE + git history + dates — NO embedding search) |
-| `grade.py` | Grading: acts × ledger corroboration → grades 0-3; grade 3 requires sealed+mapped origin |
+| `grade.py` | Grading: acts × ledger corroboration → grades 0-3; grade 3 requires a sealed, mapped origin |
 | `mapping.json` / `grades.json` / `pools.json` | Outputs: origin map (owner-audited), per-item grades (204 items), pools. Conversation IDs only — no transcript content |
 
 Rules that made it credible: extraction never sees rank lists; ledgers corroborate but

--- a/csr-engine/eval-kit/e1/score.py
+++ b/csr-engine/eval-kit/e1/score.py
@@ -7,17 +7,20 @@ from collections import defaultdict
 
 E1 = os.path.dirname(os.path.abspath(__file__))
 E2 = os.path.join(os.path.dirname(E1), "e2")
-G = json.load(open(os.path.join(E2, "grades.json")))["grades"]
-M = json.load(open(os.path.join(E2, "mapping.json")))
+with open(os.path.join(E2, "grades.json")) as f:
+    G = json.load(f)["grades"]
+with open(os.path.join(E2, "mapping.json")) as f:
+    M = json.load(f)
 
 runs = defaultdict(dict)  # arm -> qid -> convs
 meta = None
-for line in open(os.path.join(E1, "ablation.jsonl")):
-    d = json.loads(line)
-    if "meta" in d:
-        meta = d["meta"]
-        continue
-    runs[d["arm"]][d["qid"]] = d["convs"]
+with open(os.path.join(E1, "ablation.jsonl")) as f:
+    for line in f:
+        d = json.loads(line)
+        if "meta" in d:
+            meta = d["meta"]
+            continue
+        runs[d["arm"]][d["qid"]] = d["convs"]
 
 def grade(qid, conv):
     v = G[qid]["items"].get(conv)
@@ -61,5 +64,6 @@ for arm in order:
     table[arm] = row
     print(f"{arm:<15}{row['origin_mrr']!s:>7}{row['ndcg10']!s:>9}{row['recall2']!s:>9}{ung:>10}")
 
-json.dump({"meta": meta, "arms": table}, open(os.path.join(E1, "results.json"), "w"), indent=1)
+with open(os.path.join(E1, "results.json"), "w") as f:
+    json.dump({"meta": meta, "arms": table}, f, indent=1)
 print("\nresults.json written")

--- a/csr-engine/eval-kit/e2/grade.py
+++ b/csr-engine/eval-kit/e2/grade.py
@@ -8,16 +8,25 @@ import json, os, math
 from collections import defaultdict
 
 E2 = os.path.dirname(os.path.abspath(__file__))
-load = lambda n: json.load(open(os.path.join(E2, n)))
-POOLS, MAPPING, QUERIES = load("pools.json"), load("mapping.json"), load("queries.json")
-LEDGER = load("ledger.json")
+
+
+def load_json(filename):
+    with open(os.path.join(E2, filename)) as f:
+        return json.load(f)
+
+
+POOLS = load_json("pools.json")
+MAPPING = load_json("mapping.json")
+QUERIES = load_json("queries.json")
+LEDGER = load_json("ledger.json")
 QIDS = [q["id"] for q in QUERIES]
 
 def ext(vendor, qid):
     p = os.path.join(E2, f"extract_{vendor}", f"{qid}.json")
     if not os.path.exists(p):
         return None
-    d = json.load(open(p))
+    with open(p) as f:
+        d = json.load(f)
     if "error" in d:
         return None
     return {i["conv_id"]: i for i in d.get("items", [])}
@@ -32,18 +41,6 @@ agree_counts = defaultdict(lambda: [0, 0])  # act -> [agree, total]
 kappa_cells = defaultdict(lambda: [0, 0, 0, 0])  # act -> [both_yes, s_only, g_only, both_no]
 vendor_status = {}
 grades, ledger_notes = {}, []
-
-def git_events_near(conv_ts_range, target, window_h=72):
-    """Ledger corroboration: commits touching target within window of conv span."""
-    if not conv_ts_range or not target:
-        return []
-    hits = []
-    tbase = os.path.basename(target)
-    for repo, commits in LEDGER.get("git", {}).items():
-        for c in commits:
-            if any(tbase in f for f in c.get("files", [])):
-                hits.append({"repo": repo, "hash": c["hash"], "date": c["date"], "subject": c["subject"][:60]})
-    return hits[:5]
 
 for qid in QIDS:
     s, g = ext("sonnet", qid), ext("grok", qid)
@@ -150,5 +147,6 @@ summary = {
                "unresolved_excluded": MAPPING["unmapped_unresolved"],
                "out_of_corpus": list(MAPPING.get("out_of_corpus", {}).keys())},
 }
-json.dump({"grades": grades, "summary": summary}, open(os.path.join(E2, "grades.json"), "w"), indent=1)
+with open(os.path.join(E2, "grades.json"), "w") as f:
+    json.dump({"grades": grades, "summary": summary}, f, indent=1)
 print(json.dumps(summary, indent=1))

--- a/csr-engine/eval-kit/e2/map_helper.py
+++ b/csr-engine/eval-kit/e2/map_helper.py
@@ -6,7 +6,7 @@ plus the git introduction/major commits of the target. NO embedding search."""
 import sys, subprocess, os
 
 SQLITE = "/opt/homebrew/opt/sqlite/bin/sqlite3"
-DB = "$HOME/.claude-self-reflect/csr-engine.db"
+DB = os.path.expandvars("$HOME/.claude-self-reflect/csr-engine.db")
 FREEZE = "2026-07-15T23:59:59Z"
 
 qid, repo, target = sys.argv[1], sys.argv[2], sys.argv[3]

--- a/csr-engine/eval-kit/e2/prep_digests.py
+++ b/csr-engine/eval-kit/e2/prep_digests.py
@@ -5,7 +5,7 @@ Deterministic, no judgment. Output: e2/digests/<qid>.md + e2/digest_index.json""
 import json, os, glob, re
 
 E2 = os.path.dirname(os.path.abspath(__file__))
-PROJ = "$HOME/.claude/projects"
+PROJ = os.path.expandvars("$HOME/.claude/projects")
 QUERIES = {q["id"]: q for q in json.load(open(os.path.join(E2, "queries.json")))}
 POOLS = json.load(open(os.path.join(E2, "pools.json")))
 OUTD = os.path.join(E2, "digests")
@@ -31,7 +31,7 @@ def text_of(content):
     return ""
 
 SQLITE = "/opt/homebrew/opt/sqlite/bin/sqlite3"
-DB = "$HOME/.claude-self-reflect/csr-engine.db"
+DB = os.path.expandvars("$HOME/.claude-self-reflect/csr-engine.db")
 
 def digest_conv_db(conv_id, target, in_file_touch):
     """Fallback for purged JSONLs: reconstruct from CSR DB chunks (pre-freeze rows, immutable).
@@ -92,11 +92,15 @@ def digest_conv(conv_id, target, in_file_touch=False):
             if tbase.split(".")[0].lower() in t.lower():
                 keep.add(i)
         rest = [i for i, _, _ in scored if i not in keep]
-        # fill with head+tail turns
-        for i in rest[: (TURN_CAP - len(keep)) // 2]:
-            keep.add(i)
-        for i in rest[-((TURN_CAP - len(keep))):] if TURN_CAP > len(keep) else []:
-            keep.add(i)
+        # fill with head+tail turns, only while capacity remains (len(keep) can
+        # already exceed TURN_CAP from target-mention matches alone; a negative
+        # remaining budget must not silently wrap into a huge negative slice)
+        if len(keep) < TURN_CAP:
+            needed = TURN_CAP - len(keep)
+            for i in rest[: needed // 2]:
+                keep.add(i)
+            for i in rest[-(needed - needed // 2):]:
+                keep.add(i)
         user_turns = [user_turns[i] for i in sorted(keep)][:TURN_CAP]
     else:
         user_turns = user_turns[:TURN_CAP]

--- a/csr-engine/eval-kit/e2/prep_ledger.sh
+++ b/csr-engine/eval-kit/e2/prep_ledger.sh
@@ -55,13 +55,14 @@ npm view claude-self-reflect time --json 2>/dev/null || echo '{}'
 echo ','
 echo -n '"release_train": '
 python3 -c '
-import json
+import json, os
+path = os.path.expandvars("$HOME/projects/anukriti/anukriti-mvp-expo/release-train.yaml")
 try:
     import yaml
-    d = yaml.safe_load(open("$HOME/projects/anukriti/anukriti-mvp-expo/release-train.yaml"))
+    d = yaml.safe_load(open(path))
     print(json.dumps(d, default=str))
 except Exception as e:
-    print(json.dumps({"raw": open("$HOME/projects/anukriti/anukriti-mvp-expo/release-train.yaml").read()[:8000]}))
+    print(json.dumps({"raw": open(path).read()[:8000]}))
 '
 echo '}'
 } > "$OUT"

--- a/csr-engine/eval-kit/e2/prep_pools.py
+++ b/csr-engine/eval-kit/e2/prep_pools.py
@@ -5,7 +5,7 @@ import json, os, re, subprocess, glob
 
 SP = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 E2 = os.path.join(SP, "e2")
-DB = "$HOME/.claude-self-reflect/csr-engine.db"
+DB = os.path.expandvars("$HOME/.claude-self-reflect/csr-engine.db")
 SQLITE = "/opt/homebrew/opt/sqlite/bin/sqlite3"
 FREEZE = "2026-07-15"
 
@@ -32,7 +32,6 @@ def file_touch(target):
          "WHERE ce.file_path LIKE '%' || ? "
          "AND EXISTS (SELECT 1 FROM chunks c WHERE c.conversation_id = ce.session_id "
          "            AND c.timestamp <= '" + FREEZE + "T23:59:59Z')")
-    out = subprocess.run([SQLITE, DB, q], input=target, capture_output=True, text=True)
     # param binding via stdin doesn't work for sqlite3 CLI; inline safely (targets are our own constants)
     q2 = q.replace("?", "'" + target.replace("'", "''") + "'")
     out = subprocess.run([SQLITE, DB, q2], capture_output=True, text=True)

--- a/csr-engine/eval-kit/e2/run_extract.sh
+++ b/csr-engine/eval-kit/e2/run_extract.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 set -u
-SCRATCH="$SCRATCH"
+SCRATCH="${SCRATCH:?Environment variable SCRATCH must be set}"
 E2="$SCRATCH/e2"
 PROTO="$E2/extraction_prompt.md"
 OUTDIR="$E2/extract_grok"
@@ -77,14 +77,14 @@ for qid in "${QIDS[@]}"; do
   rawfile=$(run_one "$qid" 1 "")
   jsonfile="$OUTDIR/${qid}.json"
   extract_json_block < "$rawfile" > "$jsonfile.tmp"
-  if python3 -c "import json,sys; json.load(open('$jsonfile.tmp'))" 2>/dev/null; then
+  if python3 -c "import sys,json; json.load(sys.stdin)" < "$jsonfile.tmp" 2>/dev/null; then
     mv "$jsonfile.tmp" "$jsonfile"
     echo "$qid: OK (attempt 1)" >&2
   else
     echo "$qid: attempt 1 invalid JSON, retrying" >&2
     rawfile2=$(run_one "$qid" 2 "Your previous output was invalid JSON. Output only the JSON object.")
     extract_json_block < "$rawfile2" > "$jsonfile.tmp"
-    if python3 -c "import json,sys; json.load(open('$jsonfile.tmp'))" 2>/dev/null; then
+    if python3 -c "import sys,json; json.load(sys.stdin)" < "$jsonfile.tmp" 2>/dev/null; then
       mv "$jsonfile.tmp" "$jsonfile"
       echo "$qid: OK (attempt 2)" >&2
     else

--- a/csr-engine/eval-kit/e3/gen_c5.py
+++ b/csr-engine/eval-kit/e3/gen_c5.py
@@ -1,6 +1,6 @@
 import json, uuid, datetime, os
 
-OUT_DIR = "$SCRATCH/e3/c5_transcripts"
+OUT_DIR = os.path.expandvars("$SCRATCH/e3/c5_transcripts")
 
 QUERIES = [
     ("Q5", "why does import skip conversations that start with CSR agent prompts"),

--- a/csr-engine/eval-kit/e3/score.py
+++ b/csr-engine/eval-kit/e3/score.py
@@ -55,8 +55,10 @@ for arm in ["knn_exact", "full_exact", "full_no_echo_exact"]:
             row += f"{str(rk):>8}"
             if r:
                 mrr[c].append(1.0 / rk if isinstance(rk, int) else 0.0)
-        e0 = echo10(data["c0"]["runs"][arm][qid]["chunks"]) if "c0" in data else "?"
-        e5 = echo10(data["c5"]["runs"][arm][qid]["chunks"]) if "c5" in data else "?"
+        r0 = data.get("c0", {}).get("runs", {}).get(arm, {}).get(qid)
+        e0 = echo10(r0["chunks"]) if r0 else "?"
+        r5 = data.get("c5", {}).get("runs", {}).get(arm, {}).get(qid)
+        e5 = echo10(r5["chunks"]) if r5 else "?"
         row += f"{str(e0)+' -> '+str(e5):>18}"
         print(row)
     print("oMRR " + "".join(f"{round(sum(v)/len(v),3) if v else '?':>8}" for v in (mrr[c] for c in CONDS)))

--- a/csr-engine/src/daemon/ratification.rs
+++ b/csr-engine/src/daemon/ratification.rs
@@ -20,7 +20,7 @@ use crate::storage::{NarrativeUsageRow, RatificationScoreRow, Storage};
 const DIGEST_CHAR_CAP: usize = 8000;
 const RATIFICATION_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_RATIFICATION_PROMPT_SIZE: u64 = 10 * 1024;
-const EXTRACTOR_VERSION: &str = "ratification-v2";
+const EXTRACTOR_VERSION: &str = "ratification-v3";
 const MAX_LEDGER_SHAS: usize = 20;
 
 static DISABLED_LOG: Once = Once::new();

--- a/csr-engine/src/daemon/ratification.rs
+++ b/csr-engine/src/daemon/ratification.rs
@@ -403,7 +403,12 @@ pub async fn process_ratification(storage: &Arc<Storage>, conv_id: &str) -> Resu
         storage.mark_enrichment_completed(conv_id, "ratification", "")?;
         return Ok(());
     }
-    let chunks = storage.get_chunks_by_ids(&chunk_ids)?;
+    // Must use the provenance-joined path: get_chunks_by_ids alone always
+    // defaults author to ToolResult (author lives in chunk_provenance, not the
+    // chunks table), which silently starves build_digest's operator-turn
+    // filter (author == Speaker::User) and degrades the v2 extractor to plain
+    // head/tail sampling. See get_chunks_by_ids_with_provenance.
+    let chunks = storage.get_chunks_by_ids_with_provenance(&chunk_ids)?;
     let digest = build_digest(&chunks, DIGEST_CHAR_CAP);
     let prompt = format!(
         "{}\n\nCONVERSATION DIGEST:\n{}",
@@ -617,5 +622,87 @@ mod tests {
         let other = digest.find("OTHER CONTEXT").unwrap();
         assert!(op < user_pos && user_pos < other);
         assert!(digest.find("assistant explanation text").unwrap() > other);
+    }
+
+    /// Regression (CodeRabbit PR #245 finding, pre-confirmed): the unit tests
+    /// above pass only because they build `ConversationChunk`s in memory with
+    /// `author` set directly. In production, `process_ratification` fetches
+    /// chunks via storage — and `get_chunks_by_ids` always defaults `author`
+    /// to `ToolResult` because the `chunks` table has no author column (it
+    /// lives in `chunk_provenance`). That meant `build_digest`'s
+    /// `author == Speaker::User` filter always saw an empty `user_text` in
+    /// production, silently degrading the v2 extractor to plain head/tail
+    /// sampling and never emitting the operator-turn excerpts section. This
+    /// test goes through the real storage path — insert chunks +
+    /// chunk_provenance rows into a temp DB, fetch via
+    /// `get_chunks_by_ids_with_provenance`, and confirm `build_digest` emits
+    /// the operator-turn section.
+    #[test]
+    fn ratification_digest_via_storage_emits_operator_turns() {
+        use crate::provenance::{ChunkProvenance, Speaker};
+
+        let storage = Storage::open_memory().unwrap();
+        let mk = |id: &str, content: &str| ConversationChunk {
+            id: id.into(),
+            conversation_id: "conv-real".into(),
+            project_name: "p".into(),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            content: content.into(),
+            message_count: 1,
+            summary: None,
+            // Deliberately wrong/irrelevant: insert_chunk doesn't persist
+            // author (no such column on `chunks`); only chunk_provenance
+            // determines the real author once fetched via the joined path.
+            author: Speaker::ToolResult,
+            seq: 0,
+            is_sidechain: false,
+        };
+
+        let user_chunk = mk("rc1", "please fix the flaky HNSW persistence test");
+        let asst_chunk = mk("rc2", "done, added an advisory lock before dump_to_disk");
+        storage.insert_chunk(&user_chunk, &[0.0; 4]).unwrap();
+        storage.insert_chunk(&asst_chunk, &[0.0; 4]).unwrap();
+        storage
+            .insert_chunk_provenance(
+                "rc1",
+                &ChunkProvenance {
+                    author: Speaker::User,
+                    source_conv_id: "conv-real".into(),
+                    supersedes: None,
+                },
+            )
+            .unwrap();
+        storage
+            .insert_chunk_provenance(
+                "rc2",
+                &ChunkProvenance {
+                    author: Speaker::Assistant,
+                    source_conv_id: "conv-real".into(),
+                    supersedes: None,
+                },
+            )
+            .unwrap();
+
+        let ids = vec!["rc1".to_string(), "rc2".to_string()];
+
+        // Old path (what process_ratification used before this fix): every
+        // chunk defaults to ToolResult, so build_digest never sees a user turn.
+        let plain_chunks = storage.get_chunks_by_ids(&ids).unwrap();
+        let plain_digest = build_digest(&plain_chunks, DIGEST_CHAR_CAP);
+        assert!(
+            !plain_digest.contains("OPERATOR-TURN EXCERPTS"),
+            "sanity check: unjoined path must NOT surface operator turns (that's the bug)"
+        );
+
+        // New path: provenance-joined fetch recovers the true author, so
+        // build_digest correctly emits the operator-turn section.
+        let joined_chunks = storage.get_chunks_by_ids_with_provenance(&ids).unwrap();
+        let digest = build_digest(&joined_chunks, DIGEST_CHAR_CAP);
+        assert!(
+            digest.contains("=== OPERATOR-TURN EXCERPTS ==="),
+            "build_digest must emit the operator-turn section when fetched via \
+             get_chunks_by_ids_with_provenance; got: {digest}"
+        );
+        assert!(digest.contains("please fix the flaky HNSW persistence test"));
     }
 }

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -101,6 +101,20 @@ impl Storage {
         queries::get_chunks_by_ids(&conn, ids)
     }
 
+    /// Like [`Self::get_chunks_by_ids`], but resolves each chunk's true author
+    /// via a `LEFT JOIN` on `chunk_provenance` instead of defaulting to
+    /// `Speaker::ToolResult`. Needed by callers that filter on
+    /// `ConversationChunk::author` — e.g. ratification's `build_digest`, which
+    /// prioritizes `Speaker::User` turns and silently degraded to head/tail
+    /// sampling in production without this (author lives outside `chunks`).
+    pub fn get_chunks_by_ids_with_provenance(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<ConversationChunk>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::get_chunks_by_ids_with_provenance(&conn, ids)
+    }
+
     // ─── Reflection operations ───
 
     pub fn insert_reflection(

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -212,6 +212,38 @@ pub fn get_chunks_by_ids(conn: &Connection, ids: &[String]) -> Result<Vec<Conver
     Ok(chunks)
 }
 
+/// Like [`get_chunks_by_ids`], but resolves each chunk's true author via a
+/// `LEFT JOIN` on `chunk_provenance` instead of defaulting every chunk to
+/// `Speaker::ToolResult`. `get_chunks_by_ids` intentionally does not carry
+/// author (it's cheaper and most callers don't need it — reinstatement graph
+/// walks, MCP display, eval metadata); this variant exists for callers that
+/// filter on `ConversationChunk::author`, e.g. ratification's `build_digest`,
+/// which prioritizes `Speaker::User` turns. Chunks with no provenance row, or
+/// an unrecognized author token, degrade to `Speaker::ToolResult` — same
+/// fallback as [`get_chunk_provenance`].
+pub fn get_chunks_by_ids_with_provenance(
+    conn: &Connection,
+    ids: &[String],
+) -> Result<Vec<ConversationChunk>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.conversation_id, c.project_name, c.timestamp, c.content,
+                c.message_count, c.summary, cp.author
+         FROM chunks c LEFT JOIN chunk_provenance cp ON cp.chunk_id = c.id
+         WHERE c.id = ?1",
+    )?;
+    let mut chunks = Vec::new();
+    for id in ids {
+        let mut rows = stmt.query_map(params![id], row_to_chunk_with_author)?;
+        if let Some(row) = rows.next() {
+            chunks.push(row?);
+        }
+    }
+    Ok(chunks)
+}
+
 pub fn insert_reflection(
     conn: &Connection,
     id: &str,
@@ -547,11 +579,35 @@ fn row_to_chunk(row: &rusqlite::Row) -> rusqlite::Result<ConversationChunk> {
         summary: row.get(6)?,
         // Author is stored separately in chunk_provenance, not the chunks table;
         // reconstructed chunks default to non-authoritative. Live recall reads
-        // provenance explicitly via get_chunk_provenance.
+        // provenance explicitly via get_chunk_provenance, or use
+        // get_chunks_by_ids_with_provenance / row_to_chunk_with_author below.
         author: crate::provenance::Speaker::ToolResult,
         // seq/is_sidechain are not selected here (7-col SELECT, unchanged) — reads via this
         // path don't need them for WS1; real values live in the chunks table and are read
         // directly by the saga queries below when needed.
+        seq: 0,
+        is_sidechain: false,
+    })
+}
+
+/// Helper: map a row to `ConversationChunk` with a resolved author, for queries
+/// that `LEFT JOIN chunk_provenance` (8th column: nullable `author` TEXT).
+/// See `get_chunks_by_ids_with_provenance`.
+fn row_to_chunk_with_author(row: &rusqlite::Row) -> rusqlite::Result<ConversationChunk> {
+    let author_str: Option<String> = row.get(7)?;
+    let author = author_str
+        .and_then(|s| s.parse::<Speaker>().ok())
+        .unwrap_or(Speaker::ToolResult);
+    Ok(ConversationChunk {
+        id: row.get(0)?,
+        conversation_id: row.get(1)?,
+        project_name: row.get(2)?,
+        timestamp: row.get(3)?,
+        content: row.get(4)?,
+        message_count: row.get::<_, i64>(5)? as usize,
+        summary: row.get(6)?,
+        author,
+        // Not selected here — same rationale as row_to_chunk above.
         seq: 0,
         is_sidechain: false,
     })
@@ -1965,6 +2021,74 @@ mod tests {
         let conn = mem();
         let map = get_ratification_scores(&conn, &[]).unwrap();
         assert!(map.is_empty());
+    }
+
+    /// Regression: `get_chunks_by_ids` alone always defaults `author` to
+    /// `ToolResult` (chunks table has no author column), which silently starved
+    /// ratification's `build_digest` of operator turns in production even
+    /// though import correctly wrote `Speaker::User` rows into
+    /// `chunk_provenance`. `get_chunks_by_ids_with_provenance` must recover the
+    /// real author via the LEFT JOIN.
+    #[test]
+    fn get_chunks_by_ids_with_provenance_resolves_true_author() {
+        let conn = mem();
+        let chunk = ConversationChunk {
+            id: "c1".into(),
+            conversation_id: "conv-1".into(),
+            project_name: "p".into(),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            content: "fix the import bug".into(),
+            message_count: 1,
+            summary: None,
+            author: Speaker::ToolResult, // irrelevant: insert_chunk doesn't persist author
+            seq: 0,
+            is_sidechain: false,
+        };
+        insert_chunk(&conn, &chunk, &[0.0; 4]).unwrap();
+        insert_chunk_provenance(
+            &conn,
+            "c1",
+            &ChunkProvenance {
+                author: Speaker::User,
+                source_conv_id: "conv-1".into(),
+                supersedes: None,
+            },
+        )
+        .unwrap();
+
+        // Plain path (no join) always degrades to ToolResult.
+        let plain = get_chunks_by_ids(&conn, &["c1".into()]).unwrap();
+        assert_eq!(plain[0].author, Speaker::ToolResult);
+
+        // Provenance-aware path recovers the true author.
+        let with_prov = get_chunks_by_ids_with_provenance(&conn, &["c1".into()]).unwrap();
+        assert_eq!(with_prov.len(), 1);
+        assert_eq!(with_prov[0].author, Speaker::User);
+        assert_eq!(with_prov[0].content, "fix the import bug");
+    }
+
+    /// A chunk with no `chunk_provenance` row at all must still degrade to
+    /// `ToolResult` (not error), matching `get_chunk_provenance`'s fallback.
+    #[test]
+    fn get_chunks_by_ids_with_provenance_defaults_when_no_row() {
+        let conn = mem();
+        let chunk = ConversationChunk {
+            id: "c2".into(),
+            conversation_id: "conv-2".into(),
+            project_name: "p".into(),
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            content: "no provenance row".into(),
+            message_count: 1,
+            summary: None,
+            author: Speaker::ToolResult,
+            seq: 0,
+            is_sidechain: false,
+        };
+        insert_chunk(&conn, &chunk, &[0.0; 4]).unwrap();
+
+        let with_prov = get_chunks_by_ids_with_provenance(&conn, &["c2".into()]).unwrap();
+        assert_eq!(with_prov.len(), 1);
+        assert_eq!(with_prov[0].author, Speaker::ToolResult);
     }
 
     #[test]

--- a/csr-engine/tests/hooks_integration.rs
+++ b/csr-engine/tests/hooks_integration.rs
@@ -1314,9 +1314,48 @@ fn test_session_end_v3_extraction() {
     );
 }
 
+/// Snapshot/restore guard for the ratification kill-switch env vars
+/// (`CSR_NO_AI_NARRATIVES`, `CSR_NO_RATIFICATION`). `session_end::handle`
+/// skips the enrichment-state reset entirely when either is set
+/// (`daemon::ratification::check_disabled`), and both vars are process-wide —
+/// mutated by unit tests elsewhere in this crate. Pinning them for the
+/// duration of this test (and restoring on drop, so a panic doesn't leak
+/// state to whichever test runs next in this binary) keeps the assertion
+/// deterministic regardless of what else is running.
+struct RatificationEnvGuard {
+    prev_narratives: Option<String>,
+    prev_ratification: Option<String>,
+}
+
+impl RatificationEnvGuard {
+    fn pinned_enabled() -> Self {
+        let guard = Self {
+            prev_narratives: std::env::var("CSR_NO_AI_NARRATIVES").ok(),
+            prev_ratification: std::env::var("CSR_NO_RATIFICATION").ok(),
+        };
+        std::env::remove_var("CSR_NO_AI_NARRATIVES");
+        std::env::remove_var("CSR_NO_RATIFICATION");
+        guard
+    }
+}
+
+impl Drop for RatificationEnvGuard {
+    fn drop(&mut self) {
+        match &self.prev_narratives {
+            Some(v) => std::env::set_var("CSR_NO_AI_NARRATIVES", v),
+            None => std::env::remove_var("CSR_NO_AI_NARRATIVES"),
+        }
+        match &self.prev_ratification {
+            Some(v) => std::env::set_var("CSR_NO_RATIFICATION", v),
+            None => std::env::remove_var("CSR_NO_RATIFICATION"),
+        }
+    }
+}
+
 /// SessionEnd deletes enrichment_state for ratification so the daemon re-scores.
 #[test]
 fn test_session_end_resets_ratification_enrichment() {
+    let _env_guard = RatificationEnvGuard::pinned_enabled();
     let tmp = tempfile::TempDir::new().unwrap();
     let transcript = tmp.path().join("ratify-reset-session.jsonl");
 


### PR DESCRIPTION
## Summary

Closes out the CodeRabbit review observations left unaddressed when PR #245 (saga-phase1 → main) was merged, plus the pre-confirmed `build_digest` operator-turn bug found during triage. All 18 CodeRabbit findings (10 actionable comments + 8 nitpicks, all authored by `coderabbitai[bot]`) are dispositioned below.

## Findings table

| # | File:Line | Finding | Severity | Disposition |
|---|---|---|---|---|
| 1 | `data/RATIFICATION_PROMPT.md:41` | Bare fence missing `json` language (MD040) | Minor | **Fixed** |
| 2 | `eval-kit/e2/map_helper.py:9` (+3 siblings) | `$HOME`/`$SCRATCH`/`$PROJ`/`$DB` not expanded in Python string literals | Major | **Fixed** — wrapped in `os.path.expandvars(...)` in `map_helper.py`, `prep_digests.py` (PROJ + DB), `prep_pools.py` (DB) |
| 3 | `eval-kit/e2/prep_digests.py:96-99` | Chronological-slicing bug: negative slice bound when `len(keep) >= TURN_CAP` before padding, pulling in unrelated early turns | Major | **Fixed** — guard padding loops with `if len(keep) < TURN_CAP` |
| 4 | `eval-kit/e2/prep_pools.py:35-36` | Redundant, failing `subprocess.run` call (stdin param-binding doesn't work for sqlite3 CLI); output discarded anyway | Minor | **Fixed** — removed |
| 5 | `eval-kit/e2/run_extract.sh:80,87` | JSON file path interpolated into `python3 -c` string; breaks on quotes | Minor | **Fixed** — feed via `stdin` |
| 6 | `eval-kit/e3/gen_c5.py:3` | `$SCRATCH` not expanded, would create literal `$SCRATCH` dir | Major | **Fixed** |
| 7 | `eval-kit/e3/score.py:58-59` | Direct dict indexing risks `KeyError` if `qid` missing from a run | Minor | **Fixed** — `.get()`-chained lookups, same pattern as line 53 |
| 8 | `eval-kit/README.md:29` | "sealed+mapped origin" wording | Minor | **Fixed** — "a sealed, mapped origin" |
| 9 | `src/daemon/ratification.rs:412` | **`build_digest` never receives operator turns in production** — `get_chunks_by_ids` always defaults `author` to `ToolResult`; `build_digest`'s `author == Speaker::User` filter always saw an empty `user_text`, silently degrading the v2 extractor to head/tail sampling | Major (heavy lift) | **Fixed** — pre-confirmed priority item, see below |
| 10 | `tests/hooks_integration.rs:1392` | Test not independent of process-wide `CSR_NO_AI_NARRATIVES`/`CSR_NO_RATIFICATION` env vars mutated by other tests | Minor | **Fixed** — snapshot/restore guard |
| 11 | `src/hooks/post_tool_use.rs:211-214,228` | No backfill for historical `code_evolution` rows written with raw `session_id` before the `conv_id_for` fix | Trivial | **Declined** — see justification below |
| 12 | `eval-kit/e2/grade.py:36-46` | Unused, incomplete `git_events_near` function (ignores its own params) | Trivial | **Fixed** — removed |
| 13 | `eval-kit/e2/grade.py:153` | `json.dump(..., open(...))` leaves file handle open | Trivial | **Fixed** — context manager |
| 14 | `eval-kit/e2/grade.py:11-13` | `lambda` assigned to a variable (PEP 8), unmanaged file handles | Trivial | **Fixed** — named `load_json` function with context manager |
| 15 | `eval-kit/e2/grade.py:20` | `json.load(open(p))` leaves file handle open | Trivial | **Fixed** — context manager |
| 16 | `eval-kit/e1/score.py:64` | `json.dump(..., open(...))` leaves file handle open | Trivial | **Fixed** — context manager |
| 17 | `eval-kit/e1/score.py:10-20` | Multiple `open()` calls without context managers | Trivial | **Fixed** — context managers |
| 18 | `eval-kit/e2/run_extract.sh:3` | No explicit error message when `$SCRATCH` unset | Trivial | **Fixed** — `${SCRATCH:?...}` |

### Declined: #11 (code_evolution historical backfill)

CodeRabbit's own severity tag is Trivial, and the comment is a "consider backfilling" suggestion, not a diff. The `conv_id_for` fix it refers to was itself shipped in PR #245 (i.e. the exposure window for rows written with the old raw-`session_id` identifier is on the order of days, not a long-lived migration debt). There is no existing backfill mechanism for `code_evolution` to extend (the one precedent, `backfill_code_graph` in `src/import/backfill.rs`, is a different domain — AST nodes/edges, not this table) and building one is a genuinely new, untested data-migration script — out of proportion to a trivial-severity nitpick in a review-cleanup PR. Flagging as a known limitation rather than building new migration infra here.

## The `build_digest` fix (priority item)

`row_to_chunk` in `csr-engine/src/storage/queries.rs` hardcodes `author: Speaker::ToolResult` because the `chunks` table has no `author` column — it lives in `chunk_provenance`. `process_ratification` (`src/daemon/ratification.rs`) called `storage.get_chunks_by_ids(&chunk_ids)` and passed the result straight to `build_digest`, whose operator-turn section filters `c.author == Speaker::User`. In production that filter always saw zero matches, so the v2 ratification digest silently fell back to plain head/tail sampling — the existing unit test (`build_digest_prioritizes_operator_turns`) only passed because it constructs `ConversationChunk`s in memory with `author` set directly, never exercising the real storage path.

**Fix**: added `Storage::get_chunks_by_ids_with_provenance` (`src/storage/mod.rs` + `queries::get_chunks_by_ids_with_provenance` in `queries.rs`), which does `chunks LEFT JOIN chunk_provenance ON chunk_provenance.chunk_id = chunks.id` and parses the joined `author` string via `Speaker::from_str`, defaulting to `ToolResult` when there's no provenance row (same fallback as `get_chunk_provenance`). `process_ratification` now calls this instead of the plain `get_chunks_by_ids`.

Checked every other caller of `get_chunks_by_ids` (MCP tools display, the reinstatement graph walk, `prompt_submit.rs`, `eval/continuity.rs`, `eval/provenance.rs`) — none read `.author` off the returned chunks (the reinstatement walk that does need provenance already calls `get_chunk_provenance` separately), so `get_chunks_by_ids`'s existing behavior and signature are untouched; this is purely additive.

### Test plan

- `storage::queries::tests::get_chunks_by_ids_with_provenance_resolves_true_author` — inserts a chunk + a `chunk_provenance` row (`Speaker::User`) into a temp DB, confirms the plain path still degrades to `ToolResult` while the new path recovers `User`.
- `storage::queries::tests::get_chunks_by_ids_with_provenance_defaults_when_no_row` — chunk with no provenance row still degrades to `ToolResult` (doesn't error).
- `daemon::ratification::tests::ratification_digest_via_storage_emits_operator_turns` — end-to-end regression through the real storage path: inserts chunks + `chunk_provenance` (User/Assistant) into a temp DB, fetches via `get_chunks_by_ids_with_provenance`, and asserts `build_digest` emits `"=== OPERATOR-TURN EXCERPTS ==="` and the operator's text — while explicitly asserting the *old* unjoined path does NOT (sanity check that this test would have caught the original bug).

This affects the ratification v2 digest-extractor mechanism (`EXTRACTOR_VERSION = "ratification-v2"`): future ratification runs will actually receive prioritized operator-turn excerpts instead of unprioritized head/tail sampling, as originally designed.

## Verification (run inside `csr-engine/`)

- `cargo test` (full): **672 passed, 0 failed** (570 lib + 45 `hooks_integration` + 57 `integration`)
- `cargo clippy --all-targets -- -D warnings`: clean, 0 warnings
- `cargo fmt --check`: clean
- `python3 -m py_compile` + `zsh -n` / `bash -n`: all touched eval-kit scripts parse cleanly

https://claude.ai/code/session_01PUBXfUnWQEHZGha5TY5C6k


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ratification digests now more accurately identify and include operator-authored conversation excerpts using conversation provenance.

- **Bug Fixes**
  - Improved handling of missing evaluation data to prevent scoring failures.
  - Corrected runtime path resolution for home and scratch directories.
  - Strengthened extraction validation and retry behavior for invalid JSON output.
  - Improved reliability when processing files and database records across evaluation workflows.

- **Documentation**
  - Clarified evaluation criteria wording and JSON output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->