### PR TITLE
v9.4.1: source telemetry, SessionEnd fix, hook-recursion guard, landing updates

### DIFF
--- a/csr-engine/src/daemon/ratification.rs
+++ b/csr-engine/src/daemon/ratification.rs
@@ -133,6 +133,10 @@ async fn call_claude_for_acts(prompt: &str) -> Option<crate::narrative::ParsedNa
     for candidate in ratification_model_candidates() {
         let attempt = tokio::time::timeout(RATIFICATION_TIMEOUT, async {
             let mut cmd = tokio::process::Command::new("claude");
+            // Same recursion guard as session_briefing: nested claude sessions
+            // inherit hook config; without it each extraction call fires all CSR
+            // hooks and Stop stores the extractor transcript as an episode.
+            cmd.env("CSR_DISABLE_RECURSIVE_HOOKS", "1");
             if let Some(model) = &candidate {
                 cmd.args(["--model", model]);
             }

--- a/csr-engine/src/main.rs
+++ b/csr-engine/src/main.rs
@@ -364,6 +364,42 @@ async fn main() -> Result<()> {
             return csr_engine::hooks::install::handle(apply);
         }
 
+        // Recursion guard, checked before the engine is built: nested `claude -p`
+        // sessions (briefing, narratives, ratification) inherit hook config —
+        // exit before paying model/index startup for a no-op.
+        if std::env::var("CSR_DISABLE_RECURSIVE_HOOKS").as_deref() == Ok("1") {
+            return Ok(());
+        }
+
+        // SessionEnd races app exit: Claude Code cancels hooks still running at
+        // quit, so engine startup + HNSW flush (~0.5s) almost always dies as
+        // "Hook cancelled". Re-spawn ourselves disowned and return immediately;
+        // the child does the real work and survives the parent's cancellation.
+        // SessionEnd output is never injected, so nothing is lost by detaching.
+        if name == "session-end" && std::env::var("CSR_HOOK_DETACHED").as_deref() != Ok("1") {
+            use std::io::{Read, Write};
+            let mut stdin_buf = Vec::new();
+            let _ = std::io::stdin().read_to_end(&mut stdin_buf);
+            let exe = std::env::current_exe()?;
+            let mut cmd = std::process::Command::new(exe);
+            cmd.args(["hook", "session-end"])
+                .env("CSR_HOOK_DETACHED", "1")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::CommandExt;
+                cmd.process_group(0);
+            }
+            if let Ok(mut child) = cmd.spawn() {
+                if let Some(mut pipe) = child.stdin.take() {
+                    let _ = pipe.write_all(&stdin_buf);
+                }
+            }
+            return Ok(());
+        }
+
         // Other hooks need the engine
         if let Some(parent) = args.db_path.parent() {
             std::fs::create_dir_all(parent)?;

--- a/csr-engine/src/status.rs
+++ b/csr-engine/src/status.rs
@@ -46,12 +46,26 @@ pub struct SchemaMissCounts {
     pub history: i64,
 }
 
+/// Positive per-source corpus counts (v9.4 multi-source adapters).
+/// `schema_misses` says what failed to parse; this says what actually landed.
+#[derive(Serialize, Default, Debug, PartialEq, Eq)]
+pub struct SourceCounts {
+    pub plan_docs: i64,
+    pub plan_chunks: i64,
+    pub plan_unscoped_docs: i64,
+    pub registry_sessions: i64,
+    pub task_sessions_on_disk: usize,
+    pub resolution_proposals: i64,
+    pub resolution_verdicts: i64,
+}
+
 #[derive(Serialize, Default, Debug, PartialEq, Eq)]
 pub struct AuxStatus {
     pub coverage: CoverageStats,
     pub file_history_sessions: usize,
     pub transcripts_unindexed: usize,
     pub schema_misses: SchemaMissCounts,
+    pub sources: SourceCounts,
 }
 
 #[derive(Serialize, Default)]
@@ -236,6 +250,19 @@ fn gather_aux(storage: &Storage, projects_dir: &Path) -> AuxStatus {
         }
     }
 
+    let (plan_docs, plan_chunks, plan_unscoped_docs) =
+        storage.plan_source_counts().unwrap_or((0, 0, 0));
+    let task_sessions_on_disk = claude_dir
+        .map(|d| d.join("tasks"))
+        .filter(|p| p.is_dir())
+        .and_then(|p| std::fs::read_dir(p).ok())
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .count()
+        })
+        .unwrap_or(0);
+
     AuxStatus {
         coverage: CoverageStats {
             sessions_seen: seen,
@@ -245,6 +272,15 @@ fn gather_aux(storage: &Storage, projects_dir: &Path) -> AuxStatus {
         file_history_sessions,
         transcripts_unindexed,
         schema_misses,
+        sources: SourceCounts {
+            plan_docs,
+            plan_chunks,
+            plan_unscoped_docs,
+            registry_sessions: seen,
+            task_sessions_on_disk,
+            resolution_proposals: storage.count_resolution_proposals().unwrap_or(0),
+            resolution_verdicts: storage.count_resolution_verdicts().unwrap_or(0),
+        },
     }
 }
 

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -530,6 +530,27 @@ impl Storage {
         )
     }
 
