### PR TITLE
docs: homepage pull-quote + rmcp version fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ cargo bench --bench spike_bench
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| rmcp | 1.6 | MCP protocol (tool annotations, macros) |
+| rmcp | 3.1 | MCP protocol (tool annotations, macros) |
 | fastembed | 5.9 | Local embeddings |
 | hnsw_rs | 0.3 | Vector search |
 | rusqlite | 0.38 | SQLite storage |
@@ -113,7 +113,7 @@ cargo bench --bench spike_bench
 
 - **rmcp tool params**: Use `Parameters<MyStruct>` pattern, NOT individual `#[tool(param)]`
 - **rmcp tool annotations**: All 15 tools declare `annotations(...)` in the macro — hints vary per tool (most use `read_only_hint, destructive_hint, idempotent_hint`; `get_full_conversation` uses `open_world_hint` instead of `idempotent_hint`)
-- **rmcp 1.6 builders**: `ServerInfo::new(caps).with_instructions()`, `Implementation::new()`, `ReadResourceResult::new()`
+- **rmcp builders**: `ServerInfo::new(caps).with_instructions()`, `Implementation::new()`, `ReadResourceResult::new()`
 - **fastembed**: Requires `aarch64` Rust — no x86_64-apple-darwin ONNX binaries
 - **rusqlite 0.38**: No `ToSql` for `usize` — cast to `i64`
 - **Storage thread safety**: Wrap `Connection` in `std::sync::Mutex`

