### PR TITLE
release: sync Cargo.lock to 9.4.1 (unblocks tag build)

### DIFF
--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csr-engine"
-version = "9.4.0"
+version = "9.4.1"
 dependencies = [
  "anyhow",
  "ast-grep-core",


### PR DESCRIPTION
Release workflow failed at `cargo --locked` — #267 bumped Cargo.toml without Cargo.lock. npm publish never ran, version not burned. After merge: delete + re-push tag v9.4.1 on the new main commit.