### PR TITLE
codewitness: record the causal basis on every supersession receipt

### DIFF
--- a/codewitness/src/auditor.rs
+++ b/codewitness/src/auditor.rs
@@ -2,7 +2,9 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::anchor::to_git_path;
 use crate::verdict::SupersededReceipt;
-use crate::{causal, Anchor, CausalOrder, Error, StampKind, Tier, Verdict, Witness};
+use crate::{
+    causal, Anchor, CausalOrder, Error, StampKind, SupersessionBasis, Tier, Verdict, Witness,
+};
 
 /// Wraps a [`gix::Repository`] to produce and audit [`Witness`]es.
 ///
@@ -188,7 +190,9 @@ impl Auditor {
     ///      see `tests/adversarial.rs`) is accepted *only* because check #3
     ///      already proved the successor's content by direct re-derivation
     ///      from the object database; the commit graph gives no help in
-    ///      that case, and content re-derivation is why none is needed.
+    ///      that case, and content re-derivation is why none is needed. The
+    ///      emitted receipt records whether its basis was graph ordering or
+    ///      content-only evidence, so consumers can distinguish these cases.
     pub fn audit_against_successor(
         &self,
         witness: &Witness,
@@ -199,10 +203,11 @@ impl Auditor {
             return Ok(fallback);
         }
 
-        if self.successor_is_valid(witness, successor)? {
+        if let Some(basis) = self.successor_is_valid(witness, successor)? {
             Ok(Verdict::Superseded(SupersededReceipt::new(
                 successor.anchor().clone(),
                 successor.at(),
+                basis,
             )))
         } else {
             Ok(fallback)
@@ -210,16 +215,20 @@ impl Auditor {
     }
 
     /// All of [`Self::audit_against_successor`]'s supersession checks.
-    /// `Ok(false)` means the successor was fully checked and *rejected*
+    /// `Ok(None)` means the successor was fully checked and *rejected*
     /// (wrong tier, stamp mismatch, causally backwards); `Err` means a
     /// repository-access failure prevented checking at all (missing or
     /// undecodable commit, unreadable tree, merge-base error) — the two
     /// must stay distinguishable, because only the former is a
     /// deterministic fact about the evidence.
-    fn successor_is_valid(&self, witness: &Witness, successor: &Witness) -> Result<bool, Error> {
+    fn successor_is_valid(
+        &self,
+        witness: &Witness,
+        successor: &Witness,
+    ) -> Result<Option<SupersessionBasis>, Error> {
         // (1) Tier gate.
         if successor.tier() != Tier::Committed {
-            return Ok(false);
+            return Ok(None);
         }
 
         // (2) + (3): re-derive the successor's stamp from the commit it
@@ -230,19 +239,21 @@ impl Auditor {
         let bytes = self.read_committed_bytes(successor.anchor(), successor.at())?;
         let recomputed = successor.stamp().kind().compute(&bytes);
         if recomputed != *successor.stamp() {
-            return Ok(false);
+            return Ok(None);
         }
 
         // (4) Causal precedence, only meaningful when the original witness
         // is itself pinned to a real commit.
         if witness.tier() == Tier::Committed {
             let order = causal::compare(&self.repo, successor.at(), witness.at())?;
-            if matches!(order, CausalOrder::AncestorOf | CausalOrder::Equal) {
-                return Ok(false);
-            }
+            return match order {
+                CausalOrder::DescendantOf => Ok(Some(SupersessionBasis::GraphOrdered)),
+                CausalOrder::Incomparable => Ok(Some(SupersessionBasis::ContentOnly)),
+                CausalOrder::AncestorOf | CausalOrder::Equal => Ok(None),
+            };
         }
 
-        Ok(true)
+        Ok(Some(SupersessionBasis::ContentOnly))
     }
 
     // ---- content access -------------------------------------------------

--- a/codewitness/src/lib.rs
+++ b/codewitness/src/lib.rs
@@ -35,7 +35,7 @@ pub use causal::CausalOrder;
 pub use diff_id::{normalized_diff_id, DiffId};
 pub use error::{Error, Result};
 pub use stamp::{stamp_normalized, Stamp, StampKind};
-pub use verdict::{SupersededReceipt, Verdict};
+pub use verdict::{SupersededReceipt, SupersessionBasis, Verdict};
 pub use witness::{Tier, Witness};
 
 /// Re-exported so downstream crates can construct [`Witness::at`] /

--- a/codewitness/src/verdict.rs
+++ b/codewitness/src/verdict.rs
@@ -51,10 +51,29 @@ impl Verdict {
     }
 }
 
+/// The evidence that backed a [`Verdict::Superseded`] receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SupersessionBasis {
+    /// The successor commit is a proven (transitive) descendant of the
+    /// witnessed commit: the commit graph itself orders the replacement.
+    GraphOrdered,
+    /// The commit graph did not order the two commits, so the mint rests
+    /// entirely on the successor's stamp being re-derived from the object
+    /// database plus the caller's assertion that this anchor replaces the
+    /// witnessed one. Reached when the two commits are
+    /// [`crate::CausalOrder::Incomparable`] (squash, rebase, cherry-pick, or an
+    /// unrelated branch), or when the witness is [`crate::Tier::Worktree`] and
+    /// therefore carries no reproducible commit to order against.
+    ContentOnly,
+}
+
 /// The evidence backing a [`Verdict::Superseded`] verdict: which anchor
 /// replaced the witnessed one, and the commit (`receipt`) at which that
-/// successor witness was taken — always [`crate::Tier::Committed`]
-/// evidence.
+/// successor witness was taken — always [`crate::Tier::Committed`] evidence —
+/// plus the [`SupersessionBasis`] that states which evidence backed the mint.
+/// In particular, [`SupersessionBasis::ContentOnly`] must not be read as
+/// graph-proven succession.
 ///
 /// The enum variant `Verdict::Superseded` stays public so callers can
 /// match on it freely, but this payload's fields are private and there is
@@ -83,11 +102,12 @@ impl Verdict {
 pub struct SupersededReceipt {
     by: Anchor,
     receipt: gix::ObjectId,
+    basis: SupersessionBasis,
 }
 
 impl SupersededReceipt {
-    pub(crate) fn new(by: Anchor, receipt: gix::ObjectId) -> Self {
-        Self { by, receipt }
+    pub(crate) fn new(by: Anchor, receipt: gix::ObjectId, basis: SupersessionBasis) -> Self {
+        Self { by, receipt, basis }
     }
 
     /// The anchor that replaced the witnessed one.
@@ -98,6 +118,11 @@ impl SupersededReceipt {
     /// The commit at which the successor witness was taken.
     pub fn receipt(&self) -> gix::ObjectId {
         self.receipt
+    }
+
+    /// The evidence that backed this supersession receipt.
+    pub fn basis(&self) -> SupersessionBasis {
+        self.basis
     }
 }
 
@@ -117,6 +142,7 @@ mod tests {
             Verdict::Superseded(SupersededReceipt::new(
                 Anchor::new("replacement.rs"),
                 object_id(),
+                SupersessionBasis::GraphOrdered,
             )),
             Verdict::Vanished {
                 last_seen: object_id(),
@@ -139,5 +165,20 @@ mod tests {
             verdicts.each_ref().map(|verdict| verdict.is_vanished()),
             [false, false, false, true]
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn superseded_receipt_serde_round_trip_preserves_basis() {
+        let receipt = SupersededReceipt::new(
+            Anchor::new("replacement.rs"),
+            object_id(),
+            SupersessionBasis::ContentOnly,
+        );
+
+        let encoded = serde_json::to_string(&receipt).unwrap();
+        let decoded: SupersededReceipt = serde_json::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.basis(), SupersessionBasis::ContentOnly);
     }
 }

--- a/codewitness/tests/adversarial.rs
+++ b/codewitness/tests/adversarial.rs
@@ -7,7 +7,9 @@
 
 mod common;
 
-use codewitness::{causal, normalized_diff_id, Anchor, CausalOrder, Tier, Verdict};
+use codewitness::{
+    causal, normalized_diff_id, Anchor, CausalOrder, SupersessionBasis, Tier, Verdict,
+};
 use common::TempRepo;
 
 const FILE: &str = "witness.txt";
@@ -245,7 +247,37 @@ fn near_identical_edit_is_drifted_not_superseded_without_a_successor() {
         .audit_against_successor(&witness_a, &committed_successor)
         .unwrap()
     {
-        Verdict::Superseded(receipt) => assert_eq!(receipt.receipt(), commit_a_prime),
+        Verdict::Superseded(receipt) => {
+            assert_eq!(receipt.receipt(), commit_a_prime);
+            assert_eq!(receipt.basis(), SupersessionBasis::GraphOrdered);
+        }
+        other => panic!("expected Superseded, got {other:?}"),
+    }
+}
+
+#[test]
+fn worktree_witness_supersession_records_content_only_basis() {
+    let repo = TempRepo::new();
+    repo.write(FILE, "original\n");
+    repo.commit_all("original");
+
+    let auditor = repo.auditor();
+    let anchor = Anchor::new(FILE);
+    let worktree_witness = auditor.stamp(&anchor).unwrap();
+    assert_eq!(worktree_witness.tier(), Tier::Worktree);
+
+    repo.write(FILE, "replacement\n");
+    let successor_commit = repo.commit_all("replacement");
+    let successor = auditor.stamp_at(&anchor, successor_commit).unwrap();
+
+    match auditor
+        .audit_against_successor(&worktree_witness, &successor)
+        .unwrap()
+    {
+        Verdict::Superseded(receipt) => {
+            assert_eq!(receipt.basis(), SupersessionBasis::ContentOnly);
+            assert_eq!(receipt.receipt(), successor_commit);
+        }
         other => panic!("expected Superseded, got {other:?}"),
     }
 }
@@ -291,6 +323,23 @@ fn cherry_pick_duplicate_shares_diff_id_but_not_topology() {
     let id_feature = normalized_diff_id(&feature_parent_content, &feature_content);
     let id_main = normalized_diff_id(&main_commit_parent_content, &main_commit_content);
     assert_eq!(id_feature, id_main);
+
+    let witnessed_feature = auditor
+        .stamp_at(&Anchor::new(FILE), feature_commit)
+        .unwrap();
+    let successor_cherry_pick = auditor
+        .stamp_at(&Anchor::new(FILE), cherry_pick_commit)
+        .unwrap();
+    match auditor
+        .audit_against_successor(&witnessed_feature, &successor_cherry_pick)
+        .unwrap()
+    {
+        Verdict::Superseded(receipt) => {
+            assert_eq!(receipt.basis(), SupersessionBasis::ContentOnly);
+            assert_eq!(receipt.receipt(), cherry_pick_commit);
+        }
+        other => panic!("expected Superseded, got {other:?}"),
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -443,6 +492,29 @@ fn successor_causally_preceding_the_witness_is_not_superseded() {
         .unwrap();
     assert!(!verdict.is_superseded());
     assert_eq!(verdict, Verdict::Drifted);
+}
+
+#[test]
+fn successor_equal_to_the_witness_is_not_superseded() {
+    let repo = TempRepo::new();
+    repo.write(FILE, "v1\n");
+    repo.commit_all("v1");
+    repo.write(FILE, "v2\n");
+    let commit_2 = repo.commit_all("v2");
+    repo.write(FILE, "v3\n");
+    repo.commit_all("v3: current worktree state");
+
+    let auditor = repo.auditor();
+    let anchor = Anchor::new(FILE);
+    let witness = auditor.stamp_at(&anchor, commit_2).unwrap();
+    let equal_successor = auditor.stamp_at(&anchor, commit_2).unwrap();
+
+    assert_eq!(
+        auditor
+            .audit_against_successor(&witness, &equal_successor)
+            .unwrap(),
+        Verdict::Drifted
+    );
 }
 
 /// Forgery-based negative tests: these need to construct a `Witness` that


### PR DESCRIPTION
Folds into the 10.1 release. Lands before codewitness's first publish, because `SupersededReceipt` becomes frozen public API the moment the crate ships.

## Why

`Auditor::audit_against_successor` deliberately accepts a successor whose commit is `CausalOrder::Incomparable` to the witnessed one — squash, rebase and cherry-pick all produce that shape, and the stamp re-derivation check has already proved the successor's content against the object database, so the commit graph has nothing left to contribute. That decision stands.

What was missing: the receipt didn't say so. A consumer couldn't distinguish "the graph proves this successor descends from the witnessed commit" from "the graph said nothing; this rests on content re-derivation plus the caller's assertion that these anchors are related". Read uncharitably — and an external reviewer will — that reads as *any correctly stamped anchor that isn't strictly earlier qualifies, including one on an abandoned branch*.

## What changed

Record the basis rather than narrow what is accepted:

- `SupersessionBasis::GraphOrdered` — successor is a proven transitive descendant; the commit graph orders the replacement.
- `SupersessionBasis::ContentOnly` — the graph did not order the two commits, or the witness is `Tier::Worktree` and carries no reproducible commit to order against. Rests on re-derived content alone, and must not be read as graph-proven succession.

`successor_is_valid` now returns `Option<SupersessionBasis>`: `Ok(Some(basis))` accepts and states why, `Ok(None)` is a checked rejection, `Err` is "could not check". That three-way distinction is load-bearing and unchanged — an operational failure must never collapse into a verdict.

**Recall does not move.** Every input accepted before is still accepted; the rejection paths (ancestor, equal, stamp mismatch, wrong tier) still return the fallback verdict. `SupersededReceipt::new` stays `pub(crate)`, so the new field and the `basis()` accessor are additive, not breaking.

## Tests

Descendant successor records `GraphOrdered`; cherry-pick and worktree-tier witnesses record `ContentOnly`; a successor equal to the witness is still rejected; the basis survives a serde round-trip.

## Verification

`cargo test` (55 across 5 targets) and `cargo test --features serde` (58) green, `clippy --all-targets -D warnings` clean, `fmt` clean, csr-engine builds against the changed crate, and the repo pre-commit gate passed with 1,136 lib tests.

Origin: this was the one real defect a web-grounded external novelty review found in the crate's central claim.

https://claude.ai/code/session_014uFuurLMagweAq96PsijZn