### PR TITLE
fix(installer): make install and activation separate consent steps (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ postinstall — silently writing 6 hooks into the live `~/.claude/settings.json`
 registering the MCP server in `~/.claude.json`, and importing conversation
 transcripts, even for sandboxed `--prefix` evaluations. Reported in #247.
 
-- **npm postinstall is now download-only**: it fetches the binary, verifies
-  the SHA256 checksum, installs it to `~/.local/bin`, and stops. Activation
-  happens only when the user explicitly runs `csr-engine setup`. Opt back in
-  to the old one-shot behavior with `CSR_AUTO_SETUP=1`.
+- **npm postinstall is now download-only by default**: it fetches the binary,
+  verifies the SHA256 checksum, installs it to `~/.local/bin`, and stops.
+  Activation happens when the user explicitly runs `csr-engine setup`, or opt
+  back in to the old one-shot behavior with `CSR_AUTO_SETUP=1` (a failed
+  opt-in setup now exits nonzero so automation can detect it).
 - **`install.sh` now asks before running setup**: interactive installs get a
   clear prompt describing exactly what setup touches (hooks, MCP registration,
   conversation import) with a `[Y/n]` confirmation read from `/dev/tty`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Claude Self-Reflect will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.3.1] - 2026-07-24
+
+### 🔒 SECURITY/CONSENT: Install and activation are now separate steps (#247)
+
+`npm install claude-self-reflect` used to auto-run `csr-engine setup` from
+postinstall — silently writing 6 hooks into the live `~/.claude/settings.json`,
+registering the MCP server in `~/.claude.json`, and importing conversation
+transcripts, even for sandboxed `--prefix` evaluations. Reported in #247.
+
+- **npm postinstall is now download-only**: it fetches the binary, verifies
+  the SHA256 checksum, installs it to `~/.local/bin`, and stops. Activation
+  happens only when the user explicitly runs `csr-engine setup`. Opt back in
+  to the old one-shot behavior with `CSR_AUTO_SETUP=1`.
+- **`install.sh` now asks before running setup**: interactive installs get a
+  clear prompt describing exactly what setup touches (hooks, MCP registration,
+  conversation import) with a `[Y/n]` confirmation read from `/dev/tty`.
+  Non-interactive installs (CI, no TTY) never auto-activate. New env controls:
+  `CSR_AUTO_SETUP=1` (run setup without prompting) and `CSR_SKIP_SETUP=1`
+  (download only).
+- **Docs updated** (README, installation guide, landing page) to describe the
+  two-step install → activate flow.
+
 ## [9.3.0] - 2026-07-11
 
 ### 🚀 FEATURE: Narrative Cost Controls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,9 @@ curl -fsSL .../scripts/install.sh | sh  # Install v8
 
 The Rust binary re-imports from the same `~/.claude/projects/` JSONL files.
 `csr-engine hook install --apply` auto-replaces Python hooks with Rust hooks.
+Install and activation are separate consent steps (v9.3.1+): the installer
+prompts before running `csr-engine setup`; npm postinstall is download-only.
+Env controls: `CSR_AUTO_SETUP=1`, `CSR_SKIP_SETUP=1` (install.sh only).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Higher quality context. Better decisions. Fewer tokens.
 curl -fsSL https://raw.githubusercontent.com/ramakay/claude-self-reflect/main/scripts/install.sh | sh
 ```
 
-One command. Downloads the binary, runs setup, registers MCP server, installs 6 hooks. Restart Claude Code.
+Downloads the binary (SHA256-verified), then asks before activating. Setup — which registers the MCP server, installs 6 hooks, and imports your conversations — only runs with your consent. Restart Claude Code after.
+
+Non-interactive installs never activate on their own: set `CSR_AUTO_SETUP=1` to opt in, or run `csr-engine setup` yourself.
 
 | Platform | Support |
 |----------|---------|
@@ -118,7 +120,10 @@ One command. Downloads the binary, runs setup, registers MCP server, installs 6 
 
 ```bash
 npm install -g claude-self-reflect
