### PR TITLE
feat(mcp): resolution ledger - csr_resolve, verdict annotation, page demotion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Single Rust binary (`csr-engine`). No Python, no Docker, no Qdrant.
 
 ```
 csr-engine (44MB)
-  ├── MCP server (rmcp, 13 tools)
+  ├── MCP server (rmcp, 15 tools)
   ├── Embeddings (FastEmbed, 384-dim, local)
   ├── Search (HNSW, <1ms p95)
   ├── Storage (SQLite)
@@ -29,7 +29,7 @@ csr-engine eval --full         # Full eval (20 tests, ~200ms)
 csr-engine quality <file>      # AST code quality analysis
 ```
 
-## MCP Tools (14 total)
+## MCP Tools (15 total)
 
 ```
 csr_reflect_on_past   — Semantic search across past conversations
@@ -46,6 +46,7 @@ get_full_conversation — Complete JSONL retrieval
 get_session_learnings — Iteration memory for Ralph loops
 csr_code_graph        — Which conversations shaped a function/file (AST anchors)
 csr_why               — Provenance chain: why does this code/decision exist (reinstatement recall)
+csr_resolve           — Record verified verdicts (resolved/still_open/regressed) on chunks; resolved demote+annotate in future searches
 ```
 
 ## Critical Rules
@@ -88,7 +89,7 @@ cargo bench --bench spike_bench
 ### Key Patterns
 
 - **rmcp tool params**: Use `Parameters<MyStruct>` pattern, NOT individual `#[tool(param)]`
-- **rmcp tool annotations**: All 13 tools have `annotations(read_only_hint, destructive_hint, idempotent_hint)` in macro
+- **rmcp tool annotations**: All 15 tools have `annotations(read_only_hint, destructive_hint, idempotent_hint)` in macro
 - **rmcp 1.6 builders**: `ServerInfo::new(caps).with_instructions()`, `Implementation::new()`, `ReadResourceResult::new()`
 - **fastembed**: Requires `aarch64` Rust — no x86_64-apple-darwin ONNX binaries
 - **rusqlite 0.38**: No `ToSql` for `usize` — cast to `i64`

--- a/csr-engine/src/format/mod.rs
+++ b/csr-engine/src/format/mod.rs
@@ -28,6 +28,8 @@ pub fn truncate_chars(s: &str, max: usize) -> &str {
 pub struct EnrichedResult {
     pub score: f32,
     pub chunk: ConversationChunk,
+    /// Resolution-ledger annotation, when a verdict has been recorded for this chunk.
+    pub resolution: Option<String>,
 }
 
 /// Drop multi-route and near-duplicate results, keeping first occurrence.
@@ -180,10 +182,34 @@ pub fn format_search_results(
 
         // Conversation ID
         out.push_str(&format!("      <cid>{}</cid>\n", r.chunk.conversation_id));
+        out.push_str(&format!("      <id>{}</id>\n", r.chunk.id));
+
+        if let Some(ref note) = r.resolution {
+            out.push_str(&format!(
+                "      <resolution>{}</resolution>\n",
+                xml_escape(note)
+            ));
+        }
 
         out.push_str("    </r>\n");
     }
     out.push_str("  </results>\n");
+
+    let resolved_count = results
+        .iter()
+        .filter(|r| {
+            r.resolution
+                .as_deref()
+                .is_some_and(|s| s.starts_with("resolved"))
+        })
+        .count();
+    if resolved_count > 0 {
+        out.push_str(&format!(
+            "  <note>{} resolved item(s) demoted within page — matched but verified addressed</note>\n",
+            resolved_count
+        ));
+    }
+
     out.push_str("</search>\n");
 
     out
@@ -369,6 +395,12 @@ pub fn format_recency_results(
             "    <conversation_id>{}</conversation_id>\n",
             xml_escape(&r.chunk.conversation_id)
         ));
+        if let Some(ref note) = r.resolution {
+            out.push_str(&format!(
+                "    <resolution>{}</resolution>\n",
+                xml_escape(note)
+            ));
+        }
         out.push_str("  </result>\n");
     }
 
