### PR TITLE
ci(release): allow manual release via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v9.3.1). Created at the dispatched ref by the release step if it doesn't exist."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -80,6 +86,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
             *.tar.gz
             checksums.txt


### PR DESCRIPTION
Follow-up to #252: the release workflow only triggered on tag pushes. This adds a `workflow_dispatch` trigger with a required `tag` input so a release can also be launched from the Actions UI.

- On dispatch, `action-gh-release` receives `tag_name: inputs.tag` and creates the tag at the dispatched ref when publishing the release.
- Tag-push behavior is unchanged: `inputs.tag` is empty on tag events, falling back to `github.ref_name`.