### PR TITLE
Fix three Windows-only failures that make every hook a no-op

### DIFF
--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -56,13 +56,29 @@ pub fn read_stdin_json() -> HookInput {
 
     // If stdin is a TTY (not piped), don't block waiting for input
     if std::io::stdin().is_terminal() {
+        crate::telemetry::append_timing_line("CSR stdin: is a terminal, no piped input");
         return HookInput::default();
     }
 
     let mut buf = String::new();
     match std::io::stdin().read_to_string(&mut buf) {
-        Ok(_) if !buf.trim().is_empty() => serde_json::from_str(&buf).unwrap_or_default(),
-        _ => HookInput::default(),
+        Ok(_) if !buf.trim().is_empty() => match serde_json::from_str(&buf) {
+            Ok(input) => input,
+            Err(e) => {
+                // A parse failure here silently degrades to Default (no prompt,
+                // no transcript_path) — the hook then no-ops. Log it loudly.
+                crate::telemetry::append_timing_line(&format!(
+                    "CSR stdin: {}B received but JSON parse FAILED: {}",
+                    buf.len(),
+                    e
+                ));
+                HookInput::default()
+            }
+        },
+        _ => {
+            crate::telemetry::append_timing_line("CSR stdin: empty (no JSON piped)");
+            HookInput::default()
+        }
     }
 }
 
@@ -119,16 +135,35 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
     let input = read_stdin_json();
     let t_stdin = t0.elapsed();
 