@@ -452,6 +484,12 @@ pub fn format_more_results(
             "    <preview>{}</preview>\n",
             xml_escape(&preview)
         ));
+        if let Some(ref note) = r.resolution {
+            out.push_str(&format!(
+                "    <resolution>{}</resolution>\n",
+                xml_escape(note)
+            ));
+        }
         out.push_str("  </result>\n");
     }
 
@@ -598,6 +636,24 @@ pub fn age_stamp(timestamp: &str) -> String {
             relative_time_str(timestamp)
         ),
         None => timestamp.to_string(),
+    }
+}
+
+/// Render a resolution-ledger entry as a short annotation string.
+/// `created_at` is an RFC3339 timestamp; only the date portion (first 10
+/// chars, `YYYY-MM-DD`) is shown — falls back to the full string if shorter
+/// than 10 chars.
+pub fn resolution_note(entry_status: &str, evidence: &str, created_at: &str) -> String {
+    let date = if created_at.len() >= 10 {
+        &created_at[..10]
+    } else {
+        created_at
+    };
+    match entry_status {
+        "resolved" => format!("resolved — {} (verified {})", evidence, date),
+        "still_open" => format!("still open — verified {}", date),
+        "regressed" => format!("regressed — {} ({})", evidence, date),
+        other => format!("{} — {} ({})", other, evidence, date),
     }
 }
 
@@ -780,10 +836,12 @@ mod tests {
             EnrichedResult {
                 score: 0.9,
                 chunk: make_chunk("same-id", "conv-a", "content A"),
+                resolution: None,
             },
             EnrichedResult {
                 score: 0.5,
                 chunk: make_chunk("same-id", "conv-b", "content B"),
+                resolution: None,
             },
         ];
         dedupe_results(&mut results);
@@ -799,10 +857,12 @@ mod tests {
             EnrichedResult {
                 score: 0.9,
                 chunk: make_chunk("id-1", "conv-1", content),
+                resolution: None,
             },
             EnrichedResult {
                 score: 0.7,
                 chunk: make_chunk("id-2", "conv-1", content),
+                resolution: None,
             },
         ];
         dedupe_results(&mut results);
@@ -817,10 +877,12 @@ mod tests {
             EnrichedResult {
                 score: 0.9,
                 chunk: make_chunk("id-1", "conv-1", content),
+                resolution: None,
             },
             EnrichedResult {
                 score: 0.8,
                 chunk: make_chunk("id-2", "conv-2", content),
+                resolution: None,
             },
         ];
         dedupe_results(&mut results);
@@ -833,14 +895,80 @@ mod tests {
             EnrichedResult {
                 score: 0.9,
                 chunk: make_chunk("id-1", "conv-1", "Hello   World"),
+                resolution: None,
             },
             EnrichedResult {
                 score: 0.7,
                 chunk: make_chunk("id-2", "conv-1", "hello world"),
+                resolution: None,
             },
         ];
         dedupe_results(&mut results);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].chunk.id, "id-1");
