### PR TITLE
10.1 recap layer: one causal paragraph at SessionStart, dream-audited and abstention-first

### DIFF
--- a/csr-engine/src/extraction/provenance.rs
+++ b/csr-engine/src/extraction/provenance.rs
@@ -164,6 +164,15 @@ pub fn is_csr_emission(text: &str) -> bool {
     if EMISSION_HEADERS.iter().any(|h| head.contains(h)) {
         return true;
     }
+    // Injected recaps open with `recap [<age>]: ` (hooks::recap). Match that
+    // exact grammar — short bracket then "]: " — instead of a bare "recap ["
+    // substring, so genuine prose like "recap [the auth changes], then
+    // prioritize them" stays extractable (a contains-header would eat it).
+    if let Some(rest) = head.trim_start().strip_prefix("recap [") {
+        if rest.find("]: ").is_some_and(|i| i <= 24) {
+            return true;
+        }
+    }
     EMISSION_FIELD_TOKENS
         .iter()
         .filter(|t| text.contains(**t))

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -11,6 +11,7 @@ pub mod intent;
 pub mod post_tool_use;
 pub mod precompact;
 pub mod prompt_submit;
+pub mod recap;
 pub mod session_briefing;
 pub mod session_end;
 pub mod session_start;

--- a/csr-engine/src/hooks/recap.rs
+++ b/csr-engine/src/hooks/recap.rs
@@ -1,0 +1,915 @@
+//! Deterministic recap composition from a stored episode and evidence feeds.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static XML_TAG_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<[^>]{1,50}>").unwrap());
+static MD_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"#{1,4}\s+").unwrap());
+
+/// Maximum open facts accepted by the composer and requested by storage callers.
+pub const STILL_OPEN_LIMIT: usize = 3;
+
+/// A resolution associated with the current project.
+pub struct SettledFact {
+    pub claim: String,
+    pub receipt: String,
+    pub status: String,
+}
+
+/// A previously held line invalidated while the user was away.
+pub struct RetiredLine {
+    pub label: String,
+    pub receipt_oid: String,
+    pub date: String,
+}
+
+/// Evidence feeds supplied by storage.
+///
+/// Feed text is trusted, already-curated database content: its semantic content
+/// passes through without provenance filtering. Structural whitespace is
+/// collapsed so a database value cannot create additional recap lines.
+pub struct RecapFeeds {
+    pub settled: Vec<SettledFact>,
+    pub still_open: Vec<SettledFact>,
+    pub retired_while_away: Vec<RetiredLine>,
+    pub open_proposals: usize,
+}
+
+/// Compose an evidence-backed recap without reading external state.
+pub fn compose_recap(
+    ep: &crate::hooks::stop::Episode,
+    feeds: &RecapFeeds,
+    age: &str,
+) -> Option<String> {
+    const MAX_CHARS: usize = 700;
+
+    use crate::extraction::provenance::extractable;
+
+    let intent = extractable(&ep.request)
+        .map(|text| compact_preview(&text, 80))
+        .filter(|text| has_substance(text));
+    let completed = extractable(&ep.completed)
+        .map(|text| conclusion_preview(&text, 120))
+        .filter(|text| has_substance(text));
+    if intent.is_none() && completed.is_none() {
+        return None;
+    }
+
+    let mut recap = match (intent.as_deref(), completed.as_deref()) {
+        (Some(intent), Some(completed)) => format!("recap [{age}]: {intent}: {completed}."),
+        (Some(intent), None) => format!("recap [{age}]: {intent}."),
+        (None, Some(completed)) => format!("recap [{age}]: {completed}."),
+        (None, None) => unreachable!("empty episodes abstain above"),
+    };
+
+    let settled_entries: Vec<String> = feeds
+        .settled
+        .iter()
+        .filter(|fact| fact.status == "resolved")
+        .filter(|fact| !normalize_feed_text(&fact.receipt).is_empty())
+        .take(3)
+        .map(format_fact)
+        .collect();
+
+    let mut now_parts = Vec::new();
+    if let Some(blocker) = ep
+        .blockers
+        .as_deref()
+        .and_then(extractable)
+        .map(|text| compact_preview(&text, 120))
+        .filter(|text| has_substance(text))
+    {
+        now_parts.push(blocker);
+    }
+    now_parts.extend(
+        feeds
+            .still_open
+            .iter()
+            .take(STILL_OPEN_LIMIT)
+            .filter(|fact| fact.status != "resolved")
+            .filter(|fact| !normalize_feed_text(&fact.receipt).is_empty())
+            .map(format_fact),
+    );
+    if feeds.open_proposals > 0 {
+        now_parts.push(format!(
+            "{} proposals awaiting csr_resolve",
+            feeds.open_proposals
+        ));
+    }
+    let open_todos = ep
+        .todos
+        .iter()
+        .filter(|todo| todo.status != "completed")
+        .count();
+    if open_todos > 0 {
+        now_parts.push(format!("{open_todos} todos open"));
+    }
+    let next = ep.next_steps.as_deref().and_then(next_preview).or_else(|| {
+        ep.todos
+            .iter()
+            .filter(|todo| todo.status != "completed")
+            .find_map(|todo| next_preview(&todo.content))
+    });
+
+    let retired_entries: Vec<String> = feeds
+        .retired_while_away
+        .iter()
+        .filter(|line| !normalize_feed_text(&line.receipt_oid).is_empty())
+        .take(2)
+        .map(|line| {
+            format!(
+                "{} (superseded {}, {})",
+                normalize_feed_text(&line.label),
+                normalize_feed_text(&line.date),
+                normalize_feed_text(&line.receipt_oid)
+            )
+        })
+        .collect();
+    let next_line = next.map(|next| format!("Next: {next}."));
+
+    // Reserve one whole entry for every eligible evidence-list clause before
+    // using any residual budget for extras. If the minimum set itself cannot
+    // fit, drop its largest list clause rather than truncating an entry.
+    let mut clauses = [
+        ListClause::new("Settled: ", "; ", settled_entries),
+        ListClause::new("Now: ", " | ", now_parts),
+        ListClause::new("Learnt-then-retired while away: ", "; ", retired_entries),
+    ];
+    let mut used = recap.chars().count()
+        + next_line
+            .as_ref()
+            .map_or(0, |line| line.chars().count() + 1)
+        + clauses
+            .iter()
+            .map(ListClause::reserved_chars)
+            .sum::<usize>();
+
+    while used > MAX_CHARS {
+        let Some((index, chars)) = clauses
+            .iter()
+            .enumerate()
+            .filter_map(|(index, clause)| {
+                let chars = clause.reserved_chars();
+                (chars > 0).then_some((index, chars))
+            })
+            .max_by_key(|(_, chars)| *chars)
+        else {
+            break;
+        };
+        clauses[index].drop_entries();
+        used -= chars;
+    }
+
+    let mut remaining = MAX_CHARS.saturating_sub(used);
+    for clause in &mut clauses {
+        clause.add_entries_within(&mut remaining);
+    }
+
+    for line in clauses
+        .iter()
+        .filter_map(ListClause::render)
+        .chain(next_line)
+    {
+        recap.push('\n');
+        recap.push_str(&line);
+    }
+
+    Some(recap)
+}
+
+struct ListClause {
+    prefix: &'static str,
+    separator: &'static str,
+    entries: Vec<String>,
+    selected: usize,
+}
+
+impl ListClause {
+    fn new(prefix: &'static str, separator: &'static str, entries: Vec<String>) -> Self {
+        let selected = usize::from(!entries.is_empty());
+        Self {
+            prefix,
+            separator,
+            entries,
+            selected,
+        }
+    }
+
+    fn reserved_chars(&self) -> usize {
+        self.render().map_or(0, |line| line.chars().count() + 1)
+    }
+
+    fn drop_entries(&mut self) {
+        self.selected = 0;
+    }
+
+    fn add_entries_within(&mut self, remaining: &mut usize) {
+        if self.selected == 0 {
+            return;
+        }
+        while let Some(entry) = self.entries.get(self.selected) {
+            let needed = self.separator.chars().count() + entry.chars().count();
+            if needed > *remaining {
+                break;
+            }
+            *remaining -= needed;
+            self.selected += 1;
+        }
+    }
+
+    fn render(&self) -> Option<String> {
+        (self.selected > 0).then(|| {
+            format!(
+                "{}{}.",
+                self.prefix,
+                self.entries[..self.selected].join(self.separator)
+            )
+        })
+    }
+}
+
+fn format_fact(fact: &SettledFact) -> String {
+    let claim = normalize_feed_text(&fact.claim);
+    let claim = if claim.is_empty() {
+        "evidence".to_string()
+    } else {
+        claim
+    };
+    format!("{claim} ({})", normalize_feed_text(&fact.receipt))
+}
+
+fn normalize_feed_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_next_prefix(text: &str) -> &str {
+    let trimmed = text.trim_start();
+    let lower = trimmed.to_lowercase();
+    for prefix in ["next steps:", "next step:", "next:"] {
+        if lower.starts_with(prefix) {
+            return trimmed[prefix.len()..].trim_start();
+        }
+    }
+    trimmed
+}
+
+fn next_preview(text: &str) -> Option<String> {
+    let extracted = crate::extraction::provenance::extractable(text)?;
+    let preview = compact_preview(strip_next_prefix(&extracted), 80);
+    (!preview.is_empty() && !is_no_evidence_next(&preview)).then_some(preview)
+}
+
+/// Evidence requires at least one alphanumeric character: values like "…",
+/// "/", or "-*-" are punctuation-only sentinels, not content, and every
+/// clause gate must treat them as absent (abstention-first).
+fn has_substance(text: &str) -> bool {
+    text.chars().any(char::is_alphanumeric)
+}
+
+fn is_no_evidence_next(text: &str) -> bool {
+    if !has_substance(text) {
+        return true;
+    }
+    let normalized = text
+        .trim()
+        .trim_matches(|character: char| character.is_ascii_punctuation() && character != '/')
+        .trim()
+        .to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "" | "none" | "nothing" | "n/a" | "no next step" | "no next steps"
+    )
+}
+
+fn compact_preview(content: &str, max_chars: usize) -> String {
+    let clean = sanitize_preview(content);
+    if clean.chars().count() <= max_chars {
+        return clean;
+    }
+    let end = clean
+        .char_indices()
+        .nth(max_chars)
+        .map_or(clean.len(), |(index, _)| index);
+    format!("{}...", &clean[..end])
+}
+
+fn conclusion_preview(content: &str, max_chars: usize) -> String {
+    let clean = sanitize_preview(content);
+    if clean.chars().count() <= max_chars {
+        return clean;
+    }
+
+    const ELLIPSIS: &str = " … ";
+    let sentences = split_preview_sentences(&clean);
+    if sentences.is_empty() {
+        return truncate_at_word_boundary(&clean, max_chars);
+    }
+
+    let verdict = if let Some((span_start, span_end)) = find_bold_verdict_span(&clean) {
+        let (start, end) = sentences
+            .iter()
+            .copied()
+            .find(|&(start, end)| start <= span_start && span_end <= end)
+            .unwrap_or((span_start, span_end));
+        strip_bold_markers(&clean[start..end])
+    } else {
+        let (start, end) = sentences[0];
+        strip_bold_markers(&clean[start..end])
+    };
+
+    let mut result = verdict;
+    if result.chars().count() < max_chars * 3 / 5 {
+        if let Some(last) = sentences.iter().rev().find_map(|&(start, end)| {
+            let sentence = clean[start..end].trim();
+            if sentence.is_empty() || is_non_sentence_fragment(sentence) {
+                return None;
+            }
+            let stripped = strip_bold_markers(sentence);
+            (stripped != result).then_some(stripped)
+        }) {
+            result = format!("{result}{ELLIPSIS}{last}");
+        }
+    }
+
+    if result.chars().count() > max_chars {
+        result = truncate_at_word_boundary(&result, max_chars);
+    }
+    result
+}
+
+fn split_preview_sentences(text: &str) -> Vec<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut sentences = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+    while index < bytes.len() {
+        if matches!(bytes[index], b'.' | b'!' | b'?') {
+            let punctuation = bytes[index];
+            let mut end = index + 1;
+            while end < bytes.len() && bytes[end] == punctuation {
+                end += 1;
+            }
+            if bytes.get(end) == Some(&b'*') && bytes.get(end + 1) == Some(&b'*') {
+                end += 2;
+            }
+            if end >= bytes.len() || bytes[end] == b' ' {
+                let slice = &text[start..end];
+                let trim_start = slice.len() - slice.trim_start().len();
+                let trim_end = slice.trim_end().len();
+                if trim_end > trim_start {
+                    sentences.push((start + trim_start, start + trim_end));
+                }
+                while end < bytes.len() && bytes[end] == b' ' {
+                    end += 1;
+                }
+                start = end;
+                index = end;
+                continue;
+            }
+        }
+        index += 1;
+    }
+    if start < text.len() {
+        let slice = &text[start..];
+        let trim_start = slice.len() - slice.trim_start().len();
+        let trim_end = slice.trim_end().len();
+        if trim_end > trim_start {
+            sentences.push((start + trim_start, start + trim_end));
+        }
+    }
+    sentences
+}
+
+fn find_bold_verdict_span(text: &str) -> Option<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut index = 0;
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'*' && bytes[index + 1] == b'*' {
+            let inner_start = index + 2;
+            let mut close = inner_start;
+            while close + 1 < bytes.len() {
+                if bytes[close] == b'*' && bytes[close + 1] == b'*' {
+                    if text[inner_start..close].trim().chars().count() >= 10 {
+                        return Some((index, close + 2));
+                    }
+                    index = close + 2;
+                    break;
+                }
+                close += 1;
+            }
+            if close + 1 >= bytes.len() {
+                break;
+            }
+            continue;
+        }
+        index += 1;
+    }
+    None
+}
+
+fn strip_bold_markers(text: &str) -> String {
+    text.replace("**", "")
+}
+
+fn is_non_sentence_fragment(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.starts_with('|') || trimmed.contains("```")
+}
+
+fn truncate_at_word_boundary(text: &str, max_chars: usize) -> String {
+    const ELLIPSIS: &str = "...";
+    let budget = max_chars.saturating_sub(ELLIPSIS.chars().count());
+    let byte_limit = text
+        .char_indices()
+        .nth(budget)
+        .map_or(text.len(), |(index, _)| index);
+    let window = &text[..byte_limit];
+    let cut = window.rfind(char::is_whitespace).unwrap_or(byte_limit);
+    format!("{}{ELLIPSIS}", window[..cut].trim_end())
+}
+
+fn sanitize_preview(text: &str) -> String {
+    let no_literal_newline = text.replace("\\n", " ");
+    let no_xml = XML_TAG_RE.replace_all(&no_literal_newline, "");
+    let no_markdown = MD_HEADING_RE.replace_all(&no_xml, "");
+    let mut result = no_markdown
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    result.retain(|character| !character.is_control() || character == ' ');
+    result.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::stop::{Episode, TodoItem};
+
+    fn episode() -> Episode {
+        Episode {
+            schema: "session_episode/v2".into(),
+            session_id: "session-1".into(),
+            project: "csr".into(),
+            timestamp: "2026-08-07T10:00:00Z".into(),
+            request: "Fix\nthe recap composer".into(),
+            investigated: vec![],
+            completed: "Implemented deterministic recap output".into(),
+            next_steps: Some("Run the integration suite".into()),
+            blockers: Some("waiting for storage migration".into()),
+            outcome: "partial".into(),
+            error_signatures: vec![],
+            tools_used: vec![],
+            files_modified: vec![],
+            message_count: 4,
+            duration_minutes: 12,
+            todos: vec![
+                TodoItem {
+                    content: "wire session start".into(),
+                    status: "pending".into(),
+                },
+                TodoItem {
+                    content: "write composer".into(),
+                    status: "completed".into(),
+                },
+            ],
+            approved_plan: None,
+            prev_episode_id: None,
+            anchors: vec![],
+        }
+    }
+
+    fn full_feeds() -> RecapFeeds {
+        RecapFeeds {
+            settled: vec![
+                SettledFact {
+                    claim: "schema is stable".into(),
+                    receipt: "810283b".into(),
+                    status: "resolved".into(),
+                },
+                SettledFact {
+                    claim: "queries are indexed".into(),
+                    receipt: "T2 2026-07-27".into(),
+                    status: "resolved".into(),
+                },
+            ],
+            still_open: vec![SettledFact {
+                claim: "Windows path behavior".into(),
+                receipt: "91abcde".into(),
+                status: "still_open".into(),
+            }],
+            retired_while_away: vec![RetiredLine {
+                label: "old schema assumption".into(),
+                receipt_oid: "77fedca".into(),
+                date: "2026-08-06".into(),
+            }],
+            open_proposals: 2,
+        }
+    }
+
+    #[test]
+    fn composes_full_recap_in_causal_clause_order() {
+        let got = compose_recap(&episode(), &full_feeds(), "28m ago").unwrap();
+        assert_eq!(
+            got,
+            "recap [28m ago]: Fix the recap composer: Implemented deterministic recap output.\n\
+             Settled: schema is stable (810283b); queries are indexed (T2 2026-07-27).\n\
+             Now: waiting for storage migration | Windows path behavior (91abcde) | 2 proposals awaiting csr_resolve | 1 todos open.\n\
+             Learnt-then-retired while away: old schema assumption (superseded 2026-08-06, 77fedca).\n\
+             Next: Run the integration suite."
+        );
+    }
+
+    #[test]
+    fn abstains_when_request_and_completed_are_provenance_filtered() {
+        let mut ep = episode();
+        ep.request = "CSR CONTINUUM [2m ago]: prior state".into();
+        ep.completed = "## Session Intelligence (CSR v9.2)".into();
+        assert_eq!(compose_recap(&ep, &full_feeds(), "2m ago"), None);
+    }
+
+    #[test]
+    fn omits_next_without_next_steps_or_open_todos() {
+        let mut ep = episode();
+        ep.next_steps = None;
+        ep.todos.clear();
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "1h ago").unwrap();
+        assert!(!got.contains("\nNext:"));
+    }
+
+    #[test]
+    fn rejects_none_next_sentinels_and_uses_later_substantive_todo() {
+        let mut ep = episode();
+        ep.next_steps = Some("Next: none".into());
+        ep.todos = vec![
+            TodoItem {
+                content: "none".into(),
+                status: "pending".into(),
+            },
+            TodoItem {
+                content: "wire session start".into(),
+                status: "pending".into(),
+            },
+        ];
+
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "1h ago").unwrap();
+        assert!(got.ends_with("Next: wire session start."));
+        assert!(!got.contains("Next: none"));
+    }
+
+    #[test]
+    fn rejects_punctuation_only_next_values_and_uses_later_substantive_todo() {
+        let mut ep = episode();
+        ep.next_steps = Some(".".into());
+        ep.todos = vec![
+            TodoItem {
+                content: "...".into(),
+                status: "pending".into(),
+            },
+            TodoItem {
+                content: "wire session start".into(),
+                status: "pending".into(),
+            },
+        ];
+
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "1h ago").unwrap();
+        assert!(got.ends_with("Next: wire session start."));
+    }
+
+    #[test]
+    fn rejects_unicode_punctuation_only_next_values_and_uses_later_substantive_todo() {
+        let mut ep = episode();
+        ep.next_steps = Some("\u{2026}".into()); // "…" — non-ASCII punctuation
+        ep.todos = vec![
+            TodoItem {
+                content: "/".into(), // preserved by the ASCII trim, still no evidence
+                status: "pending".into(),
+            },
+            TodoItem {
+                content: "wire session start".into(),
+                status: "pending".into(),
+            },
+        ];
+
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "1h ago").unwrap();
+        assert!(got.ends_with("Next: wire session start."));
+        assert!(!got.contains("Next: \u{2026}"));
+        assert!(!got.contains("Next: /"));
+    }
+
+    #[test]
+    fn abstains_when_request_and_completed_are_punctuation_only() {
+        let mut ep = episode();
+        ep.request = "\u{2026}".into();
+        ep.completed = "/".into();
+        assert!(compose_recap(&ep, &RecapFeeds::empty(), "1h ago").is_none());
+    }
+
+    #[test]
+    fn omits_punctuation_only_blocker_from_now_clause() {
+        let mut ep = episode();
+        ep.blockers = Some("\u{2026}".into());
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "1h ago").unwrap();
+        assert!(!got.contains('\u{2026}'));
+    }
+
+    #[test]
+    fn skips_settled_fact_without_mandatory_receipt() {
+        let feeds = RecapFeeds {
+            settled: vec![
+                SettledFact {
+                    claim: "unreceipted".into(),
+                    receipt: "".into(),
+                    status: "resolved".into(),
+                },
+                SettledFact {
+                    claim: "receipted".into(),
+                    receipt: "abc1234".into(),
+                    status: "resolved".into(),
+                },
+            ],
+            ..RecapFeeds::empty()
+        };
+        let got = compose_recap(&episode(), &feeds, "now").unwrap();
+        assert!(got.contains("Settled: receipted (abc1234)."));
+        assert!(!got.contains("unreceipted"));
+    }
+
+    #[test]
+    fn enforces_fact_status_partition_at_emission() {
+        let feeds = RecapFeeds {
+            settled: vec![
+                SettledFact {
+                    claim: "actually resolved".into(),
+                    receipt: "abc1234".into(),
+                    status: "resolved".into(),
+                },
+                SettledFact {
+                    claim: "still open in settled feed".into(),
+                    receipt: "def5678".into(),
+                    status: "still_open".into(),
+                },
+            ],
+            still_open: vec![
+                SettledFact {
+                    claim: "actually open".into(),
+                    receipt: "fed4321".into(),
+                    status: "regressed".into(),
+                },
+                SettledFact {
+                    claim: "resolved in open feed".into(),
+                    receipt: "cba8765".into(),
+                    status: "resolved".into(),
+                },
+            ],
+            ..RecapFeeds::empty()
+        };
+
+        let got = compose_recap(&episode(), &feeds, "now").unwrap();
+        assert!(got.contains("Settled: actually resolved (abc1234)."));
+        assert!(got.contains("Now: waiting for storage migration | actually open (fed4321)"));
+        assert!(!got.contains("still open in settled feed"));
+        assert!(!got.contains("resolved in open feed"));
+    }
+
+    #[test]
+    fn bounds_still_open_facts_to_shared_query_limit() {
+        let feeds = RecapFeeds {
+            still_open: (0..=STILL_OPEN_LIMIT)
+                .map(|index| SettledFact {
+                    claim: format!("open fact {index}"),
+                    receipt: format!("oid{index:04}"),
+                    status: "still_open".into(),
+                })
+                .collect(),
+            ..RecapFeeds::empty()
+        };
+
+        let got = compose_recap(&episode(), &feeds, "now").unwrap();
+        assert!(got.contains(&format!("open fact {}", STILL_OPEN_LIMIT - 1)));
+        assert!(!got.contains(&format!("open fact {STILL_OPEN_LIMIT}")));
+    }
+
+    #[test]
+    fn formats_at_most_two_retired_lines_with_receipts() {
+        let feeds = RecapFeeds {
+            retired_while_away: (1..=3)
+                .map(|n| RetiredLine {
+                    label: format!("line {n}"),
+                    receipt_oid: format!("oid000{n}"),
+                    date: format!("2026-08-0{n}"),
+                })
+                .collect(),
+            ..RecapFeeds::empty()
+        };
+        let got = compose_recap(&episode(), &feeds, "now").unwrap();
+        assert!(got.contains(
+            "Learnt-then-retired while away: line 1 (superseded 2026-08-01, oid0001); line 2 (superseded 2026-08-02, oid0002)."
+        ));
+        assert!(!got.contains("line 3"));
+    }
+
+    #[test]
+    fn settled_clause_survives_when_other_optional_clauses_are_empty() {
+        let mut ep = episode();
+        ep.blockers = None;
+        ep.next_steps = None;
+        ep.todos.clear();
+        let feeds = RecapFeeds {
+            settled: vec![SettledFact {
+                claim: "done".into(),
+                receipt: "abc1234".into(),
+                status: "resolved".into(),
+            }],
+            ..RecapFeeds::empty()
+        };
+        let got = compose_recap(&ep, &feeds, "now").unwrap();
+        assert_eq!(got.lines().count(), 2);
+        assert!(got.ends_with("Settled: done (abc1234)."));
+    }
+
+    #[test]
+    fn now_clause_survives_when_other_optional_clauses_are_empty() {
+        let mut ep = episode();
+        ep.next_steps = None;
+        ep.todos.clear();
+        ep.blockers = Some("blocked on fixture".into());
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "now").unwrap();
+        assert_eq!(got.lines().count(), 2);
+        assert!(got.ends_with("Now: blocked on fixture."));
+    }
+
+    #[test]
+    fn caps_output_and_drops_whole_receipted_entries() {
+        let mut ep = episode();
+        ep.request = "r".repeat(200);
+        ep.completed = "c".repeat(250);
+        let feeds = RecapFeeds {
+            settled: (0..4)
+                .map(|n| SettledFact {
+                    claim: format!("{}-{n}", "settled".repeat(30)),
+                    receipt: format!("receipt{n}"),
+                    status: "resolved".into(),
+                })
+                .collect(),
+            still_open: (0..4)
+                .map(|n| SettledFact {
+                    claim: format!("{}-{n}", "open".repeat(30)),
+                    receipt: format!("openoid{n}"),
+                    status: "still_open".into(),
+                })
+                .collect(),
+            retired_while_away: vec![RetiredLine {
+                label: "retired".repeat(50),
+                receipt_oid: "retired-receipt".into(),
+                date: "2026-08-07".into(),
+            }],
+            open_proposals: 8,
+        };
+        let got = compose_recap(&ep, &feeds, "now").unwrap();
+        assert!(got.chars().count() <= 700);
+        assert!(got.lines().count() <= 5);
+        for fragment in got.split([';', '\n']) {
+            if fragment.contains("settledsettled") || fragment.contains("openopen") {
+                assert!(fragment.contains(')'));
+            }
+        }
+    }
+
+    #[test]
+    fn trusted_feed_text_is_passed_through_without_provenance_filtering() {
+        let feeds = RecapFeeds {
+            settled: vec![SettledFact {
+                claim: "CSR CONTINUUM retained evidence".into(),
+                receipt: "abc1234".into(),
+                status: "resolved".into(),
+            }],
+            ..RecapFeeds::empty()
+        };
+        let got = compose_recap(&episode(), &feeds, "now").unwrap();
+        assert!(got.contains("CSR CONTINUUM retained evidence (abc1234)"));
+    }
+
+    #[test]
+    fn next_falls_back_to_first_open_todo_and_filters_episode_meta() {
+        let mut ep = episode();
+        ep.next_steps = Some("CSR CONTINUUM [2m ago]: noise".into());
+        ep.todos = vec![
+            TodoItem {
+                content: "first completed".into(),
+                status: "completed".into(),
+            },
+            TodoItem {
+                content: "ship\nthe recap".into(),
+                status: "in_progress".into(),
+            },
+        ];
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "now").unwrap();
+        assert!(got.ends_with("Next: ship the recap."));
+    }
+
+    #[test]
+    fn uses_the_surviving_episode_field_without_inventing_a_placeholder() {
+        let mut ep = episode();
+        ep.request = "CSR CONTINUUM [2m ago]: noise".into();
+        ep.next_steps = None;
+        ep.todos.clear();
+        ep.blockers = None;
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "now").unwrap();
+        assert_eq!(got, "recap [now]: Implemented deterministic recap output.");
+    }
+
+    #[test]
+    fn completed_preview_keeps_verdict_and_closing_state() {
+        let mut ep = episode();
+        ep.completed = format!(
+            "Done. {} Final verdict: 52754 chunks live.",
+            "intermediate filler sentence. ".repeat(10)
+        );
+        ep.next_steps = None;
+        ep.todos.clear();
+        ep.blockers = None;
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "now").unwrap();
+        assert!(got.contains("Done. … Final verdict: 52754 chunks live."));
+        assert!(!got.contains("intermediate filler"));
+    }
+
+    #[test]
+    fn provenance_filters_csr_meta_blockers_from_now() {
+        let mut ep = episode();
+        ep.blockers = Some("CSR CONTINUUM [2m ago]: injected state".into());
+        ep.next_steps = None;
+        ep.todos.clear();
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "now").unwrap();
+        assert!(!got.contains("\nNow:"));
+        assert!(!got.contains("injected state"));
+    }
+
+    #[test]
+    fn long_early_lists_preserve_retired_and_next_clauses() {
+        let feeds = RecapFeeds {
+            settled: (0..3)
+                .map(|n| SettledFact {
+                    claim: format!("{}-{n}", "settled evidence ".repeat(10)),
+                    receipt: format!("settled{n}"),
+                    status: "resolved".into(),
+                })
+                .collect(),
+            still_open: (0..4)
+                .map(|n| SettledFact {
+                    claim: format!("{}-{n}", "open evidence ".repeat(10)),
+                    receipt: format!("openoid{n}"),
+                    status: "still_open".into(),
+                })
+                .collect(),
+            retired_while_away: vec![RetiredLine {
+                label: "obsolete parser assumption".into(),
+                receipt_oid: "77fedca".into(),
+                date: "2026-08-06".into(),
+            }],
+            open_proposals: 3,
+        };
+        let got = compose_recap(&episode(), &feeds, "28m ago").unwrap();
+        assert!(got.contains("\nSettled:"));
+        assert!(got.contains("\nNow:"));
+        assert!(got.contains("\nLearnt-then-retired while away:"));
+        assert!(got.contains("\nNext: Run the integration suite."));
+        assert!(got.chars().count() <= 700);
+        assert!(got.lines().count() <= 5);
+    }
+
+    #[test]
+    fn multiline_trusted_feeds_are_structurally_flat_but_not_filtered() {
+        let feeds = RecapFeeds {
+            settled: vec![SettledFact {
+                claim: "CSR CONTINUUM\nretained\tevidence".into(),
+                receipt: "abc\n1234".into(),
+                status: "resolved".into(),
+            }],
+            retired_while_away: vec![RetiredLine {
+                label: "old\nline".into(),
+                receipt_oid: "77f\nedca".into(),
+                date: "2026-08-\n06".into(),
+            }],
+            ..RecapFeeds::empty()
+        };
+        let got = compose_recap(&episode(), &feeds, "now").unwrap();
+        assert!(got.contains("CSR CONTINUUM retained evidence (abc 1234)"));
+        assert!(got.contains("old line (superseded 2026-08- 06, 77f edca)"));
+        assert!(got.lines().count() <= 5);
+        assert!(got.chars().count() <= 700);
+    }
+
+    impl RecapFeeds {
+        fn empty() -> Self {
+            Self {
+                settled: vec![],
+                still_open: vec![],
+                retired_while_away: vec![],
+                open_proposals: 0,
+            }
+        }
+    }
+}