+    pub fn count_resolution_verdicts(&self) -> Result<i64> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        Ok(conn.query_row("SELECT COUNT(*) FROM resolution_ledger", [], |r| r.get(0))?)
+    }
+
+    /// Plan-corpus counts: (docs, chunks, unscoped_docs). Plan chunks are
+    /// identified by their `plan:` conversation-id prefix, not `chunks.source`,
+    /// matching how every reader distinguishes them.
+    pub fn plan_source_counts(&self) -> Result<(i64, i64, i64)> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        conn.query_row(
+            "SELECT COUNT(DISTINCT conversation_id), COUNT(*),
+                    COUNT(DISTINCT CASE WHEN project_name = '_unscoped'
+                          THEN conversation_id END)
+             FROM chunks WHERE conversation_id LIKE 'plan:%'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .map_err(Into::into)
+    }
+
     /// Read back a chunk's storage-level `source` attribute (see
     /// `insert_chunk_with_source`) — used by aux-source adapter tests.
     pub fn get_chunk_source(&self, id: &str) -> Result<Option<String>> {

--- a/csr-engine/src/summarizer.rs
+++ b/csr-engine/src/summarizer.rs
@@ -100,6 +100,10 @@ async fn call_claude_headless(prompt: &str) -> Option<crate::narrative::ParsedNa
     for candidate in crate::narrative::model_candidates() {
         let attempt = tokio::time::timeout(HAIKU_TIMEOUT, async {
             let mut cmd = tokio::process::Command::new("claude");
+            // Nested sessions inherit the user's hook config — without this guard
+            // every narrative call fires all 6 CSR hooks and its Stop hook stores
+            // the analyst transcript as a session_episode (meta-episode pollution).
+            cmd.env("CSR_DISABLE_RECURSIVE_HOOKS", "1");
             if let Some(model) = &candidate {
                 cmd.args(["--model", model]);
             }

--- a/csr-engine/src/telemetry/render.rs
+++ b/csr-engine/src/telemetry/render.rs
@@ -39,6 +39,20 @@ pub mod text {
             e.ai_narrative_failed,
             e.ai_narrative_processing,
         );
+        let src = &t.status.aux.sources;
+        let miss = &t.status.aux.schema_misses;
+        println!(
+            "  Sources plans={} docs/{} chunks ({} unscoped)  tasks={} sessions  registry={} sessions",
+            src.plan_docs,
+            src.plan_chunks,
+            src.plan_unscoped_docs,
+            src.task_sessions_on_disk,
+            src.registry_sessions,
+        );
+        println!(
+            "          proposals={} verdicts={}  schema_miss: tasks={} plans={} history={}",
+            src.resolution_proposals, src.resolution_verdicts, miss.tasks, miss.plans, miss.history,
+        );
         println!();
 
         // ── Startup ───────────────────────────────────────────────────────────

--- a/csr-engine/src/telemetry/tui.rs
+++ b/csr-engine/src/telemetry/tui.rs
@@ -238,6 +238,40 @@ fn draw_index_panel(f: &mut Frame, area: Rect, t: &Telemetry) {
         lines.push(Line::from(format!("  newest      {}", newest)));
     }
 
+    let src = &t.status.aux.sources;
+    let miss = &t.status.aux.schema_misses;
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![Span::styled(
+        "Sources",
+        Style::default().add_modifier(Modifier::BOLD),
+    )]));
+    lines.push(Line::from(format!(
+        "  plans       {} docs / {} chunks  ({} unscoped)",
+        src.plan_docs, src.plan_chunks, src.plan_unscoped_docs
+    )));
+    lines.push(Line::from(format!(
+        "  tasks       {} sessions on disk",
+        src.task_sessions_on_disk
+    )));
+    lines.push(Line::from(format!(
+        "  registry    {} sessions",
+        src.registry_sessions
+    )));
+    lines.push(Line::from(format!(
+        "  resolve     {} proposals / {} verdicts",
+        src.resolution_proposals, src.resolution_verdicts
+    )));
+    let total_miss = miss.tasks + miss.plans + miss.history;
+    if total_miss > 0 {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  schema_miss tasks={} plans={} history={}",
+                miss.tasks, miss.plans, miss.history
+            ),
+            Style::default().fg(Color::Yellow),
+        )));
+    }
+
     let p = Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title(" Index "));
     f.render_widget(p, parts[1]);
 }