--- a/docs-site/src/index.css
+++ b/docs-site/src/index.css
@@ -660,9 +660,10 @@ body {
 .card--multisource { grid-column: 1 / span 7; grid-row: 7; }
 .card--paper { grid-column: 8 / span 5; grid-row: 7; }
 .card--demo { grid-column: 1 / -1; grid-row: 8; }
-.card--flatfile { grid-column: 1 / span 4; grid-row: 10; }
-.card--kgraph { grid-column: 5 / span 4; grid-row: 10; }
-.card--hosted { grid-column: 9 / span 4; grid-row: 10; }
+.card--quote { grid-column: 1 / -1; grid-row: 9; }
+.card--flatfile { grid-column: 1 / span 4; grid-row: 11; }
+.card--kgraph { grid-column: 5 / span 4; grid-row: 11; }
+.card--hosted { grid-column: 9 / span 4; grid-row: 11; }
 
 /* AST card internals */
 .ast-layout {
@@ -909,7 +910,7 @@ body {
 /* Comparison section header */
 .bento-section-header {
   grid-column: 1 / -1;
-  grid-row: 9;
+  grid-row: 10;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
@@ -1986,6 +1987,74 @@ body {
   z-index: 1;
 }
 
+.bento-card.is-visible.card--quote {
+  border-color: rgba(107,91,149,0.34);
+  border-width: 2px;
+  background:
+    radial-gradient(circle at 12% 15%, rgba(246,230,169,0.26), transparent 46%),
+    linear-gradient(135deg, rgba(255,255,255,0.86), rgba(255,255,255,0.68)),
+    rgba(255,255,255,0.80);
+  box-shadow:
+    0 24px 70px rgba(107,91,149,0.12),
+    0 2px 10px rgba(42,38,66,0.06),
+    inset 0 1px 0 rgba(255,255,255,0.90);
+}
+[data-theme="dark"] .bento-card.is-visible.card--quote {
+  border-color: rgba(199,181,255,0.28) !important;
+  background:
+    radial-gradient(circle at 12% 15%, rgba(217,189,115,0.14), transparent 46%),
+    linear-gradient(135deg, rgba(22,30,58,0.86), rgba(13,19,39,0.70)) !important;
+  box-shadow: 0 24px 70px rgba(0,0,0,0.38), inset 0 1px 0 rgba(199,181,255,0.08) !important;
+}
+
+.pull-quote {
+  margin: 10px 0 0;
+  padding-left: 30px;
+  position: relative;
+  max-width: 640px;
+}
+
+.pull-quote__mark {
+  position: absolute;
+  top: -10px;
+  left: -4px;
+  font-family: var(--font-serif);
+  font-size: 46px;
+  line-height: 1;
+  color: var(--color-purple);
+  opacity: 0.4;
+}
+
+.pull-quote__text {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 700;
+  font-size: clamp(24px, 3.2vw, 36px);
+  line-height: 1.16;
+  color: var(--color-ink);
+}
+
+.pull-quote__footer {
+  margin-top: 12px;
+}
+
+.pull-quote__attribution {
+  font-family: var(--font-mono);
+  font-style: normal;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  color: var(--color-muted);
+}
+
+.pull-quote__support {
+  margin: 16px 0 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--color-rule);
+  max-width: 560px;
+}
+
 .section-number {
   font-family: var(--font-mono);
   font-size: 16px;
@@ -2611,7 +2680,8 @@ body {
   .card--arch,
   .card--demo,
   .card--multisource,
-  .card--paper {
+  .card--paper,
+  .card--quote {
     grid-column: 1 / -1;
     grid-row: auto;
   }
@@ -2734,6 +2804,7 @@ body {
   }
   .card--ask         { min-height: 320px; }
   .card--arch        { min-height: 320px; }
+  .card--quote       { min-height: 220px; }
 
   .ask-layout {
     grid-template-columns: 1fr;

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -814,6 +814,22 @@ function KnowledgeGraphCard() {
   )
 }
 
+function PullQuoteCard() {
+  return (
+    <BentoCard className="card--quote" delay={520}>
+      <CardKicker number="—" label="FROM A LIVE SESSION" />
+      <blockquote className="pull-quote">
+        <span className="pull-quote__mark" aria-hidden="true">&ldquo;</span>
+        <p className="pull-quote__text">Retrieval beat curation today.</p>
+        <footer className="pull-quote__footer">
+          <cite className="pull-quote__attribution">— Claude, comparing its own curated MEMORY.md against CSR in a live session</cite>
+        </footer>
+      </blockquote>
+      <p className="pull-quote__support type-caption">A hand-curated memory note answered with stale information; CSR's search over past conversations surfaced the current thread in about 20ms.</p>
+    </BentoCard>
+  )
+}
+
 function WhatsNewCard() {
   return (
     <BentoCard className="card--whatsnew" delay={560} id="whats-new">
@@ -1294,6 +1310,7 @@ export default function Landing() {
           <WhatsNewCard />
           <MultiSourceCard />
           <PaperCard />
+          <PullQuoteCard />
           <div className="bento-section-header">
             <span />
             <h2>How others do it</h2>


### PR DESCRIPTION
## Summary

Two small doc changes, no engine code touched.

**Homepage pull-quote** — added a distinguished full-width card to the docs-site landing page: Claude's own verdict from a real working session, comparing its hand-curated `MEMORY.md` against CSR's search. The exact quote:

> "Retrieval beat curation today."
> — Claude, comparing its own curated MEMORY.md against CSR in a live session

It sits right after "The Paper" card and before the "How others do it" comparison section — the point in the page where a reader has already seen the mechanics and is about to see competing approaches. Styling follows the existing newspaper/bento system already on the page (serif italic quote, mono attribution line, the same distinguished-border treatment used on the Install card), so it doesn't introduce a new visual pattern. Placing it required shifting the "How others do it" section header and the three comparison cards down by one grid row — no other grid rows changed. Verified in both light and dark themes and at desktop/tablet/mobile widths with a local `vite preview` build.

**rmcp version fix** — `CLAUDE.md`'s dependency table still said rmcp 1.6; `csr-engine/Cargo.lock` on `main` has rmcp 3.1.0 (from the migration in #281) and schemars 1.2.2. Updated the version number and the "rmcp 1.6 builders" bullet label. Checked the actual code before touching anything: the `Parameters<T>` tool-param pattern, the `annotations(...)` macro usage (15 tools, `get_full_conversation` using `open_world_hint`), and the `ServerInfo::new().with_instructions()` / `Implementation::new()` / `ReadResourceResult::new()` builder calls are all still present in `src/mcp/mod.rs` as described, so those bullets stayed as-is. The "must be v1 for rmcp" schemars note is also still accurate (1.2.2 is v1).

Left alone: the other dependency table rows (fastembed, hnsw_rs, rusqlite, ast-grep-core, sonic-rs) — not in scope for this pass, didn't verify them against Cargo.lock.

## Test plan

- [x] `npm run build` in `docs-site/` — builds clean
- [x] Local `vite preview` screenshot check of the new card in light mode, dark mode, and at 1440px/390px viewports
- [x] `cargo test` (via pre-commit hook, both commits) — 1153 passed, 0 failed

https://claude.ai/code/session_01HDtuT7shH68d1T3Hn2XuSD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a pull-quote card to the landing page highlighting CSR retrieval capabilities and approximately 20 ms search latency.
  - Improved the landing page layout with responsive positioning for the new content.

- **Documentation**
  - Updated the documented `rmcp` dependency version from 1.6 to 3.1.
  - Simplified the associated builder pattern label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->