+    }
+
+    #[test]
+    fn resolution_note_formats_resolved() {
+        let note = resolution_note("resolved", "shipped commit abc123", "2026-07-20T10:00:00Z");
+        assert!(note.starts_with("resolved —"), "got: {note}");
+        assert!(note.contains("shipped commit abc123"));
+        assert!(note.contains("2026-07-20"));
+    }
+
+    #[test]
+    fn resolution_note_formats_still_open() {
+        let note = resolution_note("still_open", "unused evidence", "2026-07-20T10:00:00Z");
+        assert!(note.starts_with("still open —"), "got: {note}");
+        assert!(note.contains("2026-07-20"));
+    }
+
+    #[test]
+    fn resolution_note_formats_regressed() {
+        let note = resolution_note("regressed", "broke again in v9.4", "2026-07-20T10:00:00Z");
+        assert!(note.starts_with("regressed —"), "got: {note}");
+        assert!(note.contains("broke again in v9.4"));
+        assert!(note.contains("2026-07-20"));
+    }
+
+    #[test]
+    fn format_search_results_renders_resolution_and_footer_count() {
+        let results = vec![
+            EnrichedResult {
+                score: 0.9,
+                chunk: make_chunk("id-open", "conv-1", "open item"),
+                resolution: None,
+            },
+            EnrichedResult {
+                score: 0.8,
+                chunk: make_chunk("id-resolved", "conv-1", "resolved item"),
+                resolution: Some(resolution_note(
+                    "resolved",
+                    "verified in prod",
+                    "2026-07-20T10:00:00Z",
+                )),
+            },
+        ];
+        let xml = format_search_results(&results, "q", "all", 1, 1);
+        assert!(xml.contains("<resolution>resolved"), "got: {xml}");
+        assert!(
+            xml.contains("<note>1 resolved item(s) demoted"),
+            "got: {xml}"
+        );
+        // The unresolved result must have no <resolution> tag rendered for it —
+        // check there is exactly one <resolution> element in total.
+        assert_eq!(xml.matches("<resolution>").count(), 1);
+    }
+
+    #[test]
+    fn format_search_results_no_resolution_tag_when_none() {
+        let results = vec![EnrichedResult {
+            score: 0.9,
+            chunk: make_chunk("id-1", "conv-1", "plain item"),
+            resolution: None,
+        }];
+        let xml = format_search_results(&results, "q", "all", 1, 1);
+        assert!(!xml.contains("<resolution>"), "got: {xml}");
+        assert!(!xml.contains("<note>"), "got: {xml}");
     }
 }

--- a/csr-engine/src/mcp/mod.rs
+++ b/csr-engine/src/mcp/mod.rs
@@ -177,6 +177,18 @@ pub struct WhyParams {
     pub project: Option<String>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ResolveParams {
+    /// Chunk ids (from <id> tags in search results — NOT <cid>, which is the conversation id) this verdict applies to
+    pub chunk_ids: Vec<String>,
+    /// One of: resolved (verified addressed), still_open (verified still pending), regressed (previously resolved, broke again)
+    pub status: String,
+    /// What was verified and how, e.g. 'shipped vc75 commit 332ef68, confirmed in app.json'
+    pub evidence: String,
+    /// Optional short digest of the claim being resolved
+    pub claim: Option<String>,
+}
+
 // ─── MCP Server ───
 
 /// The MCP server that exposes CSR search/reflection tools.
@@ -647,6 +659,28 @@ impl CsrServer {
             &cfg,
         )
         .await;
+
+        tool_result(result)
+    }
+
+    #[tool(
+        name = "csr_resolve",
+        description = "Record an explicit verdict (resolved/still_open/regressed) about chunks surfaced in search results, verified against the repo or real world. Future searches annotate these chunks and demote resolved ones within the page. Verdict applies to the WHOLE chunk — for multi-claim chunks resolve only when all claims are addressed, otherwise use still_open. Append-only: a regressed verdict re-opens a resolved chunk.",
+        annotations(
+            title = "Record Resolution Verdict",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false
+        )
+    )]
+    async fn resolve(
+        &self,
+        params: Parameters<ResolveParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let p = params.0;
+
+        let result =
+            tools::resolve_chunks(&self.storage, p.chunk_ids, p.status, p.evidence, p.claim).await;
 
         tool_result(result)
     }

--- a/csr-engine/src/mcp/tools.rs
+++ b/csr-engine/src/mcp/tools.rs
@@ -90,6 +90,7 @@ fn lookup_by_conv_tag(
                     seq: 0,
                     is_sidechain: false,
                 },
+                resolution: None,
             }
         })
         .collect();
@@ -181,6 +182,7 @@ pub async fn reflect_on_past(
                 EnrichedResult {
                     score: final_score,
                     chunk: c.clone(),
+                    resolution: None,
                 }
             })
         })
@@ -246,6 +248,7 @@ pub async fn reflect_on_past(
                     seq: 0,
                     is_sidechain: false,
                 },
+                resolution: None,
             });
         }
     }