--- a/docs-site/src/index.css
+++ b/docs-site/src/index.css
@@ -657,10 +657,12 @@ body {
 .card--ask { grid-column: 1 / -1; grid-row: 4; }
 .card--arch { grid-column: 1 / -1; grid-row: 5; }
 .card--whatsnew { grid-column: 1 / -1; grid-row: 6; }
-.card--demo { grid-column: 1 / -1; grid-row: 7; }
-.card--flatfile { grid-column: 1 / span 4; grid-row: 8; }
-.card--kgraph { grid-column: 5 / span 4; grid-row: 8; }
-.card--hosted { grid-column: 9 / span 4; grid-row: 8; }
+.card--multisource { grid-column: 1 / span 7; grid-row: 7; }
+.card--paper { grid-column: 8 / span 5; grid-row: 7; }
+.card--demo { grid-column: 1 / -1; grid-row: 8; }
+.card--flatfile { grid-column: 1 / span 4; grid-row: 10; }
+.card--kgraph { grid-column: 5 / span 4; grid-row: 10; }
+.card--hosted { grid-column: 9 / span 4; grid-row: 10; }
 
 /* AST card internals */
 .ast-layout {
@@ -907,7 +909,7 @@ body {
 /* Comparison section header */
 .bento-section-header {
   grid-column: 1 / -1;
-  grid-row: 6;
+  grid-row: 9;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
@@ -1082,6 +1084,228 @@ body {
 }
 .whatsnew-list strong {
   color: var(--color-heading);
+}
+
+/* Multi-source card (v9.4) — task ledger micro-animation */
+.card--multisource {
+  background:
+    radial-gradient(circle at 75% 20%, rgba(124,148,115,0.14), transparent 55%),
+    rgba(255,255,255,0.82);
+}
+
+.multisource-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(220px, 1.1fr);
+  gap: 18px;
+  margin-top: 14px;
+  align-items: start;
+}
+
+.todo-anim {
+  border: 1px solid rgba(26,26,46,0.14);
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: rgba(255,255,255,0.6);
+  position: relative;
+}
+
+.todo-anim__title {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--color-muted);
+  margin: 0 0 8px;
+}
+
+.todo-anim__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-body);
+}
+
+.todo-anim__box {
+  width: 13px;
+  height: 13px;
+  flex: none;
+  border: 1.4px solid rgba(26,26,46,0.35);
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  animation: todoBoxFill 9s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 1.1s);
+}
+
+.todo-anim__box svg {
+  width: 9px;
+  height: 9px;
+  stroke: #fff;
+  opacity: 0;
+  animation: todoCheck 9s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 1.1s);
+}
+
+.todo-anim__label {
+  animation: todoLabelDim 9s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 1.1s);
+}
+
+.todo-anim__outcome {
+  display: inline-block;
+  margin-top: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--color-sage);
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 2px 10px;
+  opacity: 0;
+  animation: outcomeIn 9s ease-in-out infinite;
+}
+
+@keyframes todoBoxFill {
+  0%, 8% { background: transparent; border-color: rgba(26,26,46,0.35); }
+  14%, 88% { background: var(--color-sage); border-color: var(--color-sage); }
+  96%, 100% { background: transparent; border-color: rgba(26,26,46,0.35); }
+}
+
+@keyframes todoCheck {
+  0%, 9% { opacity: 0; }
+  14%, 88% { opacity: 1; }
+  96%, 100% { opacity: 0; }
+}
+
+@keyframes todoLabelDim {
+  0%, 8% { opacity: 1; }
+  14%, 88% { opacity: 0.55; }
+  96%, 100% { opacity: 1; }
+}
+
+@keyframes outcomeIn {
+  0%, 48% { opacity: 0; transform: translateY(3px); }
+  56%, 88% { opacity: 1; transform: translateY(0); }
+  96%, 100% { opacity: 0; transform: translateY(3px); }
+}
+
+.multisource-sources {
+  min-width: 0;
+}
+
+.multisource-source {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 3px 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.multisource-source__dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  align-self: center;
+  border-radius: 50%;
+  background: var(--dot);
+  animation: sourcePulse 4.4s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.55s);
+}
+
+@keyframes sourcePulse {
+  0%, 100% { transform: scale(1); opacity: 0.55; }
+  12% { transform: scale(1.5); opacity: 1; }
+  24% { transform: scale(1); opacity: 0.55; }
+}
+
+.multisource-source__name {
+  font-weight: 700;
+  color: var(--color-heading);
+  min-width: 84px;
+}
+
+.multisource-source__path {
+  color: var(--color-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.multisource-caption {
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+/* Paper card */
+.card--paper {
+  background:
+    radial-gradient(circle at 20% 15%, rgba(107,91,149,0.12), transparent 55%),
+    rgba(255,255,255,0.82);
+}
+
+.paper-title {
+  font-style: italic;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--color-heading);
+  margin: 10px 0 10px;
+}
+
+.paper-traces {
+  display: flex;
+  gap: 6px;
+  margin: 0 0 10px;
+}
+
+.paper-trace {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-purple);
+  border: 1px solid rgba(107,91,149,0.4);
+  border-radius: 999px;
+  padding: 2px 9px;
+  animation: sourcePulse 5.2s ease-in-out infinite;
+  animation-delay: calc(var(--i) * 0.6s);
+}
+
+.paper-findings {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--color-body);
+}
+
+.paper-findings strong {
+  color: var(--color-heading);
+}
+
+@media (max-width: 720px) {
+  .multisource-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+[data-theme="dark"] .todo-anim {
+  background: rgba(255,255,255,0.05);
+  border-color: rgba(255,255,255,0.14);
+}
+
+[data-theme="dark"] .todo-anim__box {
+  border-color: rgba(255,255,255,0.4);
 }
 
 .card--install {
@@ -2385,7 +2609,9 @@ body {
 
   .card--ask,
   .card--arch,
-  .card--demo {
+  .card--demo,
+  .card--multisource,
+  .card--paper {
     grid-column: 1 / -1;
     grid-row: auto;
   }

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -841,6 +841,85 @@ function WhatsNewCard() {
   )
 }
 
+function MultiSourceCard() {
+  const todos = [
+    { label: 'Fix TaskCreate regression', i: 0 },
+    { label: 'Correlate plan → origin conversation', i: 1 },
+    { label: 'Ingest history.jsonl registry', i: 2 },
+    { label: 'Wire schema-miss telemetry', i: 3 },
+  ]
+  const sources = [
+    { name: 'transcripts', path: '~/.claude/projects', color: 'var(--color-purple)' },
+    { name: 'tasks', path: '~/.claude/tasks', color: 'var(--color-sage)' },
+    { name: 'plans', path: '~/.claude/plans', color: 'var(--color-rose)' },
+    { name: 'registry', path: '~/.claude/history.jsonl', color: 'var(--color-muted)' },
+  ]
+
+  return (
+    <BentoCard className="card--multisource" delay={600}>
+      <CardKicker number="—" label="V9.4 — MULTI-SOURCE" accent="sage" />
+      <h2 className="type-hl-sm">More Than Transcripts</h2>
+      <p className="type-dateline mt-2">Tasks, plans, and session history — absorbed where they belong.</p>
+      <div className="multisource-layout">
+        <div className="todo-anim" aria-hidden="true">
+          <p className="todo-anim__title">SESSION TASKS</p>
+          {todos.map(({ label, i }) => (
+            <div key={label} className="todo-anim__item" style={{ '--i': i }}>
+              <span className="todo-anim__box">
+                <svg viewBox="0 0 10 10"><path d="M2 5.2 4.2 7.4 8 2.8" fill="none" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /></svg>
+              </span>
+              <span className="todo-anim__label">{label}</span>
+            </div>
+          ))}
+          <span className="todo-anim__outcome">outcome: shipped</span>
+        </div>
+        <div className="multisource-sources">
+          {sources.map(({ name, path, color }, i) => (
+            <div key={name} className="multisource-source" style={{ '--i': i, '--dot': color }}>
+              <span className="multisource-source__dot" />
+              <span className="multisource-source__name">{name}</span>
+              <span className="multisource-source__path">{path}</span>
+            </div>
+          ))}
+          <p className="type-caption multisource-caption">
+            Task outcomes cap sessions honestly — open tasks mean "partial", never "success". Plans decay with age; the origin conversation always outranks its plan restatement.
+          </p>
+        </div>
+      </div>
+    </BentoCard>
+  )
+}
+
+function PaperCard() {
+  return (
+    <BentoCard className="card--paper" delay={660}>
+      <CardKicker number="—" label="PUBLISHED RESEARCH" accent="purple" />
+      <h2 className="type-hl-sm">The Paper</h2>
+      <p className="paper-title">
+        Similarity Drowns Intent: Three-Trace Sagas and Reinstatement Recall for Provenance in Agentic Software Construction
+      </p>
+      <div className="paper-traces" aria-hidden="true">
+        {['intent', 'deliberation', 'artifact'].map((t, i) => (
+          <span key={t} className="paper-trace" style={{ '--i': i }}>{t}</span>
+        ))}
+      </div>
+      <ul className="paper-findings">
+        <li><strong>+53% / +47%</strong> ground-truth session coverage over one-shot kNN at equal budget, pre-registered gates, two corpora</li>
+        <li><strong>Self-indexing contamination</strong> — a memory system that records its own evaluation drowns the answers in echoes; defenses repair 72% of echo occupancy</li>
+        <li><strong>Negative result, kept</strong> — ratification weighting halted at ρ≈0 and forbade an inference-based staleness design</li>
+      </ul>
+      <a
+        className="cite-link"
+        href="https://github.com/ramakay/claude-self-reflect/blob/main/docs/plans/annaswamy-2026-similarity-drowns-intent.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read the paper (PDF) →
+      </a>
+    </BentoCard>
+  )
+}
+
 function HostedMemoryCard() {
   return (
     <BentoCard className="card--hosted" delay={960}>
@@ -1213,6 +1292,8 @@ export default function Landing() {
           <WhatYouAskCard />
           <ArchCard />
           <WhatsNewCard />
+          <MultiSourceCard />
+          <PaperCard />
           <div className="bento-section-header">
             <span />
             <h2>How others do it</h2>


### PR DESCRIPTION
## Engine
- **status/telemetry now show what landed, not just what failed**: `aux.sources` — plan docs/chunks/unscoped, registry sessions, task sessions on disk, resolution proposals/verdicts; rendered in `csr-engine telemetry` text + TUI
- **SessionEnd 'Hook cancelled' fixed**: hook detaches (parent 7ms, disowned child does engine startup + HNSW flush) so Claude Code's at-quit cancellation can't kill it
- **Nested-session hook recursion fixed**: narrative + ratification `claude -p` spawns now set `CSR_DISABLE_RECURSIVE_HOOKS` — they were firing all 6 CSR hooks per call and storing extractor transcripts as episodes (meta-episode pollution observed live in SessionStart CONTINUUM); guard also checked before engine build
- Tests: 615 + 45 + 61 green, clippy/fmt clean

## Docs site
- MultiSourceCard: task-ledger micro-animation (todos tick, outcome chip) + source lanes
- PaperCard: published paper tile (Similarity Drowns Intent, PDF link)
- Grid renumber + section-header row collision fix

https://claude.ai/code/session_013584AxeJrXkoq2hUSoCWSV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Status and telemetry views now show detailed source counts, including plans, documents, chunks, task sessions, registry sessions, and resolution activity.
  - Telemetry highlights schema issues when detected.
  - Session-end processing is more reliable during application shutdown.

- **Documentation**
  - Updated the landing page with Multi-Source and Published Research cards.
  - Added responsive layouts, dark-mode support, and animated visual treatments for the new cards.

- **Bug Fixes**
  - Prevented recursive processing from creating unwanted nested activity during automated analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->