--- a/csr-engine/src/hooks/session_start.rs
+++ b/csr-engine/src/hooks/session_start.rs
@@ -145,7 +145,13 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
             .take(MAX_TIER0_VERIFY)
             .map(|a| (a.name.clone(), verify_anchor(a, cwd)))
             .collect();
-        output.push_str(&format_tier0_block(ep, &verdicts, age));
+        output.push_str(&format_session_start_tier0(
+            engine.storage(),
+            project_name,
+            ep,
+            &verdicts,
+            age,
+        ));
         output.push_str(&format_episode_index(&episodes[1..]));
         output.push_str(DEEPER_CONTEXT_FOOTER);
     } else {
@@ -574,6 +580,7 @@ fn is_session_framing_line(line: &str) -> bool {
             .any(|l| !l.trim().is_empty() && l.trim() == trimmed)
         || trimmed.starts_with("SESSION CONTINUITY DETECTED")
         || trimmed.starts_with("EPISODE INDEX")
+        || trimmed.starts_with("recap [")
 }
 
 fn focus_text_from_output_line(line: &str) -> &str {
@@ -741,6 +748,61 @@ pub fn format_tier0_block(
     anchor_verdicts: &[(String, AnchorVerdict)],
     age: &str,
 ) -> String {
+    format_tier0_block_with_recap(ep, anchor_verdicts, age, None)
+}
+
+fn recap_disabled() -> bool {
+    std::env::var("CSR_NO_RECAP")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn format_session_start_tier0(
+    storage: &crate::storage::Storage,
+    project: &str,
+    ep: &Episode,
+    anchor_verdicts: &[(String, AnchorVerdict)],
+    age: &str,
+) -> String {
+    let recap = if recap_disabled() {
+        None
+    } else {
+        let (settled, still_open) = storage
+            .recap_ledger_feeds(project, &ep.session_id)
+            .unwrap_or_else(|error| {
+                tracing::debug!(%error, "session-start recap ledger feed unavailable");
+                (Vec::new(), Vec::new())
+            });
+        let retired_while_away = storage
+            .recap_retired_since(project, &ep.timestamp)
+            .unwrap_or_else(|error| {
+                tracing::debug!(%error, "session-start recap retired feed unavailable");
+                Vec::new()
+            });
+        let open_proposals = storage
+            .recap_open_proposals(project)
+            .unwrap_or_else(|error| {
+                tracing::debug!(%error, "session-start recap proposal feed unavailable");
+                0
+            });
+        let feeds = crate::hooks::recap::RecapFeeds {
+            settled,
+            still_open,
+            retired_while_away,
+            open_proposals,
+        };
+        crate::hooks::recap::compose_recap(ep, &feeds, age)
+    };
+
+    format_tier0_block_with_recap(ep, anchor_verdicts, age, recap.as_deref())
+}
+
+fn format_tier0_block_with_recap(
+    ep: &Episode,
+    anchor_verdicts: &[(String, AnchorVerdict)],
+    age: &str,
+    recap: Option<&str>,
+) -> String {
     let open_todos = ep.todos.iter().filter(|t| t.status != "completed").count();
     let intact = anchor_verdicts
         .iter()
@@ -776,19 +838,24 @@ pub fn format_tier0_block(
 
     let outcome = display_outcome(ep, &last);
 
-    let mut out = format!(
-        "CSR CONTINUUM [{}]: {}\nLAST: {} (outcome={})\n",
-        age, request, last, outcome
-    );
-    // Only emit the NEXT/TODOS line when it carries signal — a real next step or
-    // open todos. "NEXT: none recorded | TODOS: 0 open" is pure filler.
-    if next.is_some() || open_todos > 0 {
-        out.push_str(&format!(
-            "NEXT: {} | TODOS: {} open\n",
-            next.as_deref().unwrap_or("none recorded"),
-            open_todos
-        ));
-    }
+    let mut out = if let Some(recap) = recap {
+        format!("{recap}\n")
+    } else {
+        let mut fragments = format!(
+            "CSR CONTINUUM [{}]: {}\nLAST: {} (outcome={})\n",
+            age, request, last, outcome
+        );
+        // Only emit the NEXT/TODOS line when it carries signal — a real next step or
+        // open todos. "NEXT: none recorded | TODOS: 0 open" is pure filler.
+        if next.is_some() || open_todos > 0 {
+            fragments.push_str(&format!(
+                "NEXT: {} | TODOS: {} open\n",
+                next.as_deref().unwrap_or("none recorded"),
+                open_todos
+            ));
+        }
+        fragments
+    };
     if !anchor_verdicts.is_empty() {
         out.push_str(&format!(
             "ANCHORS: {} intact, {} modified since checkpoint{}\n",
@@ -1817,6 +1884,28 @@ mod tests {
     }
 
     #[test]
+    fn prior_injected_recap_is_session_framing() {
+        assert!(is_session_framing_line(
+            "recap [2h ago]: Fixed the auth middleware regression."
+        ));
+    }
+
+    #[test]
+    fn prior_injected_recap_is_suppressed_by_extraction_provenance() {
+        // The framing guard above only shields the SwiftBar focus selector;
+        // re-indexing protection lives in provenance::extractable, which must
+        // treat an echoed recap block as a CSR emission, not user text.
+        let echoed = "recap [2h ago]: Fixed the auth middleware regression.\n\
+                      Settled: pinned action to v1 (abc1234).\n\
+                      Next: wire session start.";
+        assert!(crate::extraction::provenance::extractable(echoed).is_none());
+        // Genuine user prose that merely starts with "recap [" must survive:
+        // suppression matches the emitted `recap [<age>]: ` grammar only.
+        let genuine = "recap [the auth changes], then prioritize them for the release";
+        assert!(crate::extraction::provenance::extractable(genuine).is_some());
+    }
+
+    #[test]
     fn test_focus_text_skips_memory_manifest_and_footer_lines() {
         // Every manifest line is framing — the SwiftBar focus file must never
         // display the capability header as the "current focus".
@@ -1869,6 +1958,107 @@ mod tests {
             prev_episode_id: None,
             anchors: vec![],
         }
+    }
+
+    fn seed_recap_feeds(storage: &crate::storage::Storage, ep: &Episode) {
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO chunks
+                        (id, conversation_id, project_name, timestamp, content, message_count)
+                     VALUES ('recap-chunk', ?1, ?2, ?3, 'fixture', 1)",
+                    rusqlite::params![ep.session_id, ep.project, ep.timestamp],
+                )?;
+                conn.execute(
+                    "INSERT INTO chunks
+                        (id, conversation_id, project_name, timestamp, content, message_count)
+                     VALUES ('proposal-chunk', ?1, ?2, ?3, 'fixture', 1)",
+                    rusqlite::params![ep.session_id, ep.project, ep.timestamp],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        storage
+            .insert_resolutions(
+                &["recap-chunk".to_string()],
+                "resolved",
+                "verified at abcdef123456",
+                Some("seeded fact"),
+                "agent",
+            )
+            .unwrap();
+        storage
+            .insert_resolution_proposal(
+                "proposal-chunk",
+                Some("open proposal"),
+                "proposal evidence",
+                "proposal-session",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn session_start_tier0_renders_recap_from_seeded_feeds() {
+        let _guard = crate::daemon::dream_cadence::env_test_guard();
+        std::env::remove_var("CSR_NO_RECAP");
+        let storage = crate::storage::Storage::open_memory().unwrap();
+        let ep = minimal_episode(
+            "Fix the auth middleware regression",
+            "Fixed token validation",
+            Some("Deploy to staging"),
+        );
+        seed_recap_feeds(&storage, &ep);
+        let verdicts = vec![("validate_token".to_string(), AnchorVerdict::Intact)];
+
+        let block = format_session_start_tier0(&storage, &ep.project, &ep, &verdicts, "2h ago");
+
+        assert!(block.starts_with(
+            "recap [2h ago]: Fix the auth middleware regression: Fixed token validation."
+        ));
+        assert!(block.contains("Settled: seeded fact (abcdef1)."));
+        assert!(block.contains("1 proposals awaiting csr_resolve"));
+        assert!(!block.contains("CSR CONTINUUM"));
+        assert!(!block.contains("LAST:"));
+        assert!(block.contains("ANCHORS: 1 intact, 0 modified since checkpoint"));
+        assert!(block.contains(r#"Full state: csr_reflect_on_past("conv_s")"#));
+    }
+
+    #[test]
+    fn session_start_tier0_none_is_byte_identical_to_fragment_snapshot() {
+        let _guard = crate::daemon::dream_cadence::env_test_guard();
+        std::env::remove_var("CSR_NO_RECAP");
+        let storage = crate::storage::Storage::open_memory().unwrap();
+        let ep = minimal_episode("", "", Some("continue work"));
+
+        let block = format_session_start_tier0(&storage, &ep.project, &ep, &[], "2h ago");
+
+        assert_eq!(
+            block,
+            "CSR CONTINUUM [2h ago]: (command-only session)\n\
+LAST: (filtered: CSR meta) (outcome=success)\n\
+NEXT: continue work | TODOS: 0 open\n\
+Full state: csr_reflect_on_past(\"conv_s\")\n"
+        );
+    }
+
+    #[test]
+    fn no_recap_kill_switch_forces_fragment_snapshot() {
+        let _guard = crate::daemon::dream_cadence::env_test_guard();
+        std::env::set_var("CSR_NO_RECAP", "1");
+        let storage = crate::storage::Storage::open_memory().unwrap();
+        let ep = minimal_episode(
+            "Fix the auth middleware regression",
+            "Fixed token validation",
+            Some("Deploy to staging"),
+        );
+        seed_recap_feeds(&storage, &ep);
+
+        let block = format_session_start_tier0(&storage, &ep.project, &ep, &[], "2h ago");
+        std::env::remove_var("CSR_NO_RECAP");
+
+        assert!(block.starts_with("CSR CONTINUUM [2h ago]: Fix the auth middleware regression\n"));
+        assert!(block.contains("LAST: Fixed token validation (outcome=success)"));
+        assert!(!block.contains("recap ["));
     }
 
     #[test]

--- a/csr-engine/src/storage/chunk_binding.rs
+++ b/csr-engine/src/storage/chunk_binding.rs
@@ -707,6 +707,14 @@ mod tests {
         std::process::Command::new("git")
             .args(args)
             .current_dir(repo)
+            // Scrub repo-pinning vars git exports to hook subprocesses —
+            // under `git commit` (pre-commit runs this suite) GIT_DIR points
+            // at the OUTER repo and would hijack these temp-repo commands.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_COMMON_DIR")
             .env("GIT_AUTHOR_NAME", "CSR Test")
             .env("GIT_AUTHOR_EMAIL", "csr@example.invalid")
             .env("GIT_COMMITTER_NAME", "CSR Test")
@@ -1250,6 +1258,11 @@ mod tests {
             .args(["clone", "-q"])
             .arg(source.path())
             .arg(&clone)
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_INDEX_FILE")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_OBJECT_DIRECTORY")
+            .env_remove("GIT_COMMON_DIR")
             .output()
             .unwrap();
         assert!(clone_output.status.success());
@@ -1402,6 +1415,11 @@ mod tests {
             Command::new("git")
                 .args(args)
                 .current_dir(repo)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_INDEX_FILE")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_OBJECT_DIRECTORY")
+                .env_remove("GIT_COMMON_DIR")
                 .env("GIT_AUTHOR_NAME", "CSR Test")
                 .env("GIT_AUTHOR_EMAIL", "csr@example.invalid")
                 .env("GIT_COMMITTER_NAME", "CSR Test")

--- a/csr-engine/src/storage/migrations.rs
+++ b/csr-engine/src/storage/migrations.rs
@@ -841,6 +841,40 @@ pub fn run(conn: &Connection) -> Result<()> {
         DROP INDEX IF EXISTS idx_witness_verdicts_identity;",
     )?;
 
+    // Recap normalizes SQLite and RFC3339 timestamps through julianday(). This
+    // partial covering index matches that expression and the feed's newest-
+    // first ordering, so LIMIT can stop after three project matches.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_witness_verdicts_recap_created
+            ON witness_verdicts(
+                julianday(created_at) DESC,
+                id DESC,
+                witness_id,
+                verdict,
+                receipt_oid,
+                created_at
+            )
+            WHERE verdict IN ('superseded_by', 'anchor_obsolete');",
+    )?;
+
+    // Recap's still-open bucket starts at newest unresolved ledger events and
+    // joins chunks by primary key. This compact partial index preserves the
+    // requested id order without duplicating unbounded claim/evidence text.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_resolution_open_recent
+            ON resolution_ledger(id DESC, chunk_id, status)
+            WHERE status IN ('still_open', 'regressed');",
+    )?;
+
+    // Recap's settled bucket also credits facts authored inside this session's
+    // sidechains (`Storage::recap_ledger_feeds` provenance UNION arm): those
+    // chunks carry their own conversation_id but point back to the parent via
+    // chunk_provenance.source_conv_id, which had no index before this.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_chunk_provenance_source_conv
+            ON chunk_provenance(source_conv_id);",
+    )?;
+
     // code_nodes conversation-attribution indexes (v10 "dreaming" chunk
     // binding — `storage::chunk_binding::witness_verdict_for_chunks`):
     // `first_conv_id`/`last_conv_id` had no index before this, so every

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -3,6 +3,7 @@ pub mod chunk_binding;
 pub mod codegraph;
 pub mod migrations;
 pub mod queries;
+pub mod recap_feeds;
 pub mod witness_ledger;
 pub mod witness_verdicts;
 

--- a/csr-engine/src/storage/recap_feeds.rs
+++ b/csr-engine/src/storage/recap_feeds.rs
@@ -1,0 +1,672 @@
+//! Read-only, project-scoped evidence feeds for session recaps.
+
+use std::sync::LazyLock;
+
+use anyhow::Result;
+use regex::Regex;
+use rusqlite::params;
+
+use super::Storage;
+use crate::hooks::recap::{RetiredLine, SettledFact};
+
+const LEDGER_FEED_LIMIT: i64 = 5;
+const RETIRED_FEED_LIMIT: i64 = 3;
+
+static RECEIPT_OID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(?:\b(?:receipt(?:_oid)?|commit|oid|sha(?:-?1)?|verified\s+at)(?:\s*[:=#]\s*|\s+)([0-9a-f]{7,40})\b|\b([0-9a-f]{7,40})\b\s+--|\b([0-9a-f]{40})\b|^([0-9a-f]{7,40})$)",
+    )
+    .expect("valid receipt OID regex")
+});
+
+/// Keep receipts compact: prefer a git-style short OID, otherwise a short
+/// human-readable preview of the evidence text.
+fn shorten_receipt(evidence: &str) -> String {
+    RECEIPT_OID_RE
+        .captures_iter(evidence)
+        .find_map(|captures| {
+            if let Some(contextual_oid) = captures.get(1) {
+                return Some(contextual_oid.as_str());
+            }
+            (2..=4)
+                .filter_map(|group| captures.get(group))
+                .map(|matched| matched.as_str())
+                .find(|candidate| candidate.chars().any(|c| c.is_ascii_alphabetic()))
+        })
+        .map(|oid| oid.chars().take(7).collect())
+        .unwrap_or_else(|| evidence.chars().take(24).collect())
+}
+
+impl Storage {
+    /// Resolution ledger evidence for the previous conversation and current
+    /// project. The highest ledger id is the current verdict for a chunk.
+    pub fn recap_ledger_feeds(
+        &self,
+        project: &str,
+        conversation_id: &str,
+    ) -> Result<(Vec<SettledFact>, Vec<SettledFact>)> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|error| anyhow::anyhow!("lock: {error}"))?;
+
+        // The caller passes the session file id, which IS the main transcript's
+        // conversation_id. Facts authored inside this session's sidechains live
+        // on chunks with their own conversation_id but point back to the parent
+        // via chunk_provenance.source_conv_id — the second UNION arm credits
+        // them through idx_chunk_provenance_source_conv (no scans either way).
+        let mut settled_statement = conn.prepare(
+            "SELECT claim, evidence, status FROM (
+                 SELECT COALESCE(r.claim, '') AS claim, r.evidence AS evidence,
+                        r.status AS status, r.id AS rid
+                 FROM chunks c INDEXED BY idx_chunks_conversation
+                 JOIN resolution_ledger r ON r.chunk_id = c.id
+                 WHERE c.conversation_id = ?1
+                   AND c.project_name = ?2
+                   AND r.status = 'resolved'
+                   AND r.id = (
+                       SELECT MAX(latest.id)
+                       FROM resolution_ledger latest
+                       WHERE latest.chunk_id = r.chunk_id
+                   )
+                 UNION
+                 SELECT COALESCE(r.claim, ''), r.evidence, r.status, r.id
+                 FROM chunk_provenance p INDEXED BY idx_chunk_provenance_source_conv
+                 JOIN chunks c ON c.id = p.chunk_id
+                 JOIN resolution_ledger r ON r.chunk_id = c.id
+                 WHERE p.source_conv_id = ?1
+                   AND c.project_name = ?2
+                   AND r.status = 'resolved'
+                   AND r.id = (
+                       SELECT MAX(latest.id)
+                       FROM resolution_ledger latest
+                       WHERE latest.chunk_id = r.chunk_id
+                   )
+             )
+             ORDER BY rid DESC
+             LIMIT ?3",
+        )?;
+        let settled = settled_statement
+            .query_map(
+                params![conversation_id, project, LEDGER_FEED_LIMIT],
+                settled_fact_from_row,
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        let mut open_statement = conn.prepare(
+            "SELECT COALESCE(r.claim, ''), r.evidence, r.status
+             FROM resolution_ledger r INDEXED BY idx_resolution_open_recent
+             JOIN chunks c ON c.id = r.chunk_id
+             WHERE r.status IN ('still_open', 'regressed')
+               AND c.project_name = ?1
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM resolution_ledger latest
+                   WHERE latest.chunk_id = r.chunk_id
+                     AND latest.id > r.id
+               )
+             ORDER BY r.id DESC
+             LIMIT ?2",
+        )?;
+        let still_open = open_statement
+            .query_map(params![project, LEDGER_FEED_LIMIT], settled_fact_from_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok((settled, still_open))
+    }
+
+    /// Negative dream verdicts recorded strictly after `since_ts`, scoped by
+    /// the project carried directly on their witness ledger rows.
+    pub fn recap_retired_since(&self, project: &str, since_ts: &str) -> Result<Vec<RetiredLine>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|error| anyhow::anyhow!("lock: {error}"))?;
+        let mut statement = conn.prepare(
+            "SELECT COALESCE(NULLIF(wl.symbol, ''), wl.file),
+                    COALESCE(v.receipt_oid, ''),
+                    SUBSTR(datetime(v.created_at), 1, 10)
+             FROM witness_verdicts v INDEXED BY idx_witness_verdicts_recap_created
+             JOIN witness_ledger wl ON wl.id = v.witness_id
+             WHERE julianday(v.created_at) > julianday(?1)
+               AND wl.project = ?2
+               AND v.verdict IN ('superseded_by', 'anchor_obsolete')
+             ORDER BY julianday(v.created_at) DESC, v.id DESC
+             LIMIT ?3",
+        )?;
+        let rows = statement
+            .query_map(params![since_ts, project, RETIRED_FEED_LIMIT], |row| {
+                let receipt: String = row.get(1)?;
+                Ok(RetiredLine {
+                    label: row.get(0)?,
+                    receipt_oid: shorten_receipt(&receipt),
+                    date: row.get(2)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Count project proposals that have not received any promoted ledger
+    /// verdict. Project scope is resolved through the proposal's chunk id.
+    pub fn recap_open_proposals(&self, project: &str) -> Result<usize> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|error| anyhow::anyhow!("lock: {error}"))?;
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*)
+             FROM resolution_proposals p
+             CROSS JOIN chunks c ON c.id = p.chunk_id
+             WHERE c.project_name = ?1
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM resolution_ledger r
+                   WHERE r.chunk_id = p.chunk_id
+                     AND julianday(r.created_at) > julianday(p.created_at)
+               )",
+            [project],
+            |row| row.get(0),
+        )?;
+        Ok(usize::try_from(count).unwrap_or(0))
+    }
+}
+
+fn settled_fact_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SettledFact> {
+    let evidence: String = row.get(1)?;
+    Ok(SettledFact {
+        claim: row.get(0)?,
+        receipt: shorten_receipt(&evidence),
+        status: row.get(2)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::Storage;
+
+    fn seed_chunk(storage: &Storage, id: &str, conversation: &str, project: &str) {
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO chunks
+                        (id, conversation_id, project_name, timestamp, content, message_count)
+                     VALUES (?1, ?2, ?3, '2026-08-01T00:00:00Z', 'fixture', 1)",
+                    rusqlite::params![id, conversation, project],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    fn seed_resolution(
+        storage: &Storage,
+        chunk_id: &str,
+        status: &str,
+        evidence: &str,
+        claim: &str,
+    ) {
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO resolution_ledger
+                        (chunk_id, status, evidence, claim, created_at)
+                     VALUES (?1, ?2, ?3, ?4, '2026-08-02T00:00:00Z')",
+                    rusqlite::params![chunk_id, status, evidence, claim],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    fn seed_witness_verdict(
+        storage: &Storage,
+        project: &str,
+        file: &str,
+        symbol: Option<&str>,
+        verdict: &str,
+        receipt: &str,
+        created_at: &str,
+    ) {
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO witness_ledger
+                        (project, file, symbol, stamp, tier, at_oid, source_kind)
+                     VALUES (?1, ?2, ?3, ?4, 'committed', ?5, 'fixture')",
+                    rusqlite::params![project, file, symbol, format!("b3:{receipt}"), receipt],
+                )?;
+                let witness_id = conn.last_insert_rowid();
+                conn.execute(
+                    "INSERT INTO witness_verdicts
+                        (witness_id, verdict, receipt_oid, observed_head_oid, created_at)
+                     VALUES (?1, ?2, ?3, 'head000', ?4)",
+                    rusqlite::params![witness_id, verdict, receipt, created_at],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn receipt_shortening_prefers_first_oid_and_falls_back_to_preview() {
+        assert_eq!(
+            shorten_receipt("T2 backfill 2026-07-27: 73878dd -- chore(done)"),
+            "73878dd"
+        );
+        assert_eq!(
+            shorten_receipt("receipt deadbeefcafebabe complete"),
+            "deadbee"
+        );
+        assert_eq!(
+            shorten_receipt("no oid receipt needs a compact preview"),
+            "no oid receipt needs a c"
+        );
+        assert_eq!(
+            shorten_receipt("session 31cb2889-e122-474f-9451-38a79406a1f7"),
+            "session 31cb2889-e122-47"
+        );
+        assert_eq!(
+            shorten_receipt("numeric id 123456789 and b3 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            "numeric id 123456789 and"
+        );
+        assert_eq!(
+            shorten_receipt("commit: abcdef1234567890 finished"),
+            "abcdef1"
+        );
+        assert_eq!(shorten_receipt("commit 1234567 completed"), "1234567");
+        // Keyword fused to the hex run is NOT an OID context — separator required.
+        assert_eq!(
+            shorten_receipt("receipt1234567 pending review here"),
+            "receipt1234567 pending r"
+        );
+        assert_eq!(
+            shorten_receipt("commitdeadbeef was not a real commit"),
+            "commitdeadbeef was not a"
+        );
+    }
+
+    #[test]
+    fn ledger_feeds_split_latest_verdicts_and_scope_by_project_and_conversation() {
+        let storage = Storage::open_memory().unwrap();
+        seed_chunk(&storage, "settled", "current", "alpha");
+        seed_chunk(&storage, "open", "older", "alpha");
+        seed_chunk(&storage, "other-project", "current", "beta");
+        seed_chunk(&storage, "other-conversation", "different", "alpha");
+
+        seed_resolution(&storage, "settled", "still_open", "old receipt", "old");
+        seed_resolution(
+            &storage,
+            "settled",
+            "resolved",
+            "verified at abcdef123456",
+            "settled claim",
+        );
+        seed_resolution(
+            &storage,
+            "open",
+            "regressed",
+            "receipt 123abcd9",
+            "open claim",
+        );
+        seed_resolution(
+            &storage,
+            "other-project",
+            "resolved",
+            "receipt fedcba9",
+            "wrong project",
+        );
+        seed_resolution(
+            &storage,
+            "other-conversation",
+            "resolved",
+            "receipt 7654321",
+            "wrong conversation",
+        );
+
+        let (settled, still_open) = storage.recap_ledger_feeds("alpha", "current").unwrap();
+
+        assert_eq!(settled.len(), 1);
+        assert_eq!(settled[0].claim, "settled claim");
+        assert_eq!(settled[0].receipt, "abcdef1");
+        assert_eq!(settled[0].status, "resolved");
+        assert_eq!(still_open.len(), 1);
+        assert_eq!(still_open[0].claim, "open claim");
+        assert_eq!(still_open[0].status, "regressed");
+    }
+
+    #[test]
+    fn settled_feed_credits_sidechain_chunks_via_provenance_parent() {
+        let storage = Storage::open_memory().unwrap();
+        // Sidechain chunk: own conversation_id, parented to "current" via provenance.
+        seed_chunk(&storage, "side", "agent-child-conv", "alpha");
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO chunk_provenance (chunk_id, author, source_conv_id)
+                     VALUES ('side', 'sidechain', 'current')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        seed_resolution(
+            &storage,
+            "side",
+            "resolved",
+            "receipt abc9876",
+            "sidechain claim",
+        );
+
+        let (settled, _) = storage.recap_ledger_feeds("alpha", "current").unwrap();
+        assert_eq!(settled.len(), 1);
+        assert_eq!(settled[0].claim, "sidechain claim");
+        assert_eq!(settled[0].receipt, "abc9876");
+    }
+
+    #[test]
+    fn ledger_feeds_cap_each_bucket_at_five_newest_rows() {
+        let storage = Storage::open_memory().unwrap();
+        for n in 0..6 {
+            let settled_id = format!("settled-{n}");
+            seed_chunk(&storage, &settled_id, "current", "alpha");
+            seed_resolution(
+                &storage,
+                &settled_id,
+                "resolved",
+                &format!("receipt aaaaaa{n}"),
+                &format!("settled {n}"),
+            );
+            let open_id = format!("open-{n}");
+            seed_chunk(&storage, &open_id, "older", "alpha");
+            seed_resolution(
+                &storage,
+                &open_id,
+                "still_open",
+                &format!("receipt bbbbbb{n}"),
+                &format!("open {n}"),
+            );
+        }
+
+        let (settled, still_open) = storage.recap_ledger_feeds("alpha", "current").unwrap();
+
+        assert_eq!(settled.len(), 5);
+        assert_eq!(still_open.len(), 5);
+        assert_eq!(settled[0].claim, "settled 5");
+        assert_eq!(still_open[0].claim, "open 5");
+    }
+
+    #[test]
+    fn retired_feed_scopes_since_boundary_and_caps_newest_three() {
+        let storage = Storage::open_memory().unwrap();
+        seed_witness_verdict(
+            &storage,
+            "alpha",
+            "/repo/src/boundary.rs",
+            Some("boundary"),
+            "anchor_obsolete",
+            "0000000f",
+            "2026-08-01T00:00:00Z",
+        );
+        seed_witness_verdict(
+            &storage,
+            "beta",
+            "/repo/src/other.rs",
+            Some("other"),
+            "anchor_obsolete",
+            "1111111f",
+            "2026-08-06T00:00:00Z",
+        );
+        seed_witness_verdict(
+            &storage,
+            "alpha",
+            "/repo/src/reinstated.rs",
+            Some("live_again"),
+            "anchor_reinstated",
+            "2222222f",
+            "2026-08-06T00:00:00Z",
+        );
+        for n in 0..4 {
+            seed_witness_verdict(
+                &storage,
+                "alpha",
+                &format!("/repo/src/file-{n}.rs"),
+                (n != 0).then_some("retired_symbol"),
+                if n % 2 == 0 {
+                    "anchor_obsolete"
+                } else {
+                    "superseded_by"
+                },
+                &format!("abcde{n}f999"),
+                &format!("2026-08-0{}T00:00:00Z", n + 2),
+            );
+        }
+
+        let retired = storage
+            .recap_retired_since("alpha", "2026-08-01T00:00:00Z")
+            .unwrap();
+
+        assert_eq!(retired.len(), 3);
+        assert_eq!(retired[0].label, "retired_symbol");
+        assert_eq!(retired[0].receipt_oid, "abcde3f");
+        assert_eq!(retired[0].date, "2026-08-05");
+        assert_eq!(retired[2].label, "retired_symbol");
+        assert!(retired.iter().all(|line| line.label != "boundary"));
+        assert!(retired.iter().all(|line| line.label != "other"));
+        assert!(retired.iter().all(|line| line.label != "live_again"));
+    }
+
+    #[test]
+    fn retired_feed_normalizes_sqlite_and_rfc3339_timestamps() {
+        let storage = Storage::open_memory().unwrap();
+        seed_witness_verdict(
+            &storage,
+            "alpha",
+            "/repo/src/mixed.rs",
+            Some("mixed_timestamp"),
+            "anchor_obsolete",
+            "abcdef1234567890",
+            "2026-08-02 00:00:01",
+        );
+
+        let retired = storage
+            .recap_retired_since("alpha", "2026-08-02T00:00:00Z")
+            .unwrap();
+
+        assert_eq!(retired.len(), 1);
+        assert_eq!(retired[0].label, "mixed_timestamp");
+    }
+
+    #[test]
+    fn retired_feed_preserves_rfc3339_fractional_second_ordering() {
+        let storage = Storage::open_memory().unwrap();
+        seed_witness_verdict(
+            &storage,
+            "alpha",
+            "/repo/src/fractional.rs",
+            Some("fractionally_later"),
+            "anchor_obsolete",
+            "abcdef1234567890",
+            "2026-08-02T00:00:00.900Z",
+        );
+
+        let retired = storage
+            .recap_retired_since("alpha", "2026-08-02T00:00:00.100Z")
+            .unwrap();
+
+        assert_eq!(retired.len(), 1);
+        assert_eq!(retired[0].label, "fractionally_later");
+    }
+
+    #[test]
+    fn retired_feed_orders_by_normalized_timestamp_before_id() {
+        let storage = Storage::open_memory().unwrap();
+        seed_witness_verdict(
+            &storage,
+            "alpha",
+            "/repo/src/newer.rs",
+            Some("newer_by_time"),
+            "anchor_obsolete",
+            "abcdef1234567890",
+            "2026-08-03 00:00:00",
+        );
+        seed_witness_verdict(
+            &storage,
+            "alpha",
+            "/repo/src/older.rs",
+            Some("older_by_time"),
+            "anchor_obsolete",
+            "fedcba1234567890",
+            "2026-08-02T00:00:00Z",
+        );
+
+        let retired = storage
+            .recap_retired_since("alpha", "2026-08-01T00:00:00Z")
+            .unwrap();
+
+        assert_eq!(retired[0].label, "newer_by_time");
+    }
+
+    #[test]
+    fn open_proposals_count_excludes_promoted_and_other_projects() {
+        let storage = Storage::open_memory().unwrap();
+        seed_chunk(&storage, "alpha-open", "a", "alpha");
+        seed_chunk(&storage, "alpha-promoted", "a", "alpha");
+        seed_chunk(&storage, "beta-open", "b", "beta");
+        storage
+            .with_connection(|conn| {
+                for (chunk_id, session_id) in [
+                    ("alpha-open", "s1"),
+                    ("alpha-promoted", "s2"),
+                    ("beta-open", "s3"),
+                ] {
+                    conn.execute(
+                        "INSERT INTO resolution_proposals
+                            (chunk_id, claim, evidence, session_id, created_at)
+                         VALUES (?1, 'claim', 'evidence', ?2, '2026-08-01 00:00:00')",
+                        rusqlite::params![chunk_id, session_id],
+                    )?;
+                }
+                Ok(())
+            })
+            .unwrap();
+        seed_resolution(&storage, "alpha-promoted", "resolved", "promoted", "claim");
+
+        assert_eq!(storage.recap_open_proposals("alpha").unwrap(), 1);
+        assert_eq!(storage.recap_open_proposals("beta").unwrap(), 1);
+    }
+
+    #[test]
+    fn open_proposal_ignores_prerequisite_ledger_row_but_not_later_promotion() {
+        let storage = Storage::open_memory().unwrap();
+        seed_chunk(&storage, "proposal", "a", "alpha");
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO resolution_ledger
+                        (chunk_id, status, evidence, claim, created_at)
+                     VALUES ('proposal', 'still_open', 'prerequisite', 'claim',
+                             '2026-08-01 00:00:00')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO resolution_proposals
+                        (chunk_id, claim, evidence, session_id, created_at)
+                     VALUES ('proposal', 'claim', 'candidate', 'session',
+                             '2026-08-02 00:00:00')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(storage.recap_open_proposals("alpha").unwrap(), 1);
+
+        storage
+            .with_connection(|conn| {
+                conn.execute(
+                    "INSERT INTO resolution_ledger
+                        (chunk_id, status, evidence, claim, created_at)
+                     VALUES ('proposal', 'resolved', 'promoted', 'claim',
+                             '2026-08-03T00:00:00Z')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(storage.recap_open_proposals("alpha").unwrap(), 0);
+    }
+
+    #[test]
+    fn recap_query_indexes_match_capped_feed_order_and_join_direction() {
+        let storage = Storage::open_memory().unwrap();
+        storage
+            .with_connection(|conn| {
+                let retired_plan = conn
+                    .prepare(
+                        "EXPLAIN QUERY PLAN
+                         SELECT v.witness_id
+                         FROM witness_verdicts v INDEXED BY idx_witness_verdicts_recap_created
+                         JOIN witness_ledger wl ON wl.id = v.witness_id
+                         WHERE julianday(v.created_at) > julianday(?1)
+                           AND wl.project = ?2
+                           AND v.verdict IN ('superseded_by', 'anchor_obsolete')
+                         ORDER BY julianday(v.created_at) DESC, v.id DESC
+                         LIMIT 3",
+                    )?
+                    .query_map(rusqlite::params!["2026-08-01T00:00:00Z", "alpha"], |row| {
+                        row.get::<_, String>(3)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?
+                    .join("\n");
+                assert!(retired_plan.contains("idx_witness_verdicts_recap_created"));
+                assert!(!retired_plan.contains("USE TEMP B-TREE FOR ORDER BY"));
+
+                let open_plan = conn
+                    .prepare(
+                        "EXPLAIN QUERY PLAN
+                         SELECT r.id
+                         FROM resolution_ledger r INDEXED BY idx_resolution_open_recent
+                         JOIN chunks c ON c.id = r.chunk_id
+                         WHERE r.status IN ('still_open', 'regressed')
+                           AND c.project_name = ?1
+                           AND NOT EXISTS (
+                               SELECT 1 FROM resolution_ledger latest
+                               WHERE latest.chunk_id = r.chunk_id
+                                 AND latest.id > r.id
+                           )
+                         ORDER BY r.id DESC
+                         LIMIT 5",
+                    )?
+                    .query_map(["alpha"], |row| row.get::<_, String>(3))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?
+                    .join("\n");
+                assert!(open_plan.contains("idx_resolution_open_recent"));
+                assert!(!open_plan.contains("idx_chunks_project"));
+
+                let proposal_plan = conn
+                    .prepare(
+                        "EXPLAIN QUERY PLAN
+                         SELECT COUNT(*)
+                         FROM resolution_proposals p
+                         CROSS JOIN chunks c ON c.id = p.chunk_id
+                         WHERE c.project_name = ?1
+                           AND NOT EXISTS (
+                               SELECT 1 FROM resolution_ledger r
+                               WHERE r.chunk_id = p.chunk_id
+                                 AND julianday(r.created_at) > julianday(p.created_at)
+                           )",
+                    )?
+                    .query_map(["alpha"], |row| row.get::<_, String>(3))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?
+                    .join("\n");
+                let proposal_first = proposal_plan.lines().next().unwrap_or_default();
+                assert!(proposal_first.contains("SCAN p"));
+                assert!(!proposal_plan.contains("idx_chunks_project"));
+                Ok(())
+            })
+            .unwrap();
+    }
+}


### PR DESCRIPTION
Stacked on #281 (base `feat/rmcp-3.1`). Merge #281 first; this rebases onto `main` after that.

## What this changes

SessionStart currently injects a pile of fragments — CONTINUUM, LAST, NEXT, ANCHORS — and leaves the model to guess how they relate. This replaces that pile with a single causal paragraph, composed deterministically from evidence already in the database:

```
recap [<age>]: <intent>: <completed>. Settled: <claim> (<receipt>).
Now: <blockers | still-open | proposals | todos>.
Learnt-then-retired while away: <label> (superseded <date>, <oid>).
Next: <evidenced next step>.
```

The chain the fragments never expressed — this happened, so we did that, and here is what has since been retired — comes from joining episodes, the resolution ledger, and dream verdicts per episode.

## Design constraints

- **No LLM anywhere on this path.** Pure composition from SQL feeds.
- **Abstention-first.** Every clause drops independently when its evidence is missing. `Next:` is never fabricated; if nothing is evidenced, the clause does not appear. Punctuation-only sentinels (`.`, `…`, `/`, `none`) never become claims — `has_substance` gates every evidence door.
- **Receipts mandatory.** A settled claim without a commit receipt is not emitted.
- **No self-contamination.** An emitted recap re-enters the corpus through the transcript, so `provenance::is_csr_emission` recognises the exact emitted grammar (`recap [<age>]: `, matched as a first-line prefix with the bracket close within 24 chars). A bare substring match would have eaten genuine user prose like "recap [the auth changes], then prioritize them" — there is a regression test for that.
- **Fail open.** Feed errors log at debug and yield empty feeds; the fragment fallback is byte-identical to today's output.
- Kill switch: `CSR_NO_RECAP=1`.

Claude Code's own `recap:` is human-facing only — not hookable, not injected into model context on resume. This fills the model-facing half; the two do not collide.

## Code

| Path | Role |
|---|---|
| `csr-engine/src/hooks/recap.rs` | pure composer, 22 in-module tests |
| `csr-engine/src/storage/recap_feeds.rs` | ledger / retired / open-proposal feeds, receipt shortening |
| `csr-engine/src/storage/migrations.rs` | 3 indexes: julianday-normalised verdict recency, open proposals, `chunk_provenance(source_conv_id)` |
| `csr-engine/src/hooks/session_start.rs` | wiring, kill switch, framing guard |
| `csr-engine/src/extraction/provenance.rs` | emitted-grammar suppression |

## Review history

Six adversarial review rounds (codex xhigh), twelve real findings fixed. Three were the exact failure classes the v10 paper documents:

1. **Silently inert wiring** — `ep.session_id` was passed where `conversation_id` was required, so sidechain-parented episodes returned empty settled feeds and the clause would simply never appear. Fixed with a `chunk_provenance` UNION arm, a new index, and a regression test.
2. **Self-contamination** — suppression was registered against the SwiftBar selector rather than `EMISSION_HEADERS`, so injected recaps stayed extractable and would have fed themselves back into the corpus.
3. **Format mismatch** — SQLite's `datetime('now')` emits `YYYY-MM-DD HH:MM:SS` while episode timestamps are RFC3339 with `T`; lexicographic comparison silently dropped same-day rows, so the retired clause would never have fired in production. Normalised through `julianday()` with a matching expression index.

## Verification

- 1,252 tests green: 1,136 lib + 45 hooks + 61 integration + 9 tad + 1 dream
- `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean
- Live smoke against the real database produced a correct recap with correct abstention
- Pre-commit passed on its own terms (no `--no-verify`). Bonus fix included: `chunk_binding` tests now `env_remove` `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` before spawning git, because git exports those to hook subprocesses and they hijacked the tests' temp repos — seven tests failed only when run from inside `git commit`.

https://claude.ai/code/session_014uFuurLMagweAq96PsijZn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added concise session recaps summarizing settled facts, open items, retired decisions, proposals, blockers, and next steps.
  - Recaps are scoped to the current project and conversation, with compact formatting and length limits.
  - Added an option to disable recaps using `CSR_NO_RECAP`.

- **Bug Fixes**
  - Improved recap detection to avoid mistaking ordinary prose for generated recap content.
  - Recaps now safely fall back to the existing session output when supporting evidence is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->