@@ -285,6 +288,7 @@ pub async fn reflect_on_past(
                         content: format!("[keyword] {}", chunk.content),
                         ..chunk
                     },
+                    resolution: None,
                 });
             }
         }
@@ -321,6 +325,7 @@ pub async fn reflect_on_past(
     }
 
     format::dedupe_results(&mut enriched);
+    apply_resolutions(&mut enriched, storage);
 
     Ok(format::format_search_results(
         &enriched,
@@ -360,6 +365,33 @@ pub async fn store_reflection(
     ))
 }
 
+/// Record a resolution verdict for one or more chunks.
+pub async fn resolve_chunks(
+    storage: &Arc<Storage>,
+    chunk_ids: Vec<String>,
+    status: String,
+    evidence: String,
+    claim: Option<String>,
+) -> Result<String> {
+    if !matches!(status.as_str(), "resolved" | "still_open" | "regressed") {
+        anyhow::bail!(
+            "invalid status '{}': must be resolved, still_open, or regressed",
+            status
+        );
+    }
+    if chunk_ids.is_empty() {
+        anyhow::bail!("chunk_ids must not be empty");
+    }
+    if evidence.trim().is_empty() {
+        anyhow::bail!("evidence must not be empty");
+    }
+
+    let n =
+        storage.insert_resolutions(&chunk_ids, &status, &evidence, claim.as_deref(), "agent")?;
+
+    Ok(format!("recorded {} verdict(s): {}", n, status))
+}
+
 /// Quick existence check — count + top match only.
 pub async fn quick_check(
     storage: &Arc<Storage>,
@@ -391,6 +423,7 @@ pub async fn quick_check(
                 .map(|c| EnrichedResult {
                     score: r.score,
                     chunk: c.clone(),
+                    resolution: None,
                 })
         })
         .collect();
@@ -866,11 +899,58 @@ fn enrich_results(
                 .map(|c| EnrichedResult {
                     score: r.score,
                     chunk: c.clone(),
+                    resolution: None,
                 })
         })
         .collect();
     format::dedupe_results(&mut enriched_vec);
+    apply_resolutions(&mut enriched_vec, storage);
     Ok(enriched_vec)
+}
+
+/// Annotate `enriched` results with any recorded resolution ledger verdicts
+/// (batch-fetched from storage) and stable-sink "resolved" entries to the
+/// bottom of the slice, preserving relative order otherwise. `still_open`
+/// and `regressed` verdicts annotate but do not move. Non-fatal: a storage
+/// error here must never fail the calling search.
+pub fn apply_resolutions(enriched: &mut Vec<EnrichedResult>, storage: &Arc<Storage>) {
+    if enriched.is_empty() {
+        return;
+    }
+    let chunk_ids: Vec<String> = enriched.iter().map(|e| e.chunk.id.clone()).collect();
+    let ledger = match storage.get_resolutions_batch(&chunk_ids) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    if ledger.is_empty() {
+        return;
+    }
+
+    for e in enriched.iter_mut() {
+        if let Some(entry) = ledger.get(&e.chunk.id) {
+            e.resolution = Some(format::resolution_note(
+                &entry.status,
+                &entry.evidence,
+                &entry.created_at,
+            ));
+        }
+    }
+
+    let mut unresolved = Vec::with_capacity(enriched.len());
+    let mut resolved = Vec::new();
+    for e in std::mem::take(enriched) {
+        let is_resolved = ledger
+            .get(&e.chunk.id)
+            .map(|entry| entry.status == "resolved")
+            .unwrap_or(false);
+        if is_resolved {
+            resolved.push(e);
+        } else {
+            unresolved.push(e);
+        }
+    }
+    unresolved.extend(resolved);
+    *enriched = unresolved;
 }
 
 #[cfg(test)]

--- a/csr-engine/src/storage/migrations.rs
+++ b/csr-engine/src/storage/migrations.rs
@@ -338,6 +338,21 @@ pub fn run(conn: &Connection) -> Result<()> {
          );",
     )?;
 