+    // Field-presence diagnostic: hook=0ms exits are indistinguishable from a
+    // missing prompt without this (live debugging 2026-07-30).
+    crate::telemetry::append_timing_line(&format!(
+        "CSR hook {} input: prompt_len={} cwd={:?} transcript={} session={}",
+        hook_name,
+        input.prompt.as_deref().map(str::len).unwrap_or(0),
+        input.cwd,
+        input.transcript_path.is_some(),
+        input.session_id.is_some(),
+    ));
+
     // Determine CWD: prefer input.cwd, fall back to process CWD
     // Validate that cwd is a real directory under $HOME (S-3 fix)
     let cwd = if let Some(ref dir) = input.cwd {
         let p = std::path::PathBuf::from(dir);
         if p.is_dir() {
             let canonical = p.canonicalize()?;
-            if let Some(home) = dirs::home_dir() {
-                if !canonical.starts_with(&home) {
-                    anyhow::bail!("cwd {} is outside home directory", canonical.display());
-                }
+            // S-3 check, Windows-fixed: canonicalize() returns a \\?\-prefixed
+            // path, so the raw home_dir() never prefix-matched and this bailed
+            // on EVERY hook that carried a cwd — compare canonical vs canonical.
+            // And outside-home is a warning, not an error: projects legitimately
+            // live on other drives (D:\...), and a hook that dies here silently
+            // disables both injection and live transcript import.
+            let home_ok = dirs::home_dir()
+                .and_then(|h| h.canonicalize().ok())
+                .map(|h| canonical.starts_with(&h))
+                .unwrap_or(false);
+            if !home_ok {
+                eprintln!("CSR: cwd {} outside home (allowed)", canonical.display());
             }
             canonical
         } else {

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -17,7 +17,7 @@ pub mod session_start;
 pub mod stop;
 
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -150,6 +150,59 @@ fn hook_input_from(read: StdinRead) -> HookInput {
     }
 }
 
+/// Resolve the directory a hook operates on. Prefers the cwd Claude Code sent,
+/// falls back to the process cwd, and **never fails**.
+///
+/// Every step here used to abort the whole hook with `?`: `canonicalize` fails if
+/// the directory is renamed or removed between `is_dir()` and the call, and
+/// `current_dir` fails outright once the process's own working directory is gone.
+/// Aborting is the failure this module keeps having to fix — it silently disables
+/// both context injection and live transcript import — so each step now degrades to
+/// the next best path and says so, rather than taking the session down with it.
+///
+/// Also performs the S-3 home-directory check (Windows-fixed: `canonicalize()`
+/// returns a `\\?\`-prefixed path, so the raw `home_dir()` never prefix-matched and
+/// this bailed on EVERY hook that carried a cwd — compare canonical vs canonical).
+/// Outside-`$HOME` is a warning, not an error: projects legitimately live on other
+/// drives.
+fn resolve_hook_cwd(input_cwd: Option<&str>) -> PathBuf {
+    if let Some(dir) = input_cwd {
+        let p = PathBuf::from(dir);
+        if p.is_dir() {
+            let resolved = match p.canonicalize() {
+                Ok(canonical) => canonical,
+                Err(e) => {
+                    crate::telemetry::append_timing_line(&format!(
+                        "CSR cwd: canonicalize({}) failed ({}) — using the path as given",
+                        p.display(),
+                        e
+                    ));
+                    p
+                }
+            };
+            let home_ok = dirs::home_dir()
+                .and_then(|h| h.canonicalize().ok())
+                .map(|h| resolved.starts_with(&h))
+                .unwrap_or(false);
+            if !home_ok {
+                eprintln!("CSR: cwd {} outside home (allowed)", resolved.display());
+            }
+            return resolved;
+        }
+    }
+
+    std::env::current_dir().unwrap_or_else(|e| {
+        // The process cwd itself is unreadable (deleted out from under us). A
+        // relative path keeps the hook alive; whatever it touches will fail on its
+        // own terms instead of killing the session here.
+        crate::telemetry::append_timing_line(&format!(
+            "CSR cwd: current_dir() failed ({}) — falling back to \".\"",
+            e
+        ));
+        PathBuf::from(".")
+    })
+}
+
 /// Shared helper: import the current transcript incrementally.
 /// Used by stop, precompact, prompt_submit, and session_end hooks.
 pub async fn import_current_transcript(input: &HookInput, engine: &Engine, cwd: &Path) {
@@ -214,32 +267,7 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
         input.session_id.is_some(),
     ));
 
-    // Determine CWD: prefer input.cwd, fall back to process CWD
-    // Validate that cwd is a real directory under $HOME (S-3 fix)
-    let cwd = if let Some(ref dir) = input.cwd {
-        let p = std::path::PathBuf::from(dir);
-        if p.is_dir() {
-            let canonical = p.canonicalize()?;
-            // S-3 check, Windows-fixed: canonicalize() returns a \\?\-prefixed
-            // path, so the raw home_dir() never prefix-matched and this bailed
-            // on EVERY hook that carried a cwd — compare canonical vs canonical.
-            // And outside-home is a warning, not an error: projects legitimately
-            // live on other drives (D:\...), and a hook that dies here silently
-            // disables both injection and live transcript import.
-            let home_ok = dirs::home_dir()
-                .and_then(|h| h.canonicalize().ok())
-                .map(|h| canonical.starts_with(&h))
-                .unwrap_or(false);
-            if !home_ok {
-                eprintln!("CSR: cwd {} outside home (allowed)", canonical.display());
-            }
-            canonical
-        } else {
-            std::env::current_dir()?
-        }
-    } else {
-        std::env::current_dir()?
-    };
+    let cwd = resolve_hook_cwd(input.cwd.as_deref());
 
     let t_setup = t0.elapsed();
 
@@ -322,6 +350,26 @@ mod tests {
             matches!(outcome, StdinRead::Empty),
             "whitespace-only input is empty, not a payload"
         );
+    }
+
+    #[test]
+    fn resolve_hook_cwd_never_fails() {
+        // A real directory is taken and canonicalized.
+        let real = std::env::temp_dir();
+        assert_eq!(
+            resolve_hook_cwd(Some(&real.to_string_lossy())),
+            real.canonicalize().unwrap()
+        );
+
+        // A cwd that is not a directory, and no cwd at all, both fall back to the
+        // process directory instead of aborting the hook.
+        let here = std::env::current_dir().unwrap();
+        assert_eq!(
+            resolve_hook_cwd(Some("/definitely/not/a/directory/csr-test")),
+            here
+        );
+        assert_eq!(resolve_hook_cwd(None), here);
+        assert_eq!(resolve_hook_cwd(Some("")), here);
     }
 
     #[test]

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -49,8 +49,27 @@ pub struct HookInput {
     pub source: Option<String>,
 }
 
