### PR TITLE
Fix three Windows-only failures that make every hook a no-op (carrier for #272)

### DIFF
--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -57,13 +57,29 @@ pub fn read_stdin_json() -> HookInput {
 
     // If stdin is a TTY (not piped), don't block waiting for input
     if std::io::stdin().is_terminal() {
+        crate::telemetry::append_timing_line("CSR stdin: is a terminal, no piped input");
         return HookInput::default();
     }
 
     let mut buf = String::new();
     match std::io::stdin().read_to_string(&mut buf) {
-        Ok(_) if !buf.trim().is_empty() => serde_json::from_str(&buf).unwrap_or_default(),
-        _ => HookInput::default(),
+        Ok(_) if !buf.trim().is_empty() => match serde_json::from_str(&buf) {
+            Ok(input) => input,
+            Err(e) => {
+                // A parse failure here silently degrades to Default (no prompt,
+                // no transcript_path) — the hook then no-ops. Log it loudly.
+                crate::telemetry::append_timing_line(&format!(
+                    "CSR stdin: {}B received but JSON parse FAILED: {}",
+                    buf.len(),
+                    e
+                ));
+                HookInput::default()
+            }
+        },
+        _ => {
+            crate::telemetry::append_timing_line("CSR stdin: empty (no JSON piped)");
+            HookInput::default()
+        }
     }
 }
 
@@ -120,16 +136,35 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
     let input = read_stdin_json();
     let t_stdin = t0.elapsed();
 
+    // Field-presence diagnostic: hook=0ms exits are indistinguishable from a
+    // missing prompt without this (live debugging 2026-07-30).
+    crate::telemetry::append_timing_line(&format!(
+        "CSR hook {} input: prompt_len={} cwd={:?} transcript={} session={}",
+        hook_name,
+        input.prompt.as_deref().map(str::len).unwrap_or(0),
+        input.cwd,
+        input.transcript_path.is_some(),
+        input.session_id.is_some(),
+    ));
+
     // Determine CWD: prefer input.cwd, fall back to process CWD
     // Validate that cwd is a real directory under $HOME (S-3 fix)
     let cwd = if let Some(ref dir) = input.cwd {
         let p = std::path::PathBuf::from(dir);
         if p.is_dir() {
             let canonical = p.canonicalize()?;
-            if let Some(home) = dirs::home_dir() {
-                if !canonical.starts_with(&home) {
-                    anyhow::bail!("cwd {} is outside home directory", canonical.display());
-                }
+            // S-3 check, Windows-fixed: canonicalize() returns a \\?\-prefixed
+            // path, so the raw home_dir() never prefix-matched and this bailed
+            // on EVERY hook that carried a cwd — compare canonical vs canonical.
+            // And outside-home is a warning, not an error: projects legitimately
+            // live on other drives (D:\...), and a hook that dies here silently
+            // disables both injection and live transcript import.
+            let home_ok = dirs::home_dir()
+                .and_then(|h| h.canonicalize().ok())
+                .map(|h| canonical.starts_with(&h))
+                .unwrap_or(false);
+            if !home_ok {
+                eprintln!("CSR: cwd {} outside home (allowed)", canonical.display());
             }
             canonical
         } else {

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -190,6 +190,15 @@ fn resolve_hook_cwd(input_cwd: Option<&str>) -> PathBuf {
             }
             return resolved;
         }
+        // A cwd arrived but does not name a directory. Falling back is the right
+        // behaviour, but doing it silently is exactly how the Windows breakage
+        // above survived unnoticed for so long — leave a line so the next one is
+        // diagnosable from the log alone.
+        // Quoted, not `Display`: an empty cwd is a real case and prints as nothing,
+        // which reads as a corrupt log line rather than the anomaly it is.
+        crate::telemetry::append_timing_line(&format!(
+            "CSR cwd: input cwd {dir:?} is not a directory — falling back to current_dir()"
+        ));
     }
 
     std::env::current_dir().unwrap_or_else(|e| {

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -18,7 +18,7 @@ pub mod session_start;
 pub mod stop;
 
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -151,6 +151,59 @@ fn hook_input_from(read: StdinRead) -> HookInput {
     }
 }
 
+/// Resolve the directory a hook operates on. Prefers the cwd Claude Code sent,
+/// falls back to the process cwd, and **never fails**.
+///
+/// Every step here used to abort the whole hook with `?`: `canonicalize` fails if
+/// the directory is renamed or removed between `is_dir()` and the call, and
+/// `current_dir` fails outright once the process's own working directory is gone.
+/// Aborting is the failure this module keeps having to fix — it silently disables
+/// both context injection and live transcript import — so each step now degrades to
+/// the next best path and says so, rather than taking the session down with it.
+///
+/// Also performs the S-3 home-directory check (Windows-fixed: `canonicalize()`
+/// returns a `\\?\`-prefixed path, so the raw `home_dir()` never prefix-matched and
+/// this bailed on EVERY hook that carried a cwd — compare canonical vs canonical).
+/// Outside-`$HOME` is a warning, not an error: projects legitimately live on other
+/// drives.
+fn resolve_hook_cwd(input_cwd: Option<&str>) -> PathBuf {
+    if let Some(dir) = input_cwd {
+        let p = PathBuf::from(dir);
+        if p.is_dir() {
+            let resolved = match p.canonicalize() {
+                Ok(canonical) => canonical,
+                Err(e) => {
+                    crate::telemetry::append_timing_line(&format!(
+                        "CSR cwd: canonicalize({}) failed ({}) — using the path as given",
+                        p.display(),
+                        e
+                    ));
+                    p
+                }
+            };
+            let home_ok = dirs::home_dir()
+                .and_then(|h| h.canonicalize().ok())
+                .map(|h| resolved.starts_with(&h))
+                .unwrap_or(false);
+            if !home_ok {
+                eprintln!("CSR: cwd {} outside home (allowed)", resolved.display());
+            }
+            return resolved;
+        }
+    }
+
+    std::env::current_dir().unwrap_or_else(|e| {
+        // The process cwd itself is unreadable (deleted out from under us). A
+        // relative path keeps the hook alive; whatever it touches will fail on its
+        // own terms instead of killing the session here.
+        crate::telemetry::append_timing_line(&format!(
+            "CSR cwd: current_dir() failed ({}) — falling back to \".\"",
+            e
+        ));
+        PathBuf::from(".")
+    })
+}
+
 /// Shared helper: import the current transcript incrementally.
 /// Used by stop, precompact, prompt_submit, and session_end hooks.
 pub async fn import_current_transcript(input: &HookInput, engine: &Engine, cwd: &Path) {
@@ -215,32 +268,7 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
         input.session_id.is_some(),
     ));
 
-    // Determine CWD: prefer input.cwd, fall back to process CWD
-    // Validate that cwd is a real directory under $HOME (S-3 fix)
-    let cwd = if let Some(ref dir) = input.cwd {
-        let p = std::path::PathBuf::from(dir);
-        if p.is_dir() {
-            let canonical = p.canonicalize()?;
-            // S-3 check, Windows-fixed: canonicalize() returns a \\?\-prefixed
-            // path, so the raw home_dir() never prefix-matched and this bailed
-            // on EVERY hook that carried a cwd — compare canonical vs canonical.
-            // And outside-home is a warning, not an error: projects legitimately
-            // live on other drives (D:\...), and a hook that dies here silently
-            // disables both injection and live transcript import.
-            let home_ok = dirs::home_dir()
-                .and_then(|h| h.canonicalize().ok())
-                .map(|h| canonical.starts_with(&h))
-                .unwrap_or(false);
-            if !home_ok {
-                eprintln!("CSR: cwd {} outside home (allowed)", canonical.display());
-            }
-            canonical
-        } else {
-            std::env::current_dir()?
-        }
-    } else {
-        std::env::current_dir()?
-    };
+    let cwd = resolve_hook_cwd(input.cwd.as_deref());
 
     let t_setup = t0.elapsed();
 
@@ -323,6 +351,26 @@ mod tests {
             matches!(outcome, StdinRead::Empty),
             "whitespace-only input is empty, not a payload"
         );
+    }
+
+    #[test]
+    fn resolve_hook_cwd_never_fails() {
+        // A real directory is taken and canonicalized.
+        let real = std::env::temp_dir();
+        assert_eq!(
+            resolve_hook_cwd(Some(&real.to_string_lossy())),
+            real.canonicalize().unwrap()
+        );
+
+        // A cwd that is not a directory, and no cwd at all, both fall back to the
+        // process directory instead of aborting the hook.
+        let here = std::env::current_dir().unwrap();
+        assert_eq!(
+            resolve_hook_cwd(Some("/definitely/not/a/directory/csr-test")),
+            here
+        );
+        assert_eq!(resolve_hook_cwd(None), here);
+        assert_eq!(resolve_hook_cwd(Some("")), here);
     }
 
     #[test]

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -50,8 +50,27 @@ pub struct HookInput {
     pub source: Option<String>,
 }
 
-/// Read and parse JSON from stdin. Returns a default HookInput if stdin is empty or invalid.
-/// Guards against hanging when invoked from a terminal (S-4 fix).
+/// How long the hook waits for the piped JSON before giving up.
+///
+/// `read_to_string` returns at EOF, so a parent that opens the pipe, writes
+/// nothing and keeps its write handle open would block the hook — and with it the
+/// session — forever. A hook must never block Claude Code, so the read is bounded.
+const STDIN_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2000);
+
+/// What reading stdin produced. Separated from the read itself so the outcomes and
+/// their logging are testable without a real pipe.
+#[derive(Debug)]
+enum StdinRead {
+    Payload(String),
+    Empty,
+    TimedOut,
+    Failed(String),
+}
+
+/// Read and parse JSON from stdin. Returns a default HookInput if stdin is empty,
+/// unreadable, invalid or too slow: a hook never fails because of its input.
+/// Guards against hanging when invoked from a terminal (S-4 fix) and against a
+/// parent that never closes the pipe.
 pub fn read_stdin_json() -> HookInput {
     use std::io::IsTerminal;
 
@@ -61,9 +80,47 @@ pub fn read_stdin_json() -> HookInput {
         return HookInput::default();
     }
 
-    let mut buf = String::new();
-    match std::io::stdin().read_to_string(&mut buf) {
-        Ok(_) if !buf.trim().is_empty() => match serde_json::from_str(&buf) {
+    hook_input_from(read_bounded(STDIN_READ_TIMEOUT, || {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map(|_| buf)
+    }))
+}
+
+/// Run `read` on its own thread and give up after `timeout`.
+///
+/// The reader thread is deliberately detached rather than joined: when the timeout
+/// fires it is still parked on a pipe nobody is going to close, and this process is
+/// about to exit anyway.
+fn read_bounded<F>(timeout: std::time::Duration, read: F) -> StdinRead
+where
+    F: FnOnce() -> std::io::Result<String> + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome = match read() {
+            Ok(buf) if buf.trim().is_empty() => StdinRead::Empty,
+            Ok(buf) => StdinRead::Payload(buf),
+            Err(e) => StdinRead::Failed(e.to_string()),
+        };
+        let _ = tx.send(outcome);
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(outcome) => outcome,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => StdinRead::TimedOut,
+        // The reader vanished without reporting. Unreadable is not the same as empty.
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            StdinRead::Failed("reader thread disconnected".to_string())
+        }
+    }
+}
+
+/// Turn a stdin read into a HookInput, recording *why* an input was unusable —
+/// empty, unreadable, too slow and unparseable used to be one indistinguishable
+/// `hook=0ms` line.
+fn hook_input_from(read: StdinRead) -> HookInput {
+    match read {
+        StdinRead::Payload(buf) => match serde_json::from_str(&buf) {
             Ok(input) => input,
             Err(e) => {
                 // A parse failure here silently degrades to Default (no prompt,
@@ -76,8 +133,19 @@ pub fn read_stdin_json() -> HookInput {
                 HookInput::default()
             }
         },
-        _ => {
+        StdinRead::Empty => {
             crate::telemetry::append_timing_line("CSR stdin: empty (no JSON piped)");
+            HookInput::default()
+        }
+        StdinRead::TimedOut => {
+            crate::telemetry::append_timing_line(&format!(
+                "CSR stdin: no EOF within {}ms, giving up (parent still holds the pipe)",
+                STDIN_READ_TIMEOUT.as_millis()
+            ));
+            HookInput::default()
+        }
+        StdinRead::Failed(e) => {
+            crate::telemetry::append_timing_line(&format!("CSR stdin: read FAILED: {}", e));
             HookInput::default()
         }
     }
@@ -215,4 +283,66 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
     crate::telemetry::append_timing_line(&timing_line);
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn read_bounded_gives_up_instead_of_hanging() {
+        // Stands in for a parent that opened the pipe and never closes it.
+        let started = Instant::now();
+        let outcome = read_bounded(Duration::from_millis(20), || {
+            std::thread::sleep(Duration::from_secs(30));
+            Ok(String::new())
+        });
+        assert!(
+            matches!(outcome, StdinRead::TimedOut),
+            "a read that never finishes must time out, got {outcome:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the hook must not wait for the reader"
+        );
+    }
+
+    #[test]
+    fn read_bounded_reports_io_errors_separately_from_empty() {
+        let outcome = read_bounded(Duration::from_secs(5), || {
+            Err(std::io::Error::other("pipe exploded"))
+        });
+        match outcome {
+            StdinRead::Failed(e) => assert!(e.contains("pipe exploded")),
+            other => panic!("an I/O failure must not be reported as empty, got {other:?}"),
+        }
+
+        let outcome = read_bounded(Duration::from_secs(5), || Ok("  \n".to_string()));
+        assert!(
+            matches!(outcome, StdinRead::Empty),
+            "whitespace-only input is empty, not a payload"
+        );
+    }
+
+    #[test]
+    fn hook_input_from_parses_a_payload_and_degrades_otherwise() {
+        let input = hook_input_from(StdinRead::Payload(
+            r#"{"prompt":"hola","cwd":"/tmp/proj"}"#.to_string(),
+        ));
+        assert_eq!(input.prompt.as_deref(), Some("hola"));
+        assert_eq!(input.cwd.as_deref(), Some("/tmp/proj"));
+
+        // Every unusable outcome degrades to a default input rather than failing:
+        // the hook still runs, it just has nothing to work with.
+        for unusable in [
+            StdinRead::Payload("not json".to_string()),
+            StdinRead::Empty,
+            StdinRead::TimedOut,
+            StdinRead::Failed("boom".to_string()),
+        ] {
+            let input = hook_input_from(unusable);
+            assert!(input.prompt.is_none() && input.transcript_path.is_none());
+        }
+    }
 }

--- a/csr-engine/src/search/cross_project.rs
+++ b/csr-engine/src/search/cross_project.rs
@@ -7,6 +7,24 @@ pub fn resolve_project_from_cwd(cwd: &str) -> Option<String> {
         return None;
     }
 
+    // Windows drive path ("D:\Claude", or "\\?\D:\Claude" after canonicalize):
+    // stored project names are Claude Code's ~/.claude/projects folder names,
+    // which encode the FULL path with every non-alphanumeric char as '-'
+    // ("D:\Claude" → "D--Claude"). The last-component fallback below returned
+    // "Claude", which matches no stored project and silently emptied every
+    // project-scoped search. Hooks receive the project root as cwd, so no
+    // component-walking is needed here.
+    let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
+    let trimmed = stripped.trim_end_matches(['\\', '/']);
+    if trimmed.len() >= 2 && trimmed.as_bytes()[1] == b':' {
+        return Some(
+            trimmed
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect(),
+        );
+    }
+
     let path = std::path::Path::new(cwd);
     let dir_name = path.file_name()?.to_string_lossy().to_string();
 

--- a/csr-engine/src/search/cross_project.rs
+++ b/csr-engine/src/search/cross_project.rs
@@ -159,4 +159,36 @@ mod tests {
         let result = resolve_project_from_cwd("/tmp/something/mydir");
         assert_eq!(result, Some("mydir".to_string()));
     }
+
+    /// Pins the stored project-name contract for Windows drive paths.
+    ///
+    /// Deliberately NOT `#[cfg(windows)]`-gated: the code path under test is pure
+    /// string handling with no platform-conditional code, so gating it would only
+    /// hide the regression from the CI that actually runs — which has no Windows
+    /// job. A hook can deliver `cwd` raw, `\\?\`-canonicalized, with a trailing
+    /// separator, or any combination of those, and every shape has to land on the
+    /// same stored name or project-scoped search silently returns nothing.
+    #[test]
+    fn test_resolve_from_cwd_windows_drive_paths() {
+        for cwd in [
+            r"D:\Claude",
+            r"\\?\D:\Claude",
+            "D:\\Claude\\",
+            "\\\\?\\D:\\Claude\\",
+        ] {
+            assert_eq!(
+                resolve_project_from_cwd(cwd),
+                Some("D--Claude".to_string()),
+                "cwd {cwd:?} must encode to the stored project name"
+            );
+        }
+
+        // The encoding covers the whole path, not just the last component — that
+        // was the original bug: "D:\Claude" resolved to "Claude", which matches no
+        // stored project.
+        assert_eq!(
+            resolve_project_from_cwd(r"D:\Proyectos\claude-self-reflect"),
+            Some("D--Proyectos-claude-self-reflect".to_string())
+        );
+    }
 }

--- a/csr-engine/src/search/cross_project.rs
+++ b/csr-engine/src/search/cross_project.rs
@@ -1,5 +1,27 @@
 use crate::import;
 
+/// Encode a path the way Claude Code names its `~/.claude/projects` folders.
+///
+/// Claude Code does `path.replace(/[^a-zA-Z0-9]/g, "-")` (verified in the shipped
+/// binary, 2.1.226). That regex carries no `u` flag, so it runs over UTF-16 code
+/// units, not scalar values: an accented BMP character costs one dash, but a
+/// non-BMP one (emoji, rarer CJK) is a surrogate pair and costs *two*. Mapping per
+/// `char` would emit one dash there and miss the stored folder — the same silent
+/// empty-result failure this whole branch exists to fix, just narrower.
+fn encode_project_folder(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for c in path.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else {
+            for _ in 0..c.len_utf16() {
+                out.push('-');
+            }
+        }
+    }
+    out
+}
+
 /// Resolve project name from a CWD path string.
 /// Pure function — testable without environment variable manipulation.
 pub fn resolve_project_from_cwd(cwd: &str) -> Option<String> {
@@ -17,12 +39,7 @@ pub fn resolve_project_from_cwd(cwd: &str) -> Option<String> {
     let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
     let trimmed = stripped.trim_end_matches(['\\', '/']);
     if trimmed.len() >= 2 && trimmed.as_bytes()[1] == b':' {
-        return Some(
-            trimmed
-                .chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-                .collect(),
-        );
+        return Some(encode_project_folder(trimmed));
     }
 
     let path = std::path::Path::new(cwd);
@@ -189,6 +206,31 @@ mod tests {
         assert_eq!(
             resolve_project_from_cwd(r"D:\Proyectos\claude-self-reflect"),
             Some("D--Proyectos-claude-self-reflect".to_string())
+        );
+    }
+
+    /// Claude Code's encoder is `replace(/[^a-zA-Z0-9]/g, "-")` with no `u` flag,
+    /// so it counts UTF-16 code units: one dash for a BMP character, two for a
+    /// surrogate pair. Non-ASCII project directories are ordinary outside English
+    /// locales, so getting this wrong reproduces the original miss on exactly the
+    /// paths least likely to be reported.
+    #[test]
+    fn test_resolve_from_cwd_non_ascii_drive_paths() {
+        // Every non-ASCII character here is BMP: one code unit, one dash.
+        assert_eq!(
+            resolve_project_from_cwd(r"D:\Proyectos\Español"),
+            Some("D--Proyectos-Espa-ol".to_string())
+        );
+        // ':' + '\' + 7 Cyrillic + '\' + 3 Cyrillic = 13 code units after "C".
+        assert_eq!(
+            resolve_project_from_cwd(r"C:\Проекты\бот"),
+            Some(format!("C{}", "-".repeat(13)))
+        );
+
+        // A non-BMP character is a surrogate pair: two code units, two dashes.
+        assert_eq!(
+            resolve_project_from_cwd("D:\\🚀x"),
+            Some("D----x".to_string())
         );
     }
 }

--- a/csr-engine/src/search/cross_project.rs
+++ b/csr-engine/src/search/cross_project.rs
@@ -39,7 +39,17 @@ pub fn resolve_project_from_cwd(cwd: &str) -> Option<String> {
     let stripped = cwd.strip_prefix(r"\\?\").unwrap_or(cwd);
     let trimmed = stripped.trim_end_matches(['\\', '/']);
     if trimmed.len() >= 2 && trimmed.as_bytes()[1] == b':' {
-        return Some(encode_project_folder(trimmed));
+        // At a drive root the separator is the path, not trailing decoration:
+        // Claude Code stores `D:\` as `D--`, so trimming down to `D:` would
+        // resolve `D-` and miss. Below the root, a trailing separator is just a
+        // shape the hook may deliver and is dropped.
+        let at_drive_root = trimmed.len() == 2 && stripped.len() > 2;
+        let to_encode = if at_drive_root {
+            &stripped[..3]
+        } else {
+            trimmed
+        };
+        return Some(encode_project_folder(to_encode));
     }
 
     let path = std::path::Path::new(cwd);
@@ -207,6 +217,23 @@ mod tests {
             resolve_project_from_cwd(r"D:\Proyectos\claude-self-reflect"),
             Some("D--Proyectos-claude-self-reflect".to_string())
         );
+    }
+
+    /// A project sitting at the drive root. The separator there is part of the
+    /// path — `D:\` is stored as `D--`, not `D-` — so the trailing-separator trim
+    /// must stop at the root.
+    #[test]
+    fn test_resolve_from_cwd_drive_root() {
+        for cwd in [r"D:\", "D:/", r"\\?\D:\", r"D:\\\\"] {
+            assert_eq!(
+                resolve_project_from_cwd(cwd),
+                Some("D--".to_string()),
+                "cwd {cwd:?} is the drive root"
+            );
+        }
+
+        // A bare drive letter carries no separator to preserve.
+        assert_eq!(resolve_project_from_cwd("D:"), Some("D-".to_string()));
     }
 
     /// Claude Code's encoder is `replace(/[^a-zA-Z0-9]/g, "-")` with no `u` flag,

--- a/csr-engine/src/telemetry/mod.rs
+++ b/csr-engine/src/telemetry/mod.rs
@@ -90,7 +90,10 @@ pub struct Telemetry {
     pub log_lines_in_window: usize,
 }
 
-/// Explicit override for the timing log location: an absolute path.
+/// Explicit override for the timing log location. Must be an absolute path — a
+/// relative one would resolve against whatever directory the hook happened to run
+/// in, scattering the log — so relative values are ignored and the normal path is
+/// used instead.
 pub const TIMING_LOG_ENV: &str = "CSR_TIMING_LOG";
 
 /// Resolve the canonical log path: `~/.claude-self-reflect/hook-timing.log`.
@@ -98,14 +101,39 @@ pub const TIMING_LOG_ENV: &str = "CSR_TIMING_LOG";
 /// Checked in order: the `CSR_TIMING_LOG` override, a test-harness redirect, then
 /// the real installation path.
 pub fn default_log_path() -> Option<PathBuf> {
-    match std::env::var_os(TIMING_LOG_ENV) {
-        Some(p) if !p.is_empty() => return Some(PathBuf::from(p)),
-        _ => {}
+    resolve_log_path(
+        std::env::var_os(TIMING_LOG_ENV),
+        running_under_test_harness(),
+        dirs::home_dir(),
+    )
+}
+
+/// The decision behind [`default_log_path`], with every input passed in.
+///
+/// Pure on purpose: the alternative is tests that mutate `CSR_TIMING_LOG` in a
+/// process-global environment while the rest of the suite reads it on other
+/// threads.
+fn resolve_log_path(
+    override_var: Option<std::ffi::OsString>,
+    under_test_harness: bool,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(raw) = override_var {
+        let p = PathBuf::from(raw);
+        if p.is_absolute() {
+            return Some(p);
+        }
+        // Empty or relative: a mis-set variable, not a request to log to "." —
+        // fall through rather than write somewhere unpredictable.
     }
-    if running_under_test_harness() {
-        return Some(std::env::temp_dir().join("csr-test-hook-timing.log"));
+    if under_test_harness {
+        // Per-process: `cargo test` runs the lib, hooks and integration harnesses
+        // concurrently, and a shared file would let them rotate each other's log.
+        return Some(
+            std::env::temp_dir().join(format!("csr-test-hook-timing-{}.log", std::process::id())),
+        );
     }
-    dirs::home_dir().map(|h| h.join(".claude-self-reflect").join("hook-timing.log"))
+    home.map(|h| h.join(".claude-self-reflect").join("hook-timing.log"))
 }
 
 /// True when this process is a `cargo test` / `cargo bench` binary.
@@ -235,21 +263,60 @@ mod log_path_tests {
         );
     }
 
-    #[test]
-    fn explicit_override_wins() {
-        let want = std::env::temp_dir().join("csr-override-probe.log");
-        std::env::set_var(TIMING_LOG_ENV, &want);
-        let got = default_log_path();
-        std::env::remove_var(TIMING_LOG_ENV);
-        assert_eq!(got, Some(want));
+    fn home() -> Option<PathBuf> {
+        Some(PathBuf::from("/home/dev"))
     }
 
-    /// An empty override is a mis-set variable, not a request to log to "".
+    fn live() -> Option<PathBuf> {
+        Some(PathBuf::from(
+            "/home/dev/.claude-self-reflect/hook-timing.log",
+        ))
+    }
+
+    /// Every input is an argument, so none of these mutate the process
+    /// environment — the suite runs in parallel and `set_var` is process-global.
     #[test]
-    fn empty_override_falls_through() {
-        std::env::set_var(TIMING_LOG_ENV, "");
-        let got = default_log_path();
-        std::env::remove_var(TIMING_LOG_ENV);
-        assert_ne!(got, Some(PathBuf::new()));
+    fn an_absolute_override_wins() {
+        let want = PathBuf::from("/var/log/csr/hook-timing.log");
+        assert_eq!(
+            resolve_log_path(Some(want.clone().into()), false, home()),
+            Some(want.clone())
+        );
+        // Even under the test harness, and even with no home directory at all.
+        assert_eq!(
+            resolve_log_path(Some(want.clone().into()), true, None),
+            Some(want)
+        );
+    }
+
+    /// Empty or relative is a mis-set variable, not a request to log to "." — it
+    /// would follow the hook's working directory and scatter the log.
+    #[test]
+    fn empty_and_relative_overrides_fall_through() {
+        for bad in ["", "hook-timing.log", "./logs/hook-timing.log", ".."] {
+            assert_eq!(
+                resolve_log_path(Some(bad.into()), false, home()),
+                live(),
+                "override {bad:?} must not be honoured"
+            );
+        }
+    }
+
+    #[test]
+    fn the_harness_redirect_is_per_process_and_not_the_live_log() {
+        let path = resolve_log_path(None, true, home()).expect("harness path");
+        assert_ne!(Some(path.clone()), live());
+        assert!(
+            path.to_string_lossy()
+                .ends_with(&format!("csr-test-hook-timing-{}.log", std::process::id())),
+            "concurrent test binaries must not share one file: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn without_an_override_or_harness_it_is_the_installed_path() {
+        assert_eq!(resolve_log_path(None, false, home()), live());
+        assert_eq!(resolve_log_path(None, false, None), None);
     }
 }

--- a/csr-engine/src/telemetry/mod.rs
+++ b/csr-engine/src/telemetry/mod.rs
@@ -90,9 +90,45 @@ pub struct Telemetry {
     pub log_lines_in_window: usize,
 }
 
+/// Explicit override for the timing log location: an absolute path.
+pub const TIMING_LOG_ENV: &str = "CSR_TIMING_LOG";
+
 /// Resolve the canonical log path: `~/.claude-self-reflect/hook-timing.log`.
+///
+/// Checked in order: the `CSR_TIMING_LOG` override, a test-harness redirect, then
+/// the real installation path.
 pub fn default_log_path() -> Option<PathBuf> {
+    match std::env::var_os(TIMING_LOG_ENV) {
+        Some(p) if !p.is_empty() => return Some(PathBuf::from(p)),
+        _ => {}
+    }
+    if running_under_test_harness() {
+        return Some(std::env::temp_dir().join("csr-test-hook-timing.log"));
+    }
     dirs::home_dir().map(|h| h.join(".claude-self-reflect").join("hook-timing.log"))
+}
+
+/// True when this process is a `cargo test` / `cargo bench` binary.
+///
+/// Without this, `cargo test` appends to the developer's live hook-timing.log —
+/// the same log they debug hooks with, which is how a test run can invent
+/// evidence for the bug being investigated.
+///
+/// Two signals, both required: Cargo exports `CARGO_MANIFEST_DIR` into the
+/// processes it launches, and it runs test/bench harnesses out of
+/// `target/<profile>/deps/`. An installed `csr-engine` has neither; `cargo run`
+/// has the first but not the second, so a hook run by hand still writes where the
+/// developer expects.
+fn running_under_test_harness() -> bool {
+    if std::env::var_os("CARGO_MANIFEST_DIR").is_none() {
+        return false;
+    }
+    std::env::args_os().next().is_some_and(|arg0| {
+        Path::new(&arg0)
+            .parent()
+            .and_then(|d| d.file_name())
+            .is_some_and(|d| d == std::ffi::OsStr::new("deps"))
+    })
 }
 
 /// The previous log generation kept after rotation: `hook-timing.log.1`.
@@ -174,4 +210,46 @@ pub fn collect(db_path: &Path, projects_dir: &Path, window: Window) -> Result<Te
         log_lines_scanned: scanned,
         log_lines_in_window: entries.len(),
     })
+}
+
+#[cfg(test)]
+mod log_path_tests {
+    use super::*;
+
+    /// The bug this guards: `cargo test` used to append to
+    /// `~/.claude-self-reflect/hook-timing.log` — the developer's live log —
+    /// because the path resolved straight through `home_dir()`.
+    #[test]
+    fn test_runs_never_resolve_to_the_live_log() {
+        let path = default_log_path().expect("a log path is always resolvable under test");
+        let live = dirs::home_dir().map(|h| h.join(".claude-self-reflect").join("hook-timing.log"));
+        assert_ne!(
+            Some(path.clone()),
+            live,
+            "a test run must not write to the installed log"
+        );
+        assert!(
+            running_under_test_harness(),
+            "the harness signal is what redirects it; path was {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn explicit_override_wins() {
+        let want = std::env::temp_dir().join("csr-override-probe.log");
+        std::env::set_var(TIMING_LOG_ENV, &want);
+        let got = default_log_path();
+        std::env::remove_var(TIMING_LOG_ENV);
+        assert_eq!(got, Some(want));
+    }
+
+    /// An empty override is a mis-set variable, not a request to log to "".
+    #[test]
+    fn empty_override_falls_through() {
+        std::env::set_var(TIMING_LOG_ENV, "");
+        let got = default_log_path();
+        std::env::remove_var(TIMING_LOG_ENV);
+        assert_ne!(got, Some(PathBuf::new()));
+    }
 }

--- a/docs-site/src/content/configuration.md
+++ b/docs-site/src/content/configuration.md
@@ -20,6 +20,7 @@ Configured in `~/.claude/settings.json` via `csr-engine hook install --apply`.
 | CSR_NARRATIVE_MODEL | — | Override model for AI narratives (falls back to `haiku`, then CLI default) |
 | CSR_NO_AI_NARRATIVES | — | Set to `1` to disable AI narrative generation entirely |
 | CSR_DB_PATH | ~/.claude-self-reflect/csr-engine.db | Custom DB path |
+| CSR_TIMING_LOG | ~/.claude-self-reflect/hook-timing.log | Custom hook-timing log path (test runs redirect to a temp file automatically) |
 
 AI narratives run through the Claude Code CLI (`claude -p`) — no API key required.
 


### PR DESCRIPTION
Carrier branch for #272 by @davrodwconnections — the four original commits cherry-picked onto `main` (v10.1.0) with authorship intact — plus the two follow-ups that review recorded.

Why a carrier: the `main` ruleset requires a code-scanning result, and CodeQL default setup does not scan fork heads, so #272 can never satisfy it (admin merge does not bypass that rule either). Opening the same commits from a branch in this repo lets CodeQL run.

## From #272 — three Windows-only hook failures, no behaviour change on Unix

1. The S-3 home-directory guard compared a `\\?\`-prefixed canonical path against a raw `home_dir()`, so it bailed on *every* hook carrying a `cwd`. Now canonical-vs-canonical, and outside-`$HOME` is a warning rather than a hard error — projects legitimately live on `D:\`, and dying there disabled live transcript import too, not just injection.
2. `resolve_project_from_cwd` returned `Claude` for `D:\Claude` while chunks are stored under `D--Claude`, so project-scoped search silently returned nothing. Drive paths now encode the full path, matching what `normalize_project_name` stores.
3. The stdin read is bounded (2s) and every outcome — empty, unparseable, timed out, failed — is logged, instead of collapsing into one indistinguishable `hook=0ms` line.

## Added here — the two items recorded during review

**`cargo test` no longer writes to the developer's live `hook-timing.log`** (`1558b0e`). `append_timing_line` resolved through `dirs::home_dir()` with no override, so a test run appended to whatever installation the developer was actually using — the log they read while debugging hooks. `default_log_path` now checks an explicit `CSR_TIMING_LOG` path, then a test-harness redirect to a temp file, then the real path. The harness check requires two signals: Cargo exports `CARGO_MANIFEST_DIR` into processes it launches, and it runs test binaries out of `target/<profile>/deps/`. An installed binary has neither; `cargo run` has only the first, so a hook run by hand still writes where the developer expects.

**Non-ASCII Windows paths encode like Claude Code does** (`59dfcf3`). The drive-path branch emitted one dash per Rust `char`. Claude Code uses `path.replace(/[^a-zA-Z0-9]/g, "-")` — confirmed in the shipped binary, 2.1.226 — and that regex has no `u` flag, so it counts UTF-16 code units: one dash for a BMP character, two for a surrogate pair. `D:\🚀x` is stored as `D----x` and we resolved `D---x` — the same silent miss this branch exists to fix, aimed at the locales least likely to report it. Test expectations were taken from Node running the actual regex rather than derived by hand.

## Verification

macOS aarch64, at `59dfcf3`:

```
cargo test --release --lib                            1150 passed, 0 failed
cargo test --release --test hooks_integration            45 passed
cargo test --release --test integration                  61 passed
cargo fmt --check                                     clean
cargo clippy --release --lib --tests -- -D warnings   clean
```

Behavioural, against the installed v10.1 binary as the control:

| case | v10.1 (before) | this branch |
|---|---|---|
| `cwd` outside `$HOME` (`/private/tmp`) | `Error: cwd /private/tmp is outside home directory`, exit 1 | warns, hook runs, exit 0 |
| parent opens the pipe and never closes it | still parked at 25s, killed | returns in 3s |
| `D:\Claude`, `\\?\D:\Claude`, trailing separator | — | all encode to `D--Claude` |
| `cargo test` effect on the live log | test-origin lines appended | 19 before, 19 after — zero |
| release binary logging | live log | live log (unchanged) |

Full review and receipts on #272.

Closes #272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty, invalid, failed, or delayed input so processing falls back safely instead of hanging or failing unexpectedly.
  * Improved working-directory resolution when environment or path information is unavailable.
  * Fixed project recognition for Windows drive paths, including extended path prefixes and trailing separators.

* **Reliability**
  * Added clearer diagnostics for unusable input and directory-resolution issues.
  * Improved support for projects located across nested Windows directories.

* **Configuration**
  * Added `CSR_TIMING_LOG` to customize timing-log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->