+    // Migration: resolution ledger (v9.4+) — append-only verdicts per chunk_id;
+    // latest row wins on read. No FK on chunk_id (may reference reflections too).
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS resolution_ledger (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chunk_id TEXT NOT NULL,
+            status TEXT NOT NULL CHECK(status IN ('resolved','still_open','regressed')),
+            evidence TEXT NOT NULL,
+            claim TEXT,
+            source TEXT NOT NULL DEFAULT 'agent',
+            created_at TEXT DEFAULT (datetime('now'))
+         );
+         CREATE INDEX IF NOT EXISTS idx_resolution_chunk ON resolution_ledger(chunk_id, id);",
+    )?;
+
     Ok(())
 }
 
@@ -368,6 +383,20 @@ mod tests {
             )
             .is_ok(),
             "ratification_scores table must exist after migration"
+        );
+    }
+
+    #[test]
+    fn resolution_ledger_migration_idempotent() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        run(&conn).expect("first migrations::run");
+        run(&conn).expect("second migrations::run (idempotent)");
+        assert!(
+            conn.prepare(
+                "SELECT chunk_id, status, evidence, claim, source, created_at FROM resolution_ledger LIMIT 0"
+            )
+            .is_ok(),
+            "resolution_ledger table must exist after migration"
         );
     }
 }

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -2,7 +2,9 @@ pub mod codegraph;
 pub mod migrations;
 pub mod queries;
 
-pub use queries::{NarrativeUsageRow, NarrativeUsageSummary, RatificationScoreRow};
+pub use queries::{
+    NarrativeUsageRow, NarrativeUsageSummary, RatificationScoreRow, ResolutionEntry,
+};
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -834,6 +836,30 @@ impl Storage {
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
         codegraph::get_node_rank(&conn, id)
     }
+
+    // ─── Resolution ledger ───
+
+    /// Append resolution verdicts for one or more chunk ids.
+    pub fn insert_resolutions(
+        &self,
+        chunk_ids: &[String],
+        status: &str,
+        evidence: &str,
+        claim: Option<&str>,
+        source: &str,
+    ) -> Result<usize> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::insert_resolutions(&conn, chunk_ids, status, evidence, claim, source)
+    }
+
+    /// Batch-fetch latest resolution entries keyed by chunk_id.
+    pub fn get_resolutions_batch(
+        &self,
+        chunk_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, queries::ResolutionEntry>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::get_resolutions_batch(&conn, chunk_ids)
+    }
 }
 
 #[cfg(test)]
@@ -1088,5 +1114,83 @@ mod tests {
         let storage = Storage::open_memory().unwrap();
         // In-memory DBs have no WAL — the pragma must not error.
         let _ = storage.checkpoint_wal();
+    }
+
+    #[test]
+    fn resolution_ledger_insert_and_batch_read() {
+        let storage = Storage::open_memory().unwrap();
+        let n = storage
+            .insert_resolutions(
+                &["c1".to_string(), "c2".to_string()],
+                "resolved",
+                "test evidence",
+                None,
+                "agent",
+            )
+            .unwrap();
+        assert_eq!(n, 2);
+
+        let map = storage
+            .get_resolutions_batch(&["c1".to_string(), "c2".to_string()])
+            .unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("c1").unwrap().status, "resolved");
+        assert_eq!(map.get("c2").unwrap().status, "resolved");
+        assert_eq!(map.get("c1").unwrap().evidence, "test evidence");
+    }
+
+    #[test]
+    fn resolution_ledger_latest_wins() {
+        let storage = Storage::open_memory().unwrap();
+        storage
+            .insert_resolutions(&["c1".to_string()], "resolved", "first", None, "agent")
+            .unwrap();
+        storage
+            .insert_resolutions(&["c1".to_string()], "regressed", "later", None, "agent")
+            .unwrap();
+        storage
+            .insert_resolutions(&["c2".to_string()], "resolved", "ok", None, "agent")
+            .unwrap();
+
+        let map = storage
+            .get_resolutions_batch(&["c1".to_string(), "c2".to_string()])
+            .unwrap();
+        assert_eq!(map.get("c1").unwrap().status, "regressed");
+        assert_eq!(map.get("c2").unwrap().status, "resolved");
+    }
+
+    #[test]
+    fn resolution_ledger_unknown_id_absent() {
+        let storage = Storage::open_memory().unwrap();
+        storage
+            .insert_resolutions(&["c1".to_string()], "resolved", "evidence", None, "agent")
+            .unwrap();
+
+        let map = storage
+            .get_resolutions_batch(&["c1".to_string(), "unknown-id".to_string()])
+            .unwrap();
+        assert_eq!(map.len(), 1);
+        assert!(map.contains_key("c1"));
+        assert!(!map.contains_key("unknown-id"));
+    }
+
+    #[test]
+    fn resolution_ledger_empty_batch() {
+        let storage = Storage::open_memory().unwrap();
+        let map = storage.get_resolutions_batch(&[]).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn resolution_ledger_invalid_status_errors() {
+        let storage = Storage::open_memory().unwrap();
+        let result = storage.insert_resolutions(
+            &["c1".to_string()],
+            "bogus_status",
+            "evidence",
+            None,
+            "agent",
+        );
+        assert!(result.is_err());
     }
 }

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -1969,6 +1969,91 @@ pub fn list_session_ids(conn: &Connection, prefix: &str, limit: usize) -> Result
         .map_err(|e| anyhow::anyhow!("{}", e))
 }
 
