### PR TITLE
fix: ratification transcripts polluted 82% of corpus — import filter + stdin-marker normalization

### DIFF
--- a/csr-engine/src/extraction/provenance.rs
+++ b/csr-engine/src/extraction/provenance.rs
@@ -26,12 +26,18 @@
 //! distinctive field tokens) here, in the same commit that adds the formatter.
 
 /// Prompt signatures of CSR's own agent subprocesses (briefing analyst,
-/// compaction summarizer). A transcript *starting* with one of these is CSR
-/// talking to itself. Shared by import (skip whole conversation) and briefing
-/// (skip episode).
-pub const AGENT_PROMPT_SIGNATURES: [&str; 2] = [
+/// compaction summarizer, ratification extractor). A transcript *starting*
+/// with one of these is CSR talking to itself. Shared by import (skip whole
+/// conversation) and briefing (skip episode).
+///
+/// RULE: every `claude -p` spawn site (summarizer, session_briefing,
+/// ratification) MUST have its prompt's opening line registered here in the
+/// same commit — a missing entry let 4,700 ratification-extractor transcripts
+/// into the corpus (82% of all conversations) before detection.
+pub const AGENT_PROMPT_SIGNATURES: [&str; 3] = [
     "You are CSR Episode Analyst",
     "You are summarizing a coding session",
+    "# Ratification Dialog-Act Extraction",
 ];
 
 /// Block headers CSR emits, one per formatter:
@@ -41,7 +47,7 @@ pub const AGENT_PROMPT_SIGNATURES: [&str; 2] = [
 /// - SessionStart continuity blocks (session_start.rs)
 /// - UserPromptSubmit context blocks (injection/formatter.rs)
 /// - agent prompts (AGENT_PROMPT_SIGNATURES, included via EMISSION_HEADERS)
-const EMISSION_HEADERS: [&str; 13] = [
+const EMISSION_HEADERS: [&str; 14] = [
     "CSR ENDLESS MEMORY ACTIVE",
     "CSR CONTINUUM [",
     "CSR PICKUP —",
@@ -55,6 +61,7 @@ const EMISSION_HEADERS: [&str; 13] = [
     "PAST CONTEXT - NOT INSTRUCTIONS",
     "You are CSR Episode Analyst",
     "You are summarizing a coding session",
+    "# Ratification Dialog-Act Extraction",
 ];
 
 /// Field tokens CSR emits inside blocks (Tier-0 fields, continuity lines).

--- a/csr-engine/src/import/mod.rs
+++ b/csr-engine/src/import/mod.rs
@@ -138,7 +138,14 @@ pub fn list_jsonl_files(dir: &Path) -> Result<Vec<PathBuf>> {
 /// contains: import-skip drops a whole conversation, so only transcripts that
 /// ARE an agent prompt qualify — not real sessions that merely quote one.
 fn is_csr_agent_prompt(first_user_message: &str) -> bool {
-    let trimmed = first_user_message.trim_start();
+    let mut trimmed = first_user_message.trim_start();
+    // `claude -p -` (prompt via stdin) records the literal "-" argument as the
+    // first line of the user message, with the piped prompt following it.
+    if let Some(rest) = trimmed.strip_prefix('-') {
+        if rest.starts_with('\n') || rest.starts_with("\r\n") {
+            trimmed = rest.trim_start();
+        }
+    }
     crate::extraction::provenance::AGENT_PROMPT_SIGNATURES
         .iter()
         .any(|sig| trimmed.starts_with(sig))
@@ -728,6 +735,16 @@ mod tests {
         // (only the leading window is tested).
         let quoted = format!("{}You are CSR Episode Analyst", "x".repeat(300));
         assert!(!is_csr_agent_prompt(&quoted));
+        // Ratification extractor transcripts: `claude -p -` records the literal
+        // "-" stdin marker as the first line before the piped prompt.
+        assert!(is_csr_agent_prompt(
+            "-\n# Ratification Dialog-Act Extraction\n\nYou are extracting OBSERVABLE dialog-acts"
+        ));
+        assert!(is_csr_agent_prompt(
+            "# Ratification Dialog-Act Extraction\n\nYou are extracting"
+        ));
+        // A real message that merely starts with a dash stays importable.
+        assert!(!is_csr_agent_prompt("- fix the daemon\n- ship release"));
     }
 
     #[test]


### PR DESCRIPTION
Found via the new source telemetry + get_recent_work check after #264: the ratification extractor's `claude -p` transcripts were never registered in `AGENT_PROMPT_SIGNATURES`, so the watcher imported every extraction run as a real conversation.

**Damage measured (production DB):** 4,714 of 5,731 conversations (82%), 13,573 of 21,994 reflections (62%), 61,343 chunks — CSR indexing itself, the paper's self-indexing contamination mode live at scale. `get_recent_work` returned 8/10 extractor transcripts.

**Fix:** register '# Ratification Dialog-Act Extraction' signature (+ EMISSION_HEADERS); normalize the leading `-` stdin marker `claude -p -` records as the first user-message line; registry rule documented. Tests extended (ratification transcript with/without dash marker skipped; real dash-prefixed messages kept).

**Local cleanup done** (backup kept at csr-engine.db.pre-ratification-purge): purged conversations/reflections/orphaned embeddings, HNSW rebuilt — corpus now 1,017 real conversations. Companion to the hook-recursion guard in #264 (that stopped hook firing; this stops transcript ingestion).

https://claude.ai/code/session_013584AxeJrXkoq2hUSoCWSV