### PR TITLE
docs: re-litigation benchmark results + post-#251 review nits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ cargo bench --bench spike_bench
 ### Key Patterns
 
 - **rmcp tool params**: Use `Parameters<MyStruct>` pattern, NOT individual `#[tool(param)]`
-- **rmcp tool annotations**: All 15 tools have `annotations(read_only_hint, destructive_hint, idempotent_hint)` in macro
+- **rmcp tool annotations**: All 15 tools declare `annotations(...)` in the macro — hints vary per tool (most use `read_only_hint, destructive_hint, idempotent_hint`; `get_full_conversation` uses `open_world_hint` instead of `idempotent_hint`)
 - **rmcp 1.6 builders**: `ServerInfo::new(caps).with_instructions()`, `Implementation::new()`, `ReadResourceResult::new()`
 - **fastembed**: Requires `aarch64` Rust — no x86_64-apple-darwin ONNX binaries
 - **rusqlite 0.38**: No `ToSql` for `usize` — cast to `i64`

--- a/docs-site/src/content/mcp-tools.md
+++ b/docs-site/src/content/mcp-tools.md
@@ -57,7 +57,7 @@ Iteration-level memory for Ralph loops.
 
 Provenance chain — why does this code or decision exist. Reinstatement recall: seed search, blended second hop through the code graph and episode chains.
 
-```
+```python
 csr_why("why does the rerank scaffold demotion exist")
 ```
 
@@ -65,7 +65,7 @@ csr_why("why does the rerank scaffold demotion exist")
 
 Record a verified verdict about chunks surfaced in search results: `resolved`, `still_open`, or `regressed`. Append-only ledger — future searches annotate these chunks and demote resolved ones within the page; a `regressed` verdict re-opens them. Use after verifying a recalled item against the repo or real world. Pass chunk ids from the `<id>` tags in search results.
 
-```
+```python
 csr_resolve(chunk_ids=["..."], status="resolved", evidence="shipped vc75, verified in app.json")
 ```
 