+// ─── Resolution ledger ───
+
+/// Latest explicit verdict for a chunk (or reflection) id.
+#[derive(Debug, Clone)]
+pub struct ResolutionEntry {
+    pub status: String,
+    pub evidence: String,
+    pub claim: Option<String>,
+    pub created_at: String,
+}
+
+/// Append resolution verdicts for one or more chunk ids in a single transaction.
+/// Returns the number of rows inserted.
+pub fn insert_resolutions(
+    conn: &Connection,
+    chunk_ids: &[String],
+    status: &str,
+    evidence: &str,
+    claim: Option<&str>,
+    source: &str,
+) -> Result<usize> {
+    if chunk_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let tx = conn.unchecked_transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO resolution_ledger (chunk_id, status, evidence, claim, source, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?;
+        for chunk_id in chunk_ids {
+            stmt.execute(params![chunk_id, status, evidence, claim, source, now])?;
+        }
+    }
+    tx.commit()?;
+    Ok(chunk_ids.len())
+}
+
+/// Batch-fetch the latest resolution entry per chunk_id (highest `id` wins).
+/// Chunk ids with no ledger rows are absent from the returned map.
+pub fn get_resolutions_batch(
+    conn: &Connection,
+    chunk_ids: &[String],
+) -> Result<HashMap<String, ResolutionEntry>> {
+    if chunk_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let placeholders: Vec<String> = (1..=chunk_ids.len()).map(|i| format!("?{}", i)).collect();
+    let sql = format!(
+        "SELECT chunk_id, status, evidence, claim, source, created_at
+         FROM resolution_ledger
+         WHERE id IN (
+             SELECT MAX(id) FROM resolution_ledger WHERE chunk_id IN ({}) GROUP BY chunk_id
+         )",
+        placeholders.join(", ")
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::types::ToSql> = chunk_ids
+        .iter()
+        .map(|id| id as &dyn rusqlite::types::ToSql)
+        .collect();
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            ResolutionEntry {
+                status: row.get(1)?,
+                evidence: row.get(2)?,
+                claim: row.get(3)?,
+                created_at: row.get(5)?,
+            },
+        ))
+    })?;
+
+    let mut map = HashMap::new();
+    for row in rows {
+        let (chunk_id, entry) = row?;
+        map.insert(chunk_id, entry);
+    }
+    Ok(map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/csr-engine/tests/integration.rs
+++ b/csr-engine/tests/integration.rs
@@ -386,6 +386,7 @@ fn test_format_search_results_structure() {
             seq: 0,
             is_sidechain: false,
         },
+        resolution: None,
     }];
 
     let xml = format::format_search_results(&results, "docker memory", "test-project", 5, 2);
