### PR TITLE
Build on Windows: replace the Unix inode with a portable file identity

### DIFF
--- a/csr-engine/src/import/registry.rs
+++ b/csr-engine/src/import/registry.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
-use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use anyhow::Result;
@@ -26,6 +25,27 @@ pub struct IngestStats {
     pub parse_errors: usize,
 }
 
+/// Per-file identity used to detect that `history.jsonl` was replaced rather
+/// than appended to.
+///
+/// On Unix this is the inode. Windows has no inode; the closest stable stand-in
+/// is the creation timestamp, which changes when the path is backed by a new
+/// file. `file_index()` would be the exact analogue but it is still unstable
+/// (rust-lang/rust#63010), and this check does not warrant pulling in a
+/// `windows-sys` dependency: the head hash and the size check already catch
+/// rotation on their own, so this value only has to be a corroborating signal.
+#[cfg(unix)]
+fn file_identity(metadata: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.ino()
+}
+
+#[cfg(windows)]
+fn file_identity(metadata: &std::fs::Metadata) -> u64 {
+    use std::os::windows::fs::MetadataExt;
+    metadata.creation_time()
+}
+
 /// Incrementally ingest `~/.claude/history.jsonl` into `session_registry`.
 ///
 /// Called ONLY from the daemon loop (single writer) — never from setup or
@@ -43,7 +63,7 @@ pub fn ingest_history(storage: &Storage, history_path: &Path) -> Result<IngestSt
 
     let metadata = std::fs::metadata(history_path)?;
     let file_size = metadata.len();
-    let inode = metadata.ino();
+    let inode = file_identity(&metadata);
 
     // First line for head-hash (bounded read — do not load whole file).
     let first_line_bytes = read_first_line_bytes(history_path)?;


### PR DESCRIPTION
## The problem

`csr-engine` does not compile for any Windows target. `file_identity()` in
`src/import/registry.rs` calls `std::os::unix::fs::MetadataExt::ino()` unconditionally:

```
error[E0433]: cannot find `unix` in `os`
 --> src\import\registry.rs:9:14
error[E0599]: no method named `ino` found for struct `std::fs::Metadata`
```

Notably, this is the *only* thing standing in the way. There are no Unix-only dependencies in
`Cargo.toml`, no `[target.'cfg(unix)']` sections, `rusqlite` is already `bundled` and `reqwest`
already uses `rustls-tls` — so once this one function is made portable, the whole crate builds
natively on `x86_64-pc-windows-msvc`.

## The change

`file_identity()` is now split per platform. Unix keeps `ino()` verbatim; Windows uses
`creation_time()` from `std::os::windows::fs::MetadataExt`.

**Why not `file_index()`**, which would be the exact analogue of an inode: it is still unstable
(rust-lang/rust#63010), so it cannot be used on stable at all. My first attempt used it and
failed with `error[E0658]: use of unstable library feature 'windows_by_handle'`.

Pulling in `windows-sys` to call `GetFileInformationByHandle` directly seemed disproportionate
for one corroborating signal, given that `head_hash` and the size comparison already detect
rotation on their own — this value only has to agree with them. `creation_time()` changes when
the path is backed by a new file, which is the property the check actually needs.

One caveat worth stating rather than hiding: NTFS *file system tunneling* can preserve a
creation timestamp when a file is deleted and recreated under the same name within ~15 seconds.
In that window this value would fail to signal rotation — but the head hash and size still do,
which is why I was comfortable with the trade-off. If you would rather have exact semantics
here, I am happy to add `windows-sys` and use `GetFileInformationByHandle` instead; your call.

**No behaviour change on Unix.**

## Verification

On Windows 11, `stable-x86_64-pc-windows-msvc` (rustc 1.97.1), MSVC Build Tools 2022:

- `cargo build --release` — clean
- `cargo fmt --check` — clean
- `cargo clippy --release -- -D warnings` — clean
- `cargo test --release --lib` — **615 passed, 0 failed**
- `csr-engine setup` end to end: imported 41 conversations / 7133 chunks, registered the MCP
  server, and wrote all 6 hooks with correct Windows paths. Search returns expected results
  through the MCP server.

**What I did not run:** the integration tests under `tests/`. Building them relinks
`csr-engine.exe`, and Windows holds an image lock on a running executable — the MCP server was
live in an active Claude Code session, so cargo could not replace the binary. That is an
artifact of my environment, not of this change; on CI with nothing running it should be a
non-issue.

I did not add a test for this. A meaningful one would have to assert platform-specific
behaviour, and I did not want to guess at where you would want it to live — happy to add one
wherever you prefer.

## Not included

I am also running a second, unrelated local change (a multilingual embedding model, which helps
a non-English transcript corpus and would *hurt* an English one). That is a divergence rather
than a fix, so it is deliberately kept out of this PR. Mentioning it only so it is clear this
branch is the portability fix and nothing else.
