### PR TITLE
docs: hero watermark credits Claude Self-Reflect, not Claude Code

### DIFF
--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -1274,12 +1274,12 @@ export default function Landing() {
 
       <div className="hero-watermark" aria-hidden="true">
         <h1 className="hero-watermark__title">You or your agent don't have to remember any of this</h1>
-        <p className="hero-watermark__subtext">because Claude Code does.</p>
+        <p className="hero-watermark__subtext">because Claude Self-Reflect does.</p>
       </div>
 
       <main className="landing-main">
         <p className="type-dateline landing-dateline" style={{ opacity: datelineVisible ? 1 : 0 }}>
-          Claude Self-Reflect / v8.2 / Rust Engine / Local Memory Archive
+          Claude Self-Reflect / v9.5.2 / Rust Engine / Local Memory Archive
         </p>
 
         <section className="bento-grid" aria-label="Claude Self-Reflect overview">


### PR DESCRIPTION
Two homepage copy fixes:

- The hero watermark payoff read "because Claude Code does." — backwards: Claude Code is the thing that forgets at compaction; Claude Self-Reflect is what remembers. Now reads "because Claude Self-Reflect does."
- Dateline version was six releases stale: v8.2 → v9.5.2.

Verified with a local `npm run build` (clean, pre-existing chunk-size warning only).

https://claude.ai/code/session_01HDtuT7shH68d1T3Hn2XuSD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the landing-page hero messaging to reference Claude Self-Reflect.
  * Updated the displayed version to v9.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->