@@ -418,6 +419,7 @@ fn test_format_recency_results_includes_age_stamp() {
             seq: 0,
             is_sidechain: false,
         },
+        resolution: None,
     }];
 
     let xml = format::format_recency_results(&results, "recency query", "last 7 days");
@@ -446,6 +448,7 @@ fn test_dedupe_results_collapses_same_conversation_duplicate() {
                 seq: 0,
                 is_sidechain: false,
             },
+            resolution: None,
         },
         EnrichedResult {
             score: 0.70,
@@ -461,6 +464,7 @@ fn test_dedupe_results_collapses_same_conversation_duplicate() {
                 seq: 1,
                 is_sidechain: false,
             },
+            resolution: None,
         },
     ];
 
@@ -497,6 +501,7 @@ fn test_format_quick_check_structure() {
             seq: 0,
             is_sidechain: false,
         },
+        resolution: None,
     }];
 
     let xml = format::format_quick_check(&results, "JWT auth");
@@ -532,6 +537,7 @@ fn test_xml_escaping_in_output() {
             seq: 0,
             is_sidechain: false,
         },
+        resolution: None,
     }];
 
     let xml = format::format_search_results(&results, "test <query>", "test & <project>", 0, 0);
@@ -541,6 +547,87 @@ fn test_xml_escaping_in_output() {
     // Query should be escaped
     assert!(xml.contains("test &lt;query&gt;"));
     // Content in CDATA is OK as-is (CDATA handles it)
+}
+
+#[test]
+fn test_resolve_and_annotate() {
+    let storage = std::sync::Arc::new(Storage::open_memory().unwrap());
+    storage
+        .insert_resolutions(
+            &["c-resolved".to_string()],
+            "resolved",
+            "shipped and verified",
+            None,
+            "agent",
+        )
+        .unwrap();
+
+    let mut enriched = vec![
+        EnrichedResult {
+            score: 0.9,
+            chunk: ConversationChunk {
+                id: "c-unresolved".into(),
+                conversation_id: "conv-1".into(),
+                project_name: "test".into(),
+                timestamp: "2026-01-15T10:00:00Z".into(),
+                content: "unresolved claim".into(),
+                message_count: 1,
+                summary: None,
+                author: csr_engine::provenance::Speaker::ToolResult,
+                seq: 0,
+                is_sidechain: false,
+            },
+            resolution: None,
+        },
+        EnrichedResult {
+            score: 0.8,
+            chunk: ConversationChunk {
+                id: "c-resolved".into(),
+                conversation_id: "conv-1".into(),
+                project_name: "test".into(),
+                timestamp: "2026-01-15T10:00:00Z".into(),
+                content: "resolved claim".into(),
+                message_count: 1,
+                summary: None,
+                author: csr_engine::provenance::Speaker::ToolResult,
+                seq: 1,
+                is_sidechain: false,
+            },
+            resolution: None,
+        },
+    ];
+
+    csr_engine::mcp::tools::apply_resolutions(&mut enriched, &storage);
+
+    assert_eq!(enriched.len(), 2);
+    assert_eq!(
+        enriched[0].chunk.id, "c-unresolved",
+        "unresolved entry stays first"
+    );
+    assert_eq!(
+        enriched[1].chunk.id, "c-resolved",
+        "resolved entry sinks to the bottom"
+    );
+    assert!(enriched[0].resolution.is_none());
+    assert!(enriched[1]
+        .resolution
+        .as_deref()
+        .unwrap()
+        .starts_with("resolved"));
+}
+
+#[test]
+fn test_resolve_chunks_invalid_status_errors() {
+    let storage = std::sync::Arc::new(Storage::open_memory().unwrap());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(csr_engine::mcp::tools::resolve_chunks(
+        &storage,
+        vec!["c1".to_string()],
+        "bogus".to_string(),
+        "some evidence".to_string(),
+        None,
+    ));
+    assert!(result.is_err());
 }
 
 // ─── Test 12: Temporal parsing ───
@@ -750,6 +837,7 @@ fn test_full_pipeline_storage_search_format() {
                 .map(|c| EnrichedResult {
                     score: r.score,
                     chunk: c.clone(),
+                    resolution: None,
                 })
         })
         .collect();

