### PR TITLE
release: 10.1.0 — v10 dreaming and the recap layer ship together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,102 @@ All notable changes to Claude Self-Reflect will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.1.0] - 2026-08-08
+
+### Dreaming and recap: memory that forgets on evidence and hands back one paragraph
+
+v10 folds into a single release. Two halves: the engine now retires its own
+claims when the code they described moves, and the session opens with one
+causal paragraph instead of a pile of fragments. 10.0.0 was never published —
+everything below ships together as 10.1.0.
+
+#### Recap at SessionStart (headline)
+
+Session start used to inject CONTINUUM, LAST, NEXT and ANCHORS as separate
+fragments and leave the model to guess how they related. It now composes one
+paragraph from evidence already in the database:
+
+```
+recap [<age>]: <intent>: <completed>. Settled: <claim> (<receipt>).
+Now: <blockers | still-open | proposals | todos>.
+Learnt-then-retired while away: <label> (superseded <date>, <oid>).
+Next: <evidenced next step>.
+```
+
+- No LLM on this path — pure composition over SQL feeds.
+- Abstention-first: every clause drops independently when its evidence is
+  missing. `Next:` is never invented. Punctuation-only sentinels never become
+  claims.
+- Receipts mandatory: a settled claim without a commit receipt is not emitted.
+- No self-contamination: emitted recaps re-enter the corpus through the
+  transcript, so the extraction sanitizer recognises the exact emitted grammar.
+- Feed errors fail open to the previous fragment output, byte for byte.
+- Kill switch: `CSR_NO_RECAP=1`.
+
+Claude Code's own `recap:` is human-facing and is not injected into model
+context on resume; this fills the model-facing half.
+
+#### Dreaming: evidence-grounded forgetting
+
+- **`codewitness` crate.** A deterministic evidence kernel: span-level BLAKE3
+  stamps pinned to commit OIDs, audited as intact, drifted, vanished, or
+  explicitly superseded. Causal ordering via git ancestry, no LLM and no
+  timestamps on the verdict path. Operational failures stay errors and never
+  collapse into verdicts. Every supersession receipt now records whether its
+  basis was graph ordering (`GraphOrdered`) or content re-derivation alone
+  (`ContentOnly`), so a squash/rebase successor is never mistaken for a
+  graph-proven one.
+- **Witness ledger.** Append-only `witness_ledger` plus `witness_generations`
+  publication manifests; `codegraph stamp-spans --at <rev>` mints witnesses at
+  historical revisions.
+- **Deterministic supersession verdicts.** Successor join, event ledger, and
+  two-channel consumption — demote and annotate rather than delete, with
+  `[stale anchor]` / `[evolved]` markers carrying commit receipts into search
+  results.
+- **Validity partition in rerank**, consuming dream verdicts; active forgetting
+  applies accelerated decay to demoted symbols.
+- **Daemon dream cadence** (6h, `CSR_DREAM_INTERVAL_SECS`, kill switch
+  `CSR_NO_DREAMING=1`), dream summary in the telemetry dashboard, and
+  `--report` HTML journal.
+- **T4 benchmark**, ported into `codewitness labels` / `codewitness bench` —
+  deterministic and provenance-stamped. H1 rematch on the corrected extractor:
+  1.000 / 1.000 over 13,626 beliefs.
+
+#### Search and corpus
+
+- **TAD v2**: temporal decay driven by release ancestry rather than wall-clock
+  age, with an hourly ancestry cache that fails open to neutral.
+- **Self-contamination closed**: the importer no longer indexes CSR's own tool
+  output. Counters for suppressed blocks and scrubbed hook wrappers appear in
+  `status`.
+- **Corpus expansion**: sidechain attribution (real project and parent session
+  recovered from provenance) and an optional Codex rollout adapter.
+- `reflect_on_past` sinks resolved chunks before the limit cut, so stale chunks
+  no longer occupy top-k slots ahead of live ones.
+
+#### Codegraph correctness
+
+- Type-qualified symbol identity for witness joins.
+- `#N`-collision abstention: occurrence keys, a complete-generation protocol,
+  and fail-closed lineage selection.
+
+#### Protocol
+
+- **rmcp 1.6 → 3.1** (MCP spec 2026-07-28): elicitation types renamed, tasks on
+  the SEP-2663 TaskManager with prior poll/TTL behaviour preserved, hand-written
+  `call_tool`/`list_tools`. All 15 tools, schemas and annotation hints unchanged.
+
+#### CI and tests
+
+- `codewitness` has its own scoped workflow with a mutation gate and a
+  determinism harness; all 31 missed mutants killed. `cargo-semver-checks` now
+  probes the crates.io index for a baseline, so it turns enforcing by itself at
+  first publish instead of relying on a flag someone must remember to remove.
+- `chunk_binding` tests clear `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` before
+  spawning git — git exports those to hook subprocesses, which hijacked the
+  tests' temp repositories and made seven of them fail only when run from inside
+  `git commit`.
+
 ## [9.5.0] - 2026-08-03
 
 ### Codegraph truth pass: evidence-tiered resolution, two-channel attribution, honest abstention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Claude Self-Reflect v10.0 — Action Guide
