### PR TITLE
ci(release): fix invalid workflow expression in tag resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,16 @@ jobs:
       - name: Combine checksums
         run: cat checksums-*.txt > checksums.txt
 
+      - name: Resolve release tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: echo "tag=${INPUT_TAG:-${GITHUB_REF_NAME#release/}}" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.tag || (startsWith(github.ref, 'refs/heads/release/') && replace(github.ref_name, 'release/', '')) || github.ref_name }}
+          tag_name: ${{ steps.tag.outputs.tag }}
           files: |
             *.tar.gz
             checksums.txt


### PR DESCRIPTION
Fixes the release workflow file introduced in #254: `replace()` is not a supported function in workflow expressions, so the file failed validation and every triggered run errored immediately (including on pushes to `main`).

The tag is now resolved in a shell step — the `workflow_dispatch` input when set, otherwise the ref name with any `release/` prefix stripped — and passed to `action-gh-release` as `tag_name`. Covers all three triggers:

- tag push `v9.3.1` → `v9.3.1`
- branch push `release/v9.3.1` → `v9.3.1`
- dispatch with `tag=v9.3.1` → `v9.3.1`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hai1VP8L8mcpgJY42coZx1)_