### PR TITLE
docs: README section for the published paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Higher quality context. Better decisions. Fewer tokens.
 CSR's retrieval design is documented in a research paper, measured on the system's own development history:
 
 > **Similarity Drowns Intent: Three-Trace Sagas and Reinstatement Recall for Provenance in Agentic Software Construction**
-> Annaswamy, 2026 — [PDF](docs/plans/annaswamy-2026-similarity-drowns-intent.pdf)
+> 2026 — [PDF](docs/plans/annaswamy-2026-similarity-drowns-intent.pdf)
 
 Ask a memory system "why did we drop Qdrant?" and cosine similarity returns a recording of you asking that question earlier, at 0.984 similarity. The decision itself scores lower than its own echoes. The paper measures this failure, the multi-hop walk built to counter it (+53% and +47% ground-truth session coverage over one-shot kNN on two corpora, pre-registered gates, blind cross-vendor judging), and a second finding that fell out of evaluation: a self-recording memory system ingests its own eval dialogue and drowns the answers it's being tested on. It also keeps its negative results — a pre-registered ratification-weighting hypothesis died at ρ≈0 and forbade an entire staleness design.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Single 44MB binary. No databases. No containers. No API keys required.
 - [The Problem](#the-forgetting-problem) — Why Claude needs memory
 - [The Architecture](#one-binary-44mb) — How CSR solves it
 - [The Pipeline](#the-pipeline) — Progressive enrichment (9.3x improvement)
+- [The Paper](#the-paper) — Published research behind the retrieval design
 - [Install](#install) — One-command install, consent-first activation
 - [What You'll Ask](#what-youll-ask) — Natural language, no syntax
 - [Performance](#performance) | [MCP Tools](#mcp-tools) | [Hooks](#hooks) | [CLI](#cli-reference)
@@ -95,6 +96,17 @@ Higher quality context. Better decisions. Fewer tokens.
 <br clear="both" />
 
 > **[Explore the full documentation →](https://ramakay.github.io/claude-self-reflect/#/docs/enrichment)**
+
+---
+
+## The Paper
+
+CSR's retrieval design is documented in a research paper, measured on the system's own development history:
+
+> **Similarity Drowns Intent: Three-Trace Sagas and Reinstatement Recall for Provenance in Agentic Software Construction**
+> Annaswamy, 2026 — [PDF](docs/plans/annaswamy-2026-similarity-drowns-intent.pdf)
+
+Ask a memory system "why did we drop Qdrant?" and cosine similarity returns a recording of you asking that question earlier, at 0.984 similarity. The decision itself scores lower than its own echoes. The paper measures this failure, the multi-hop walk built to counter it (+53% and +47% ground-truth session coverage over one-shot kNN on two corpora, pre-registered gates, blind cross-vendor judging), and a second finding that fell out of evaluation: a self-recording memory system ingests its own eval dialogue and drowns the answers it's being tested on. It also keeps its negative results — a pre-registered ratification-weighting hypothesis died at ρ≈0 and forbade an entire staleness design.
 
 ---
 


### PR DESCRIPTION
Adds 'The Paper' section between Pipeline and Install: title + PDF link (docs/plans/annaswamy-2026-similarity-drowns-intent.pdf), the 0.984 echo example, +53%/+47% coverage numbers, contamination finding, and the kept negative result. Matches the docs-site paper tile shipped in #264.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “The Paper” section to the README.
  * Included the referenced research paper’s title and a PDF link.
  * Updated the table of contents to link to the new section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->