--- a/docs-site/src/content/mcp-tools.md
+++ b/docs-site/src/content/mcp-tools.md
@@ -2,7 +2,7 @@
 title: MCP Tools Reference
 ---
 
-13 tools available to Claude automatically via MCP.
+15 tools available to Claude automatically via MCP.
 
 ## Search Tools
 
@@ -52,6 +52,22 @@ Retrieve complete JSONL conversation by ID.
 Iteration-level memory for Ralph loops.
 
 ## Storage Tools
+
+### csr_why
+
+Provenance chain — why does this code or decision exist. Reinstatement recall: seed search, blended second hop through the code graph and episode chains.
+
+```
+csr_why("why does the rerank scaffold demotion exist")
+```
+
+### csr_resolve
+
+Record a verified verdict about chunks surfaced in search results: `resolved`, `still_open`, or `regressed`. Append-only ledger — future searches annotate these chunks and demote resolved ones within the page; a `regressed` verdict re-opens them. Use after verifying a recalled item against the repo or real world. Pass chunk ids from the `<id>` tags in search results.
+
+```
+csr_resolve(chunk_ids=["..."], status="resolved", evidence="shipped vc75, verified in app.json")
+```
 
 ### store_reflection
 Store insights for future retrieval. Embedded and indexed immediately.


### PR DESCRIPTION
## Why

Stacked on #250. Dogfooding showed the deeper harm behind stale recall: an agent *verified* that 4/5 recalled "queued" items had already shipped — then that verdict evaporated as prose. #250 made recall honest about age; this PR gives verified verdicts a durable home.

**Asserted state only.** Automated closure inference from prose was rejected on evidence (pre-registered negative ratification result, rho ~0.04-0.07 across 3 extractors). The ledger records only explicit verdicts written by the verifying agent at check time. Design cross-checked by grok-advisor (AGREE 9/10; demotion-truncation concern resolved by demoting post-limit).

## What

- **`resolution_ledger` table** — append-only; latest row per chunk_id wins; statuses `resolved | still_open | regressed`. No FK (chunk_ids may reference reflections); no project column (UUIDv5 chunk ids are globally unique, cross-project surfacing safe).
- **`csr_resolve` MCP tool (15th)** — `(chunk_ids, status, evidence, claim?)`. Verdict applies to the whole chunk; multi-claim chunks stay `still_open` until all claims addressed.
- **Search-time** — one batch ledger lookup in `reflect_on_past` + `enrich_results`. All verdicts annotate (`<resolution>` tag); only `resolved` demotes — stable partition **within the returned page** (post-limit: nothing ever drops out), plus a footer count. `regressed` re-opens: full rank restored, annotation kept. Never hidden, never deleted.
- **`<id>` tag added to search results** — implementer-lane catch: `csr_resolve` keys on `chunk.id`, which was never rendered anywhere; verdicts recorded from `<cid>` (conversation id) would have silently no-op'd.
- **Docs** — CLAUDE.md + docs-site tool lists to 15, including the previously missing `csr_why` entry.

## DoD evidence

- `cargo test`: 586 lib + 45 hooks + 61 integration, 0 failures (+13 new); fmt + clippy clean
- Live-DB stdio replay (exact dogfooding query): baseline → `csr_resolve` two genuinely-shipped items → re-query shows both annotated `resolved — shipped vc75/1.5.8...` and sunk within page with footer note, nothing dropped → `regressed` verdict restores full rank with regressed annotation → re-resolved (truthful final state). All 8 checks pass.

https://claude.ai/code/session_01FrNuZJMHK1Y4jpSx88C5aL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `csr_resolve` tool for recording chunk verdicts as resolved, still open, or regressed.
  - Search results now include resolution annotations and place resolved items lower in result lists.
  - Added validation for resolution statuses, evidence, and chunk selections.

- **Documentation**
  - Updated MCP documentation to reflect 15 available tools.
  - Added usage guidance and examples for resolution and provenance tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->