-/// Read and parse JSON from stdin. Returns a default HookInput if stdin is empty or invalid.
-/// Guards against hanging when invoked from a terminal (S-4 fix).
+/// How long the hook waits for the piped JSON before giving up.
+///
+/// `read_to_string` returns at EOF, so a parent that opens the pipe, writes
+/// nothing and keeps its write handle open would block the hook — and with it the
+/// session — forever. A hook must never block Claude Code, so the read is bounded.
+const STDIN_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2000);
+
+/// What reading stdin produced. Separated from the read itself so the outcomes and
+/// their logging are testable without a real pipe.
+#[derive(Debug)]
+enum StdinRead {
+    Payload(String),
+    Empty,
+    TimedOut,
+    Failed(String),
+}
+
+/// Read and parse JSON from stdin. Returns a default HookInput if stdin is empty,
+/// unreadable, invalid or too slow: a hook never fails because of its input.
+/// Guards against hanging when invoked from a terminal (S-4 fix) and against a
+/// parent that never closes the pipe.
 pub fn read_stdin_json() -> HookInput {
     use std::io::IsTerminal;
 
@@ -60,9 +79,47 @@ pub fn read_stdin_json() -> HookInput {
         return HookInput::default();
     }
 
-    let mut buf = String::new();
-    match std::io::stdin().read_to_string(&mut buf) {
-        Ok(_) if !buf.trim().is_empty() => match serde_json::from_str(&buf) {
+    hook_input_from(read_bounded(STDIN_READ_TIMEOUT, || {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map(|_| buf)
+    }))
+}
+
+/// Run `read` on its own thread and give up after `timeout`.
+///
+/// The reader thread is deliberately detached rather than joined: when the timeout
+/// fires it is still parked on a pipe nobody is going to close, and this process is
+/// about to exit anyway.
+fn read_bounded<F>(timeout: std::time::Duration, read: F) -> StdinRead
+where
+    F: FnOnce() -> std::io::Result<String> + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome = match read() {
+            Ok(buf) if buf.trim().is_empty() => StdinRead::Empty,
+            Ok(buf) => StdinRead::Payload(buf),
+            Err(e) => StdinRead::Failed(e.to_string()),
+        };
+        let _ = tx.send(outcome);
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(outcome) => outcome,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => StdinRead::TimedOut,
+        // The reader vanished without reporting. Unreadable is not the same as empty.
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            StdinRead::Failed("reader thread disconnected".to_string())
+        }
+    }
+}
+
+/// Turn a stdin read into a HookInput, recording *why* an input was unusable —
+/// empty, unreadable, too slow and unparseable used to be one indistinguishable
+/// `hook=0ms` line.
+fn hook_input_from(read: StdinRead) -> HookInput {
+    match read {
+        StdinRead::Payload(buf) => match serde_json::from_str(&buf) {
             Ok(input) => input,
             Err(e) => {
                 // A parse failure here silently degrades to Default (no prompt,
@@ -75,8 +132,19 @@ pub fn read_stdin_json() -> HookInput {
                 HookInput::default()
             }
         },
-        _ => {
+        StdinRead::Empty => {
             crate::telemetry::append_timing_line("CSR stdin: empty (no JSON piped)");
+            HookInput::default()
+        }
+        StdinRead::TimedOut => {
+            crate::telemetry::append_timing_line(&format!(
+                "CSR stdin: no EOF within {}ms, giving up (parent still holds the pipe)",
+                STDIN_READ_TIMEOUT.as_millis()
+            ));
+            HookInput::default()
+        }
+        StdinRead::Failed(e) => {
+            crate::telemetry::append_timing_line(&format!("CSR stdin: read FAILED: {}", e));
             HookInput::default()
         }
     }
@@ -214,4 +282,66 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
     crate::telemetry::append_timing_line(&timing_line);
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn read_bounded_gives_up_instead_of_hanging() {
+        // Stands in for a parent that opened the pipe and never closes it.
+        let started = Instant::now();
+        let outcome = read_bounded(Duration::from_millis(20), || {
+            std::thread::sleep(Duration::from_secs(30));
+            Ok(String::new())
+        });
+        assert!(
+            matches!(outcome, StdinRead::TimedOut),
+            "a read that never finishes must time out, got {outcome:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the hook must not wait for the reader"
+        );
+    }
+
+    #[test]
+    fn read_bounded_reports_io_errors_separately_from_empty() {
+        let outcome = read_bounded(Duration::from_secs(5), || {
+            Err(std::io::Error::other("pipe exploded"))
+        });
+        match outcome {
+            StdinRead::Failed(e) => assert!(e.contains("pipe exploded")),
+            other => panic!("an I/O failure must not be reported as empty, got {other:?}"),
+        }
+
+        let outcome = read_bounded(Duration::from_secs(5), || Ok("  \n".to_string()));
+        assert!(
+            matches!(outcome, StdinRead::Empty),
+            "whitespace-only input is empty, not a payload"
+        );
+    }
+
+    #[test]
+    fn hook_input_from_parses_a_payload_and_degrades_otherwise() {
+        let input = hook_input_from(StdinRead::Payload(
+            r#"{"prompt":"hola","cwd":"/tmp/proj"}"#.to_string(),
+        ));
+        assert_eq!(input.prompt.as_deref(), Some("hola"));
+        assert_eq!(input.cwd.as_deref(), Some("/tmp/proj"));
+
+        // Every unusable outcome degrades to a default input rather than failing:
+        // the hook still runs, it just has nothing to work with.
+        for unusable in [
+            StdinRead::Payload("not json".to_string()),
+            StdinRead::Empty,
+            StdinRead::TimedOut,
+            StdinRead::Failed("boom".to_string()),
+        ] {
+            let input = hook_input_from(unusable);
+            assert!(input.prompt.is_none() && input.transcript_path.is_none());
+        }
+    }
 }

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -189,6 +189,15 @@ fn resolve_hook_cwd(input_cwd: Option<&str>) -> PathBuf {
             }
             return resolved;
         }
+        // A cwd arrived but does not name a directory. Falling back is the right
+        // behaviour, but doing it silently is exactly how the Windows breakage
+        // above survived unnoticed for so long — leave a line so the next one is
+        // diagnosable from the log alone.
+        // Quoted, not `Display`: an empty cwd is a real case and prints as nothing,
+        // which reads as a corrupt log line rather than the anomaly it is.
+        crate::telemetry::append_timing_line(&format!(
+            "CSR cwd: input cwd {dir:?} is not a directory — falling back to current_dir()"
+        ));
     }
 
     std::env::current_dir().unwrap_or_else(|e| {

--- a/csr-engine/src/search/cross_project.rs
+++ b/csr-engine/src/search/cross_project.rs
@@ -7,6 +7,24 @@ pub fn resolve_project_from_cwd(cwd: &str) -> Option<String> {
         return None;
     }
 
+    // Windows drive path ("D:\Claude", or "\\?\D:\Claude" after canonicalize):
+    // stored project names are Claude Code's ~/.claude/projects folder names,
+    // which encode the FULL path with every non-alphanumeric char as '-'
+    // ("D:\Claude" → "D--Claude"). The last-component fallback below returned
+    // "Claude", which matches no stored project and silently emptied every
+    // project-scoped search. Hooks receive the project root as cwd, so no
+    // component-walking is needed here.
+    let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
+    let trimmed = stripped.trim_end_matches(['\\', '/']);
+    if trimmed.len() >= 2 && trimmed.as_bytes()[1] == b':' {
+        return Some(
+            trimmed
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect(),
+        );
+    }
+
     let path = std::path::Path::new(cwd);
     let dir_name = path.file_name()?.to_string_lossy().to_string();
 

--- a/csr-engine/src/search/cross_project.rs
+++ b/csr-engine/src/search/cross_project.rs
@@ -159,4 +159,36 @@ mod tests {
         let result = resolve_project_from_cwd("/tmp/something/mydir");
         assert_eq!(result, Some("mydir".to_string()));
     }
+
+    /// Pins the stored project-name contract for Windows drive paths.
+    ///
+    /// Deliberately NOT `#[cfg(windows)]`-gated: the code path under test is pure
+    /// string handling with no platform-conditional code, so gating it would only
+    /// hide the regression from the CI that actually runs — which has no Windows
+    /// job. A hook can deliver `cwd` raw, `\\?\`-canonicalized, with a trailing
+    /// separator, or any combination of those, and every shape has to land on the
+    /// same stored name or project-scoped search silently returns nothing.
+    #[test]
+    fn test_resolve_from_cwd_windows_drive_paths() {
+        for cwd in [
+            r"D:\Claude",
+            r"\\?\D:\Claude",
+            "D:\\Claude\\",
+            "\\\\?\\D:\\Claude\\",
+        ] {
+            assert_eq!(
+                resolve_project_from_cwd(cwd),
+                Some("D--Claude".to_string()),
+                "cwd {cwd:?} must encode to the stored project name"
+            );
+        }
+
+        // The encoding covers the whole path, not just the last component — that
+        // was the original bug: "D:\Claude" resolved to "Claude", which matches no
+        // stored project.
+        assert_eq!(
+            resolve_project_from_cwd(r"D:\Proyectos\claude-self-reflect"),
+            Some("D--Proyectos-claude-self-reflect".to_string())
+        );
+    }
 }


### PR DESCRIPTION
## The problem

On Windows every `csr-engine hook <name>` invocation returned in ~0 ms without searching or
importing anything. Three independent causes, all in the hook path:

**1. The S-3 home-directory guard can never pass.** `dispatch_hook` canonicalizes `input.cwd`
and compares it against `dirs::home_dir()`. On Windows `canonicalize()` returns a `\\?\`-prefixed
path (`\\?\C:\Users\me\proj`) while `home_dir()` returns `C:\Users\me`, so the `starts_with`
check fails for *every* path — including paths that really are inside `$HOME` — and the hook
bails with `cwd ... is outside home directory`. Any invocation carrying a `cwd` dies here, which
is all of them from a real session.

**2. `resolve_project_from_cwd` returns a name that matches nothing.** It falls back to the last
path component, so `D:\Claude` becomes `"Claude"`, while chunks are stored under Claude Code's
encoded project-folder name, `"D--Claude"` (every non-alphanumeric character becomes `-`). The
project filter then matched no rows, so project-scoped searches silently returned nothing —
no error, just empty results.

**3. None of this was observable.** Empty stdin, a JSON parse failure and a missing prompt all
produced the same `hook=0ms` line, so the three cases were indistinguishable from "nothing to do".

## The change

1. Compare canonical against canonical, and demote outside-`$HOME` from a hard error to a warning
   on stderr. Two reasons for the demotion rather than just fixing the prefix: on Windows projects
   legitimately live on another volume (`D:\...`), which no amount of canonicalization will make a
   child of `C:\Users\...`; and dying here also disables live transcript import, not only
   injection, since the hook is the only place `transcript_path` is seen. If you would rather keep
   the guard hard, I am happy to make the relaxation `#[cfg(windows)]`-only — your call.
2. Drive-letter paths (with or without the `\\?\` prefix) are encoded to the stored form.
   Hooks receive the project root as `cwd`, so no component walking is needed.
3. `read_stdin_json` logs which of the three states it hit, and `dispatch_hook` logs
   field presence (`prompt_len`, `cwd`, `transcript`, `session`). This is what made the rest
   of the diagnosis possible.

**No behaviour change on Unix**: the canonical-vs-canonical comparison is equivalent where
`canonicalize()` adds no prefix, and the drive-letter branch cannot be reached by a POSIX path.

## Verification

Windows 11, `stable-x86_64-pc-windows-msvc` (rustc 1.97.1):

- `cargo test --release --lib` — **615 passed, 0 failed**
- `cargo fmt --check`, `cargo clippy --release -- -D warnings` — clean
- Live, in a real desktop-app session: hooks now execute with `transcript=true`, and the index
  resumed growing after being frozen at 7133 chunks since setup:

```
CSR hook post-tool-use input: prompt_len=0 cwd=Some("D:\\Claude") transcript=true session=true
CSR hook stop input: prompt_len=0 cwd=Some("D:\\Claude") transcript=true session=true
CSR prompt-submit inject: items=2 anti=0 stdout=640B top=[0.538/chunk, 0.462/reflection]
```

One note on how I ran the tests. This branch is based on `main`, which does not compile on
Windows until #271 (the `ino()` portability fix) lands, so I ran the suite on a branch that also
carries that one-line fix. The two files touched here are byte-identical between the two branches.
The changes are independent — merge them in either order.

I did not add tests. `resolve_project_from_cwd` has an obvious unit-test shape and I would gladly
add one; I did not want to guess at where you want Windows-conditional assertions to live.

## One more Windows bug, not fixed here

While tracking the above I found the reason the hooks were not merely failing but never starting.
`hooks/install.rs` builds each entry as `format!("{} hook ...", binary_path)` from
`current_exe()`. On Windows that is `D:\path\to\csr-engine.exe`, and the resulting `settings.json`
command string is executed through a POSIX shell, which treats the backslashes as escapes:

```
D:pathtocsr-engine.exe: command not found     (exit 127)
```

So `csr-engine setup` on Windows installs seven hooks that cannot run, and since the process never
starts, nothing reaches `hook-timing.log` — which is exactly why I first assumed the hooks were
not being invoked at all. Rewriting those paths with forward slashes (accepted by both `sh` and
`cmd`) made all seven fire immediately; that is how the live evidence above was produced.

I left the fix out of this PR to keep it reviewable — it is a separate concern in a separate
module. Say the word and I will send it as its own one-line change: normalize the separators when
building the command strings on Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of piped and interactive input by preventing stalled reads, providing clearer diagnostics for empty or invalid input, and safely using default values when needed.
  * Improved hook reliability with safer working-directory handling, including valid paths outside the home directory.
  * Added more useful execution diagnostics and timing information.
  * Fixed project resolution for Windows drive paths and improved path normalization to prevent incorrect project names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->