--- a/docs/plans/saga-relitigation-results.md
+++ b/docs/plans/saga-relitigation-results.md
@@ -1,0 +1,96 @@
+# Re-litigation Benchmark — Results (run 2026-07-20, graded 2026-07-22..24)
+
+Behavioral test of Naur-style theory restoration: does conversation memory stop an
+agent from re-litigating settled decisions — and does reinstatement recall earn
+separation from plain similarity search while doing it? Designed under binding
+cross-vendor advisor conditions (Grok 4.5): similarity-only kNN control arm
+required, ≥7 headline tasks from post-tuning decisions, blinded human rubric
+grading, four-way task-class mix, arms identical except retrieval path.
+
+## Design
+
+- **16 sealed tasks** (12 headline + 4 calibration), sha256-sealed before any arm
+  ran (`eval-kit/relitigation/tasks.sealed.json`, seal `749fc0f8…`). Four classes,
+  pre-registered correct action per task: settled-for-cause (decline+cite, 4),
+  should-change (accept, 4), irrelevant-past (ignore past, 2), ambiguous
+  (check/ask, 2) + 4 calibration.
+- **Three arms**, identical prompt/harness/model (`claude -p`, Sonnet), differing
+  only in retrieved context: **R** = production reinstatement recall; **K** =
+  similarity-only kNN (E1-style, chunks + reflections, max-score merge); **N** =
+  no memory. Context rendered by one shared function — no scores, no arm-revealing
+  wording; deterministic ordering; hooks and tools disabled in test dialogues.
+- **Leak defense**: arms ran against a frozen DB snapshot scrubbed of the design
+  session and its subagent conversations + derived reflections; retrieval outputs
+  verified to contain zero scrubbed ids.
+- **Grading**: operator graded all 36 headline responses (12 tasks × 3 arms)
+  blinded — arm identity hidden behind shuffled X/Y/Z codes, key sealed until all
+  grades were in. Rubric 0–3 reason-faithful action: 3 = correct action + true
+  reason; 2 = correct action, partial reason; 1 = wrong action but serious
+  engagement (or correct action, wrong reason); 0 = careless.
+
+## Results
+
+### Action level (all 16 tasks, pre-registered correct actions)
+
+Memory arms 12/16 correct actions each; no-memory 8/16. Reinstatement and kNN
+produced **identical verdicts on all 16 tasks**.
+
+Sharpest single datapoint: on the calibration task replaying the integrity-check
+performance fix, the no-memory arm ACCEPTS re-breaking a shipped 11.4s→11ms fix;
+both memory arms decline citing the original incident.
+
+### Reason quality (12 headline tasks, blinded human rubric, max 36)
+
+| Class | Reinstatement | kNN | No-memory |
+|---|---|---|---|
+| settled-for-cause (4) | **10/12** | **9/12** | 6/12 |
+| should-change (4) | 6/12 | 6/12 | 6/12 |
+| irrelevant-past (2) | 6/6 | 6/6 | 6/6 |
+| ambiguous (2) | 5/6 | 6/6 | 6/6 |
+| **Total** | **27/36** | **27/36** | **24/36** |
+
+## Findings
+
+1. **Memory prevents re-litigation exactly where theory predicts.** On
+   settled-for-cause tasks both memory arms nearly double the no-memory arm's
+   reason quality (10 and 9 vs 6) and the no-memory arm's failures are the
+   dangerous kind — accepting requests that re-open shipped fixes. This is the
+   behavioral cash-value of Naur theory restoration: the reason a decision was
+   settled survives only through memory.
+
+2. **Reinstatement gained no separation from plain kNN — at either level.**
+   Identical actions on 16/16 tasks; tied 27–27 on blinded reason quality. On
+   single-hop re-litigation tasks ("does history bear on this request?"), one-shot
+   similarity retrieval restores the theory as well as the full reinstatement
+   walk. The reinstatement spike's +53% advantage lived on multi-hop provenance
+   queries; this benchmark's tasks are single-hop, and the tie localizes the
+   invention's value to the multi-hop regime — the next benchmark, if run, should
+   be built of tasks whose justification chain spans multiple conversations.
+
+3. **Uniform conservatism bias, arm-independent.** All three arms scored 6/12 on
+   should-change: valid changes (a forcing-feature dependency bump, a
+   now-satisfied precondition, an ablation-backed rebalance) were met with
+   NEEDS-INFO instead of acceptance in 10 of 12 responses (every arm accepted only
+   the intent-margin task, where the request itself carried a week of telemetry).
+   Memory did not cause the caution (no-memory shows it identically) — but memory
+   also did not cure it: retrieving the pin's own exit condition did not stop the
+   arm from asking for permission it already had. Practical consequence: a
+   memory-augmented agent's failure mode shifts from "re-breaks settled things"
+   toward "over-defers on justified change," and task mixes that omit
+   should-change classes would miss this entirely.
+
+4. **No over-generalization of the negative result.** On irrelevant-past tasks
+   (including one proposing edge-level ratification right after Gate A′ killed
+   node-level) every arm correctly declined to treat inapplicable history as
+   binding — perfect 6/6 across all arms. The feared failure mode "memory of a
+   failure blocks structurally different follow-ups" did not appear.
+
+## Verdict
+
+Memory's benefit on re-litigation is real and class-specific (settled-for-cause);
+reinstatement recall is not the source of that benefit on single-hop tasks — plain
+similarity retrieval suffices. The invention's claim now rests where the spike
+found it: multi-hop provenance. Honest summary for the paper: *a blinded,
+pre-registered, three-arm behavioral benchmark shows conversation memory roughly
+halves reason-quality failures on settled decisions (10+9 vs 6 of 12), while
+showing no reinstatement-over-kNN separation in the single-hop regime.*


### PR DESCRIPTION
## What

Two doc commits, no code:

**1. Re-litigation benchmark results (`docs/plans/saga-relitigation-results.md`)** — blinded grading complete. Three-arm behavioral benchmark (R = reinstatement recall, K = similarity-only kNN, N = no memory), 16 sha256-sealed tasks, operator-graded blind on a 0–3 reason-faithful-action rubric.

- Action level: memory arms 12/16 correct each; no-memory 8/16
- Reason quality: R 27/36 = K 27/36 > N 24/36
- Effect concentrated in settled-for-cause class (10+9 vs 6 of 12); no-memory arm ACCEPTS re-breaking a shipped fix
- Reinstatement gains **no separation** over plain kNN in the single-hop regime — invention's claim stays localized to multi-hop provenance (where the +53% spike lived)
- New finding: uniform arm-independent conservatism on should-change tasks (over-defers on justified change)

**2. Post-#251 CodeRabbit nits**

- `CLAUDE.md`: annotation claim overclaimed — `get_full_conversation` uses `open_world_hint`, not `idempotent_hint`; reworded to "hints vary per tool"
- `docs-site/src/content/mcp-tools.md`: language identifiers on two bare fenced blocks (MD040)

## Why now

Main moved ahead with unrelated work (consent installer #247, release CI, v9.3.1); branch is cut from latest main (f9a1997).

https://claude.ai/code/session_01FrNuZJMHK1Y4jpSx88C5aL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified tool annotation guidance, including the distinct behavior of `get_full_conversation`.
  * Improved MCP storage-tool documentation with formatted Python examples for `csr_why` and `csr_resolve`.
  * Added a detailed re-litigation benchmark results report covering methodology, findings, and conclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->