+# Claude Self-Reflect v10.1 — Action Guide
 
 ## Architecture
 
@@ -15,7 +15,7 @@ csr-engine (44MB)
   └── 3-layer enrichment pipeline
 ```
 
-## Corpus Sources (v10.0)
+## Corpus Sources (v10.1)
 
 | Source | Stage | Notes |
 |---|---|---|
@@ -31,7 +31,11 @@ csr-engine (44MB)
 
 ## Dreaming (v10)
 
-Evidence-grounded forgetting: append-only `witness_ledger` (span-level BLAKE3 stamps at commit OIDs) + `witness_generations` publication manifests; deterministic abstention-first verdicts (no LLM); demote+annotate consumption (`[stale anchor]`/`[evolved]` with commit receipts in search). Daemon dream cadence 6h (`CSR_DREAM_INTERVAL_SECS` override), kill switch `CSR_NO_DREAMING=1`; TAD v2 decays by release ancestry (`conversation_ancestry_cache`, hourly refresh, fail-open to neutral). Benchmark: `codewitness labels` + `codewitness bench` (eval-kit/t4) — deterministic, provenance-stamped.
+Evidence-grounded forgetting: append-only `witness_ledger` (span-level BLAKE3 stamps at commit OIDs) + `witness_generations` publication manifests; deterministic abstention-first verdicts (no LLM); demote+annotate consumption (`[stale anchor]`/`[evolved]` with commit receipts in search). Daemon dream cadence 6h (`CSR_DREAM_INTERVAL_SECS` override), kill switch `CSR_NO_DREAMING=1`; TAD v2 decays by release ancestry (`conversation_ancestry_cache`, hourly refresh, fail-open to neutral). Benchmark: `codewitness labels` + `codewitness bench` (eval-kit/t4) — deterministic, provenance-stamped. Supersession receipts carry their basis (`GraphOrdered` vs `ContentOnly`) — a squash/rebase successor is never read as graph-proven.
+
+## Recap (v10.1)
+
+SessionStart injects one causal paragraph instead of the fragment pile: `recap [<age>]: <intent>: <completed>. Settled: <claim> (<receipt>). Now: <blockers|still-open|proposals|todos>. Learnt-then-retired while away: <label> (superseded <date>, <oid>). Next: <evidenced next step>.` Composer `src/hooks/recap.rs` + feeds `src/storage/recap_feeds.rs`, zero LLM. Every clause drops independently without evidence; `Next:` is never fabricated; receipts mandatory. Feeds fail open to the byte-identical fragment fallback. Suppressed from re-import by exact emitted grammar in `provenance::is_csr_emission` (the self-contamination guard). Kill switch `CSR_NO_RECAP=1`.
 
 ## Key Commands
 
@@ -125,7 +129,7 @@ cargo bench --bench spike_bench
 
 | Hook | When | What |
 |------|------|------|
-| SessionStart | Session begins | Injects past context (framed as history, not instructions) |
+| SessionStart | Session begins | Injects the recap paragraph (framed as history, not instructions); falls back to fragments when feeds are empty |
 | UserPromptSubmit | Every prompt | Predictive context injection |
 | PostToolUse | After Edit/Write | Tracks file changes |
 | Stop | Every response | Stores iteration learnings |

--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "csr-engine"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "anyhow",
  "ast-grep-core",

--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csr-engine"
-version = "10.0.0"
+version = "10.1.0"
 edition = "2021"
 description = "Claude Self-Reflect: Rust MCP server with embedded vector search"
 

--- a/csr-engine/src/hooks/recap.rs
+++ b/csr-engine/src/hooks/recap.rs
@@ -6,6 +6,11 @@ use regex::Regex;
 
 static XML_TAG_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<[^>]{1,50}>").unwrap());
 static MD_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"#{1,4}\s+").unwrap());
+/// Bullet markers at the head of a flattened line. Lines are joined with
+/// spaces before the recap is composed, so a markdown list would otherwise
+/// read as `a: - one - two` in the middle of a sentence.
+static MD_BULLET_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\s*(?:[-*+]|\d{1,3}[.)])\s+").unwrap());
 
 /// Maximum open facts accepted by the composer and requested by storage callers.
 pub const STILL_OPEN_LIMIT: usize = 3;
@@ -57,9 +62,13 @@ pub fn compose_recap(
     }
 
     let mut recap = match (intent.as_deref(), completed.as_deref()) {
-        (Some(intent), Some(completed)) => format!("recap [{age}]: {intent}: {completed}."),
-        (Some(intent), None) => format!("recap [{age}]: {intent}."),
-        (None, Some(completed)) => format!("recap [{age}]: {completed}."),
+        (Some(intent), Some(completed)) => format!(
+            "recap [{age}]: {}: {}",
+            intent.trim_end().trim_end_matches(TRAILING_JUNK),
+            terminate_clause(completed)
+        ),
+        (Some(intent), None) => format!("recap [{age}]: {}", terminate_clause(intent)),
+        (None, Some(completed)) => format!("recap [{age}]: {}", terminate_clause(completed)),
         (None, None) => unreachable!("empty episodes abstain above"),
     };
 
@@ -287,11 +296,7 @@ fn compact_preview(content: &str, max_chars: usize) -> String {
     if clean.chars().count() <= max_chars {
         return clean;
     }
-    let end = clean
-        .char_indices()
-        .nth(max_chars)
-        .map_or(clean.len(), |(index, _)| index);
-    format!("{}...", &clean[..end])
+    truncate_at_word_boundary(&clean, max_chars)
 }
 
 fn conclusion_preview(content: &str, max_chars: usize) -> String {
@@ -426,13 +431,38 @@ fn truncate_at_word_boundary(text: &str, max_chars: usize) -> String {
         .map_or(text.len(), |(index, _)| index);
     let window = &text[..byte_limit];
     let cut = window.rfind(char::is_whitespace).unwrap_or(byte_limit);
-    format!("{}{ELLIPSIS}", window[..cut].trim_end())
+    // Trailing punctuation before an ellipsis reads as a typo once the
+    // clause terminator is appended (`witness ledger,....`), so drop it.
+    let kept = window[..cut].trim_end().trim_end_matches(TRAILING_JUNK);
+    format!("{kept}{ELLIPSIS}")
+}
+
+/// Punctuation that must not survive immediately before an appended
+/// ellipsis or clause terminator.
+const TRAILING_JUNK: [char; 7] = [',', ';', ':', '-', '—', '–', '.'];
+
+/// Terminate a recap clause with a single `.`, unless it already ends in
+/// terminal punctuation or an ellipsis. Without this, a truncated clause
+/// renders as `… witness ledger....`.
+fn terminate_clause(clause: &str) -> String {
+    let trimmed = clause.trim_end();
+    if trimmed.ends_with("...")
+        || trimmed.ends_with('…')
+        || trimmed.ends_with('.')
+        || trimmed.ends_with('!')
+        || trimmed.ends_with('?')
+    {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}.")
+    }
 }
 
 fn sanitize_preview(text: &str) -> String {
     let no_literal_newline = text.replace("\\n", " ");
     let no_xml = XML_TAG_RE.replace_all(&no_literal_newline, "");
-    let no_markdown = MD_HEADING_RE.replace_all(&no_xml, "");
+    let no_headings = MD_HEADING_RE.replace_all(&no_xml, "");
+    let no_markdown = MD_BULLET_RE.replace_all(&no_headings, "");
     let mut result = no_markdown
         .lines()
         .map(str::trim)
@@ -911,5 +941,78 @@ mod tests {
                 open_proposals: 0,
             }
         }
+    }
+
+    // ---- readability regressions from the 10.1.0 live smoke ------------
+    //
+    // The first real recap read `...never thought about it v10 of CSR b...:
+    // Current state: Merged to main: - #281 ... witness ledger,....` — a
+    // mid-word cut, flattened bullets, and a comma stacked against the
+    // ellipsis and clause terminator.
+
+    #[test]
+    fn compact_preview_never_cuts_mid_word() {
+        let got = compact_preview(
+            "dreaming research on v10 of CSR before anything shipped",
+            30,
+        );
+        assert!(got.ends_with("..."), "expected an ellipsis, got {got:?}");
+        let body = got.trim_end_matches('.');
+        assert!(
+            body.split_whitespace().last().is_some_and(|word| {
+                "dreaming research on v10 of CSR before anything shipped"
+                    .split_whitespace()
+                    .any(|whole| whole == word)
+            }),
+            "last word was cut mid-token: {got:?}"
+        );
+    }
+
+    #[test]
+    fn truncation_drops_trailing_punctuation_before_the_ellipsis() {
+        let got = truncate_at_word_boundary("codewitness, witness ledger, deterministic", 26);
+        assert!(!got.contains(",..."), "comma survived the cut: {got:?}");
+        assert!(got.ends_with("..."), "expected an ellipsis, got {got:?}");
+    }
+
+    #[test]
+    fn clause_terminator_is_never_doubled() {
+        assert_eq!(terminate_clause("witness ledger..."), "witness ledger...");
+        assert_eq!(terminate_clause("done already."), "done already.");
+        assert_eq!(terminate_clause("shipped it"), "shipped it.");
+        assert_eq!(terminate_clause("why not?"), "why not?");
+    }
+
+    #[test]
+    fn markdown_bullets_do_not_leak_into_the_paragraph() {
+        let cleaned =
+            sanitize_preview("Merged to main:\n- #281 landed\n- #282 landed\n2. then tag");
+        assert!(!cleaned.contains("- #281"), "bullet survived: {cleaned:?}");
+        assert!(
+            !cleaned.contains("2. then"),
+            "ordered marker survived: {cleaned:?}"
+        );
+        assert!(cleaned.contains("#281 landed"));
+    }
+
+    #[test]
+    fn live_shaped_episode_reads_as_prose() {
+        let mut ep = episode();
+        ep.request =
+            "Dreaming, we researched it chatted around it never thought about it v10 of CSR being \
+             the release that makes it real"
+                .into();
+        ep.completed = "Current state:\n- Merged to main: #281 v10 dreaming (codewitness, witness \
+                        ledger, deterministic supersession)\n- #282 recap layer"
+            .into();
+        ep.next_steps = None;
+        ep.blockers = None;
+        ep.todos = vec![];
+
+        let got = compose_recap(&ep, &RecapFeeds::empty(), "2m ago").unwrap();
+        assert!(!got.contains("...."), "stacked punctuation: {got:?}");
+        assert!(!got.contains(",..."), "comma against ellipsis: {got:?}");
+        assert!(!got.contains(": - "), "flattened bullet: {got:?}");
+        assert!(!got.contains("Next:"), "next was fabricated: {got:?}");
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-self-reflect",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Give Claude perfect memory of all your conversations. Single binary, zero dependencies.",
   "keywords": [
     "claude",


### PR DESCRIPTION
Release commit for 10.1.0. Merge after #283 so the tag covers the supersession-basis fix.

## Version sync

`package.json`, `csr-engine/Cargo.toml` and the regenerated `csr-engine/Cargo.lock` all read 10.1.0 in this single commit. The v9.4.1 incident was a Cargo.toml bump without the lock: the Release workflow builds with `--locked` and the tag build failed before publish, so the lock is staged here rather than left for a follow-up.

10.0.0 was prepared but never published. Everything from the v10 dreaming work therefore ships as 10.1.0, with recap as the headline feature.

## Docs

- CHANGELOG entry covering both halves — recap at SessionStart, and dreaming (codewitness, witness ledger, deterministic supersession, validity partition, dream cadence, T4 benchmark) — plus TAD v2, the closed self-contamination loop, corpus expansion, codegraph correctness fixes, and rmcp 1.6 → 3.1.
- CLAUDE.md: new Recap section, supersession-basis note, and a SessionStart hook row that describes what the hook actually injects.

## Gates run locally

- `cargo test --lib`: 1,136 passed (via pre-commit, which also runs fmt and clippy `-D warnings`)
- `cargo build --release`: clean at 10.1.0
- `csr-engine eval`: 5/5 — 148,743 chunks, search 1.2ms, 15 MCP tools

Still to do after merge, and deliberately not done here: tag `v10.1.0` on merged main (that triggers the Release workflow and the npm publish, which is burn-on-publish), and the codewitness crates.io publish, which needs `publish = false` flipped first. The crate name is confirmed free on crates.io.

https://claude.ai/code/session_014uFuurLMagweAq96PsijZn