### PR TITLE
ci(release): support starting a release from a release/v* branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     tags: ['v*']
+    # A branch named release/vX.Y.Z releases tag vX.Y.Z; the tag is
+    # created by the release step when it publishes.
+    branches: ['release/v*']
   workflow_dispatch:
     inputs:
       tag:
@@ -86,7 +89,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ inputs.tag || (startsWith(github.ref, 'refs/heads/release/') && replace(github.ref_name, 'release/', '')) || github.ref_name }}
           files: |
             *.tar.gz
             checksums.txt


### PR DESCRIPTION
Adds a second way to start a release: pushing a branch named `release/vX.Y.Z` runs the workflow and releases tag `vX.Y.Z` — the release step derives the tag from the branch name and creates it when publishing. Existing tag-push and `workflow_dispatch` triggers are unchanged.

The `release/*` branch can be deleted after the run.