### PR TITLE
docs: v9.4 README + docs-site sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Single 44MB binary. No databases. No containers. No API keys required.
 
 [Install](#install) | [How It Works](#how-it-works) | [MCP Tools](#mcp-tools) | [FAQ](https://ramakay.github.io/claude-self-reflect/#/docs/troubleshooting)
 
-> **v9.2 — Episode Intelligence**
-> Sessions end as structured episodes; new sessions open with a CONTINUUM of where you left off.
-> Provenance re-ranking, semantic intent routing, code graph, full-transcript recall, telemetry dashboard.
-> Sub-millisecond search, ~150ms cached startup, 570+ tests, zero external dependencies.
-> [Release notes](https://github.com/ramakay/claude-self-reflect/releases/tag/v9.2.0) | [Announcement](https://github.com/ramakay/claude-self-reflect/discussions/175)
+> **v9.4 — Multi-Source Memory**
+> CSR now remembers more than transcripts: task outcomes, plan documents, and a cross-project session registry — each absorbed at the lifecycle stage it belongs to.
+> Episodes carry real task state again (Claude Code's TodoWrite→TaskCreate rename had silently emptied them — found, fixed, and guarded with schema-miss telemetry).
+> Sub-millisecond search, ~150ms cached startup, 720+ tests, zero external dependencies.
+> [Release notes](https://github.com/ramakay/claude-self-reflect/releases/tag/v9.4.0)
 
 <img src="docs-site/public/images/csr-demo.gif" alt="CSR Demo — Setup, Search, and Hooks" width="800" />
 
@@ -166,7 +166,7 @@ No special syntax. No commands. CSR finds relevant past context and injects it a
 </details>
 
 <details>
-<summary><strong>MCP Tools</strong> — 12 annotated tools available to Claude</summary>
+<summary><strong>MCP Tools</strong> — 15 annotated tools available to Claude</summary>
 
 All tools include [MCP tool annotations](https://spec.modelcontextprotocol.io/specification/2025-11-05/server/tools/#annotations) so Claude Code understands their safety characteristics.
 
@@ -184,6 +184,9 @@ All tools include [MCP tool annotations](https://spec.modelcontextprotocol.io/sp
 | `csr_get_more` | Paginate through additional results | read-only |
 | `get_full_conversation` | Retrieve complete JSONL conversation | read-only |
 | `get_session_learnings` | Iteration-level memory for Ralph loops | read-only |
+| `csr_code_graph` | Which conversations shaped a function or file (AST anchors) | read-only |
+| `csr_why` | Provenance chain — why does this code/decision exist | read-only |
+| `csr_resolve` | Record verified verdicts (resolved/still_open/regressed) on chunks | **writes** |
 
 </details>
 

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -818,25 +818,25 @@ function WhatsNewCard() {
   return (
     <BentoCard className="card--whatsnew" delay={560} id="whats-new">
       <CardKicker number="—" label="LATEST RELEASE" accent="purple" />
-      <h2 className="type-hl-sm">What's New in v9.3.0</h2>
+      <h2 className="type-hl-sm">What's New in v9.4.0</h2>
       <ul className="whatsnew-list">
         <li>
-          <strong>Narrative token accounting</strong> — every AI narrative call is metered, including failures; <code>csr-engine status</code> reports calls and tokens spent today and all-time
+          <strong>Multi-source memory</strong> — CSR now absorbs more of <code>~/.claude</code> than transcripts: task outcomes, plan documents, and a cross-project session registry, each at the lifecycle stage it belongs to
         </li>
         <li>
-          <strong>Model chain + kill switch</strong> — narratives resolve <code>CSR_NARRATIVE_MODEL</code> → <code>haiku</code> → CLI default instead of a dated model pin; <code>CSR_NO_AI_NARRATIVES=1</code> turns AI narratives off entirely
+          <strong>Task-state regression fixed</strong> — Claude Code renamed TodoWrite → TaskCreate and episode task extraction silently emptied; episodes carry real todos and task-aware outcomes again, with open tasks capping a session at "partial"
         </li>
         <li>
-          <strong>CODE MAP injection</strong> — exploration prompts ("how does the ring navigation work?") are detected semantically and answered with file pointers from the conversation that built the feature — before the agent re-maps the codebase
+          <strong>Plan documents searchable</strong> — <code>~/.claude/plans/*.md</code> imported as decay-aware chunks, correlated to their origin conversation; the origin always outranks its plan restatement in search
         </li>
         <li>
-          <strong>File-level anchors</strong> — code provenance tracking now covers every language via whole-file anchors, not just the six AST-parsed ones
+          <strong>Honest coverage</strong> — <code>csr-engine status</code> now measures sessions seen vs imported, unindexed transcripts, and per-source schema-miss counters so silent format churn can't rot quality invisibly
         </li>
         <li>
-          <strong>Briefing cache</strong> — the session briefing regenerates only when episode content actually changes, cutting repeat SessionStart cost to zero
+          <strong>Resolution proposals</strong> — completed tasks matching still-open items generate proposals a human promotes via <code>csr_resolve</code>; never automatic verdicts
         </li>
       </ul>
-      <a className="cite-link" href="https://github.com/ramakay/claude-self-reflect/releases/tag/v9.3.0" target="_blank" rel="noopener noreferrer">Full release notes →</a>
+      <a className="cite-link" href="https://github.com/ramakay/claude-self-reflect/releases/tag/v9.4.0" target="_blank" rel="noopener noreferrer">Full release notes →</a>
     </BentoCard>
   )
 }


### PR DESCRIPTION
Post-release docs sync (same tradition as #234 for v9.3):

- README banner v9.2 → v9.4 (multi-source memory), test count 570+ → 720+
- MCP tools table: 12 → 15 (adds `csr_code_graph`, `csr_why`, `csr_resolve`)
- Landing "What's New" tile: v9.3.0 → v9.4.0 with multi-source bullets
- docs-site build verified

https://claude.ai/code/session_013584AxeJrXkoq2hUSoCWSV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release information to v9.4, highlighting multi-source memory and related improvements.
  * Added documentation for three MCP tools, including a write-capable resolution tool.
  * Refreshed the landing page’s “What’s New” content and release-notes link.
  * Documented improvements to task-state handling, plan document searchability, status coverage, and resolution proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->