+csr-engine setup   # activation is a separate, explicit step
 ```
+
+`npm install` only downloads the checksummed binary — it never touches `~/.claude` or indexes conversations. Activation happens when you run `csr-engine setup`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ npm install -g claude-self-reflect
 csr-engine setup   # activation is a separate, explicit step
 ```
 
-`npm install` only downloads the checksummed binary — it never touches `~/.claude` or indexes conversations. Activation happens when you run `csr-engine setup`.
+By default `npm install` only downloads the checksummed binary — it does not touch `~/.claude` or index conversations. Activation happens when you run `csr-engine setup`, or set `CSR_AUTO_SETUP=1` during install to opt in.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Single 44MB binary. No databases. No containers. No API keys required.
 - [The Problem](#the-forgetting-problem) — Why Claude needs memory
 - [The Architecture](#one-binary-44mb) — How CSR solves it
 - [The Pipeline](#the-pipeline) — Progressive enrichment (9.3x improvement)
-- [Install](#install) — One command setup
+- [Install](#install) — One-command install, consent-first activation
 - [What You'll Ask](#what-youll-ask) — Natural language, no syntax
 - [Performance](#performance) | [MCP Tools](#mcp-tools) | [Hooks](#hooks) | [CLI](#cli-reference)
 - [AI Narratives](#ai-narratives-optional) | [Upgrading](#upgrading-from-v7x) | [Troubleshooting](#troubleshooting)

--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csr-engine"
-version = "9.3.0"
+version = "9.3.1"
 dependencies = [
  "anyhow",
  "ast-grep-core",

--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csr-engine"
-version = "9.3.0"
+version = "9.3.1"
 edition = "2021"
 description = "Claude Self-Reflect: Rust MCP server with embedded vector search"
 

--- a/docs-site/src/content/installation.md
+++ b/docs-site/src/content/installation.md
@@ -32,7 +32,7 @@ npm install -g claude-self-reflect
 csr-engine setup
 ```
 
-`npm install` only downloads the checksummed binary. It never modifies `~/.claude/settings.json`, registers MCP servers, or indexes conversations — activation is the separate, explicit `csr-engine setup` step (or set `CSR_AUTO_SETUP=1` during install to opt in).
+By default `npm install` only downloads the checksummed binary — it does not modify `~/.claude/settings.json`, register MCP servers, or index conversations. Activation is the separate, explicit `csr-engine setup` step, or set `CSR_AUTO_SETUP=1` during install to opt in.
 
 ## Verify
 

--- a/docs-site/src/content/installation.md
+++ b/docs-site/src/content/installation.md
@@ -16,7 +16,23 @@ No Docker. No Python. No API keys.
 curl -fsSL https://raw.githubusercontent.com/ramakay/claude-self-reflect/main/scripts/install.sh | sh
 ```
 
-Downloads the binary and auto-runs setup: imports conversations, registers MCP server, installs all 6 hooks.
+Downloads the binary (SHA256-verified) and then **asks before activating**. Setup — which imports conversations, registers the MCP server, and installs all 6 hooks — only runs after you confirm at the prompt.
+
+Non-interactive installs (CI, scripts) never activate automatically. Control the behavior with:
+
+| Variable | Effect |
+|----------|--------|
+| `CSR_AUTO_SETUP=1` | Run setup without prompting |
+| `CSR_SKIP_SETUP=1` | Download only, never run setup |
+
+### npm
+
+```bash
+npm install -g claude-self-reflect
+csr-engine setup
+```
+
+`npm install` only downloads the checksummed binary. It never modifies `~/.claude/settings.json`, registers MCP servers, or indexes conversations — activation is the separate, explicit `csr-engine setup` step (or set `CSR_AUTO_SETUP=1` during install to opt in).
 
 ## Verify
 

--- a/docs-site/src/content/privacy.md
+++ b/docs-site/src/content/privacy.md
@@ -14,6 +14,10 @@ title: Privacy & Security
 
 **Zero network connections** by default. No telemetry.
 
+## Consent-Gated Activation
+
+Installing CSR does not activate it. Nothing is written to `~/.claude/settings.json`, no MCP server is registered, and no conversations are indexed until you explicitly run `csr-engine setup` (or approve the installer's prompt). npm postinstall is download-only, so sandboxed evaluation (`npm install --prefix`) leaves your live Claude Code configuration untouched. See [Installation](#/docs/installation) for the `CSR_AUTO_SETUP` / `CSR_SKIP_SETUP` controls.
+
 ## Optional Cloud: AI Narratives
 
 Only Layer 3 uses cloud API. Requires explicit opt-in:

--- a/docs-site/src/content/quickstart.md
+++ b/docs-site/src/content/quickstart.md
@@ -2,6 +2,8 @@
 title: Quick Start
 ---
 
+> Everything below assumes CSR is activated — you've run `csr-engine setup` and restarted Claude Code. Installing alone doesn't activate anything; see [Installation](#/docs/installation).
+
 ## Your First Search
 
 Open Claude Code and ask:

--- a/docs-site/src/content/upgrading.md
+++ b/docs-site/src/content/upgrading.md
@@ -21,8 +21,11 @@ v8.0 replaced the Python/Docker/Qdrant stack with a single Rust binary.
 docker compose down 2>/dev/null
 claude mcp remove claude-self-reflect 2>/dev/null
 
-# Install v8
+# Install v8 — the installer asks before running setup
 curl -fsSL https://raw.githubusercontent.com/ramakay/claude-self-reflect/main/scripts/install.sh | sh
+
+# If you declined (or installed non-interactively), activate explicitly:
+csr-engine setup
 
 # Restart Claude Code
 ```

--- a/docs-site/src/content/why-csr.md
+++ b/docs-site/src/content/why-csr.md
@@ -16,7 +16,7 @@ CSR is a single 44MB binary. SQLite, HNSW search, FastEmbed embeddings, MCP serv
 
 | | CSR | Typical Memory Tool |
 |--|-----|---------------------|
-| **Install** | `curl \| sh` (one command) | npm + Docker + Python + DB |
+| **Install** | `curl \| sh` (one command, asks before activating) | npm + Docker + Python + DB |
 | **Dependencies** | None | Docker, Python, vector DB, Node.js |
 | **Processes** | 1 (on-demand) | 3-5 background services |
 | **Startup** | ~150ms (cached) | Seconds to minutes |
@@ -48,3 +48,7 @@ Indexes ALL your Claude Code projects automatically. Solutions from one project 
 ### Privacy First
 
 Everything runs on your machine by default. No cloud APIs, no accounts, no telemetry. The only optional cloud feature is AI Narratives (Layer 3).
+
+### Consent First
+
+Install and activation are separate steps. Installing (via `curl | sh` or npm) only downloads the SHA256-verified binary — nothing touches `~/.claude/settings.json`, no MCP server is registered, and no conversations are indexed until you explicitly approve `csr-engine setup` (interactive installs prompt; non-interactive installs never activate on their own). See [Installation](#/docs/installation) for the `CSR_AUTO_SETUP` / `CSR_SKIP_SETUP` controls.

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -525,7 +525,7 @@ function InstallCard() {
             <code>curl -fsSL .../scripts/install.sh | sh</code>
             <CopyBtn text={command} />
           </div>
-          <p className="type-caption mt-2">One command. Downloads binary, auto-runs setup, registers hooks + MCP. Restart Claude Code.</p>
+          <p className="type-caption mt-2">One command. Downloads binary, then asks before activating hooks + MCP. Restart Claude Code.</p>
           <div className="install-tabs-inline">
             {['44MB binary', 'zero deps', '6 hooks', '12 MCP tools'].map((label, index) => (
               <span key={label} className="tear-tab" style={{ animationDelay: `${720 + index * 70}ms` }}>{label}</span>

--- a/installer/postinstall.js
+++ b/installer/postinstall.js
@@ -3,9 +3,10 @@
 /**
  * Post-install hook for npm.
  * Downloads the csr-engine binary from GitHub Releases and verifies its
- * checksum. Nothing else: activation (hook registration, MCP registration,
- * conversation import) only happens when the user explicitly runs
- * `csr-engine setup` — postinstall must never touch ~/.claude or index data.
+ * checksum. By default nothing else: activation (hook registration, MCP
+ * registration, conversation import) happens when the user explicitly runs
+ * `csr-engine setup` — postinstall does not touch ~/.claude or index data
+ * unless the user opts in with CSR_AUTO_SETUP=1.
  * Detects existing Python CSR installations and guides upgrade.
  *
  * Environment variables:
@@ -190,6 +191,30 @@ function findExpectedChecksum(checksumData, filename) {
   throw new Error(`No checksum entry found for ${filename}`);
 }
 
+// --- Activation ---
+
+// Activation is a separate consent event: setup writes hooks into
+// ~/.claude/settings.json, registers the MCP server, and imports
+// conversation transcripts. Never do that from a package manager
+// lifecycle script unless the user explicitly opted in.
+function runOrExplainActivation(binaryPath) {
+  if (process.env.CSR_AUTO_SETUP === '1') {
+    console.log('  CSR_AUTO_SETUP=1 — running setup...');
+    try {
+      execFileSync(binaryPath, ['setup'], { stdio: 'inherit', timeout: 60000 });
+      console.log('\n  \x1b[32mDone. Restart Claude Code to activate.\x1b[0m\n');
+    } catch {
+      console.log('\n  Setup failed. Run manually: csr-engine setup\n');
+      process.exitCode = 1;
+    }
+  } else {
+    console.log('\n  \x1b[1mTo activate\x1b[0m (registers the MCP server, installs hooks,');
+    console.log('  and imports your conversations), run:');
+    console.log('\n    \x1b[1;32mcsr-engine setup\x1b[0m\n');
+    console.log('  Then restart Claude Code.\n');
+  }
+}
+
 // --- Existing installation detection ---
 
 function findExistingBinary() {
@@ -255,7 +280,8 @@ async function main() {
         stdio: ['ignore', 'pipe', 'ignore'],
       }).trim();
       if (version === pkgVersion || version === tag || version.includes(` ${pkgVersion}`)) {
-        console.log(`\n  \x1b[1;32mcsr-engine ${pkgVersion} already installed.\x1b[0m\n`);
+        console.log(`\n  \x1b[1;32mcsr-engine ${pkgVersion} already installed.\x1b[0m`);
+        runOrExplainActivation(existingBinary);
         return;
       }
       console.log(`  Updating ${existingBinary} to ${tag}...`);
@@ -305,24 +331,7 @@ async function main() {
 
     console.log(`  \x1b[1;32mInstalled:\x1b[0m ${destPath}`);
 
-    // Activation is a separate consent event: setup writes hooks into
-    // ~/.claude/settings.json, registers the MCP server, and imports
-    // conversation transcripts. Never do that from a package manager
-    // lifecycle script unless the user explicitly opted in.
-    if (process.env.CSR_AUTO_SETUP === '1') {
-      console.log('  CSR_AUTO_SETUP=1 — running setup...');
-      try {
-        execFileSync(destPath, ['setup'], { stdio: 'inherit', timeout: 60000 });
-        console.log('\n  \x1b[32mDone. Restart Claude Code to activate.\x1b[0m\n');
-      } catch {
-        console.log('\n  Setup encountered errors. Run manually: csr-engine setup\n');
-      }
-    } else {
-      console.log('\n  \x1b[1mNot yet active.\x1b[0m To register the MCP server, install hooks,');
-      console.log('  and import your conversations, run:');
-      console.log('\n    \x1b[1;32mcsr-engine setup\x1b[0m\n');
-      console.log('  Then restart Claude Code.\n');
-    }
+    runOrExplainActivation(destPath);
 
     if (pythonSignals.length > 0) {
       console.log('  Old Python stack can be cleaned up:');

--- a/installer/postinstall.js
+++ b/installer/postinstall.js
@@ -2,11 +2,15 @@
 
 /**
  * Post-install hook for npm.
- * Downloads the csr-engine binary from GitHub Releases.
+ * Downloads the csr-engine binary from GitHub Releases and verifies its
+ * checksum. Nothing else: activation (hook registration, MCP registration,
+ * conversation import) only happens when the user explicitly runs
+ * `csr-engine setup` — postinstall must never touch ~/.claude or index data.
  * Detects existing Python CSR installations and guides upgrade.
  *
  * Environment variables:
  *   CSR_SKIP_BINARY_DOWNLOAD=1  — Skip binary download (CI, offline, custom builds)
+ *   CSR_AUTO_SETUP=1            — Opt in to running `csr-engine setup` after download
  */
 
 import {
@@ -301,13 +305,23 @@ async function main() {
 
     console.log(`  \x1b[1;32mInstalled:\x1b[0m ${destPath}`);
 
-    // Auto-run setup
-    console.log('  Running setup...');
-    try {
-      execFileSync(destPath, ['setup'], { stdio: 'inherit', timeout: 60000 });
-      console.log('\n  \x1b[32mDone. Restart Claude Code to activate.\x1b[0m\n');
-    } catch {
-      console.log('\n  Setup encountered errors. Run manually: csr-engine setup\n');
+    // Activation is a separate consent event: setup writes hooks into
+    // ~/.claude/settings.json, registers the MCP server, and imports
+    // conversation transcripts. Never do that from a package manager
+    // lifecycle script unless the user explicitly opted in.
+    if (process.env.CSR_AUTO_SETUP === '1') {
+      console.log('  CSR_AUTO_SETUP=1 — running setup...');
+      try {
+        execFileSync(destPath, ['setup'], { stdio: 'inherit', timeout: 60000 });
+        console.log('\n  \x1b[32mDone. Restart Claude Code to activate.\x1b[0m\n');
+      } catch {
+        console.log('\n  Setup encountered errors. Run manually: csr-engine setup\n');
+      }
+    } else {
+      console.log('\n  \x1b[1mNot yet active.\x1b[0m To register the MCP server, install hooks,');
+      console.log('  and import your conversations, run:');
+      console.log('\n    \x1b[1;32mcsr-engine setup\x1b[0m\n');
+      console.log('  Then restart Claude Code.\n');
     }
 
     if (pythonSignals.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Give Claude perfect memory of all your conversations. Single binary, zero dependencies.",
   "keywords": [
     "claude",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,11 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/ramakay/claude-self-reflect/main/scripts/install.sh | sh
+#
+# Environment variables:
+#   CSR_INSTALL_DIR    — Binary install directory (default: ~/.local/bin)
+#   CSR_SKIP_SETUP=1   — Download only; never run `csr-engine setup`
+#   CSR_AUTO_SETUP=1   — Run setup without prompting (automation)
 
 set -e
 
@@ -180,8 +185,29 @@ Build from source instead:
     verify
     check_path
 
-    # Auto-run setup if binary is on PATH
-    if command -v "$BINARY_NAME" >/dev/null 2>&1 || [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+    # Setup writes hooks into ~/.claude/settings.json, registers the MCP
+    # server, and imports conversation transcripts — that needs explicit
+    # consent. Prompt when a terminal is available; otherwise (CI, piped
+    # non-interactive shells) leave activation to the user.
+    RUN_SETUP=no
+    if [ "${CSR_SKIP_SETUP:-}" = "1" ]; then
+        RUN_SETUP=no
+    elif [ "${CSR_AUTO_SETUP:-}" = "1" ]; then
+        RUN_SETUP=yes
+    elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        printf '\n  Setup registers the MCP server, installs 6 Claude Code hooks\n' > /dev/tty
+        printf '  into ~/.claude/settings.json, and imports your conversations\n' > /dev/tty
+        printf '  from ~/.claude/projects/ into a local index.\n\n' > /dev/tty
+        printf '  \033[1mRun setup now? [Y/n]\033[0m ' > /dev/tty
+        answer=""
+        read -r answer < /dev/tty || answer=""
+        case "$answer" in
+            [Nn]*) RUN_SETUP=no ;;
+            *)     RUN_SETUP=yes ;;
+        esac
+    fi
+
+    if [ "$RUN_SETUP" = "yes" ]; then
         printf '\n  \033[1mRunning setup...\033[0m\n\n'
         if "${INSTALL_DIR}/${BINARY_NAME}" setup 2>&1; then
             printf '\n  \033[32m✓\033[0m  Done. Restart Claude Code to activate.\n\n'
@@ -191,9 +217,9 @@ Build from source instead:
             printf '    # Then restart Claude Code\n\n'
         fi
     else
-        printf '\n  \033[1mNext steps:\033[0m\n'
+        printf '\n  \033[1mNot yet active.\033[0m To register MCP, install hooks, and import conversations:\n'
         printf '    %s setup\n' "$BINARY_NAME"
-        printf '    # Restart Claude Code\n\n'
+        printf '    # Then restart Claude Code\n\n'
     fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -200,11 +200,16 @@ Build from source instead:
         printf '  from ~/.claude/projects/ into a local index.\n\n' > /dev/tty
         printf '  \033[1mRun setup now? [Y/n]\033[0m ' > /dev/tty
         answer=""
-        read -r answer < /dev/tty || answer=""
-        case "$answer" in
-            [Nn]*) RUN_SETUP=no ;;
-            *)     RUN_SETUP=yes ;;
-        esac
+        # A failed read is not consent — only a successful (possibly empty)
+        # response may select the yes-default.
+        if read -r answer < /dev/tty; then
+            case "$answer" in
+                [Nn]*) RUN_SETUP=no ;;
+                *)     RUN_SETUP=yes ;;
+            esac
+        else
+            RUN_SETUP=no
+        fi
     fi
 
     if [ "$RUN_SETUP" = "yes" ]; then
@@ -215,6 +220,7 @@ Build from source instead:
             printf '\n  \033[33m⚠\033[0m  Setup encountered errors. Try manually:\n'
             printf '    %s setup\n' "$BINARY_NAME"
             printf '    # Then restart Claude Code\n\n'
+            exit 1
         fi
     else
         printf '\n  \033[1mNot yet active.\033[0m To register MCP, install hooks, and import conversations:\n'


### PR DESCRIPTION
Fixes #247.

## Problem

`npm install claude-self-reflect` auto-ran `csr-engine setup` from postinstall — silently writing 6 hooks into the live `~/.claude/settings.json`, registering the MCP server in `~/.claude.json`, and importing conversation transcripts, even for sandboxed `--prefix` evaluations. Install and activation were a single, non-consensual event.

## Changes

**`installer/postinstall.js` — download-only**
- Postinstall now stops after downloading the binary, verifying its SHA256 checksum, and installing it to `~/.local/bin`.
- It prints a clear "to activate, run `csr-engine setup`" message instead of running setup.
- `CSR_AUTO_SETUP=1` opts back into the old one-shot behavior (for automation/dotfiles); a failed opt-in setup exits nonzero.

**`scripts/install.sh` — explicit consent prompt**
- Interactive installs now get a prompt describing exactly what setup touches (hooks in `~/.claude/settings.json`, MCP registration, conversation import) with a `[Y/n]` confirmation read from `/dev/tty` — so `curl | sh` still prompts correctly. A failed consent read fails closed.
- Non-interactive installs (CI, no TTY) never auto-activate; they print next steps instead.
- New env controls: `CSR_AUTO_SETUP=1` (run setup without prompting), `CSR_SKIP_SETUP=1` (download only).

**Docs + release**
- README, docs-site (installation, privacy, why-csr, quickstart, upgrading, landing) updated to the two-step install → activate flow.
- CHANGELOG entry for 9.3.1; version bumped in `package.json`, `Cargo.toml`, `Cargo.lock`.