### PR TITLE
docs: move homepage quote to the second slot, add session receipts

### DIFF
--- a/docs-site/src/index.css
+++ b/docs-site/src/index.css
@@ -2705,6 +2705,11 @@ body {
     grid-column: 1 / -1;
   }
 
+  /* base grid-row: 3 must not pin this ahead of auto-placed cards here */
+  .card--pipeline {
+    grid-row: auto;
+  }
+
   .card--active,
   .card--search,
   .card--import,

--- a/docs-site/src/index.css
+++ b/docs-site/src/index.css
@@ -598,7 +598,7 @@ body {
 .bento-grid {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  grid-template-rows: minmax(320px, auto) minmax(300px, auto) auto auto auto auto minmax(280px, auto);
+  grid-template-rows: minmax(320px, auto) auto minmax(300px, auto) auto auto auto auto;
   gap: 16px;
   align-items: stretch;
 }
@@ -649,18 +649,18 @@ body {
 .card--forgetting { grid-column: 1 / span 5; grid-row: 1; }
 .card--active { grid-column: 6 / span 4; grid-row: 1; }
 .card--search { grid-column: 10 / span 3; grid-row: 1; }
-.card--import { grid-column: 1 / span 4; grid-row: 2; }
-.card--binary { grid-column: 5 / span 3; grid-row: 2; }
-.card--pipeline { grid-column: 8 / span 5; grid-row: 2; }
-.card--privacy { grid-column: 1 / span 3; grid-row: 3; }
-.card--install { grid-column: 4 / -1; grid-row: 3; }
-.card--ask { grid-column: 1 / -1; grid-row: 4; }
-.card--arch { grid-column: 1 / -1; grid-row: 5; }
-.card--whatsnew { grid-column: 1 / -1; grid-row: 6; }
-.card--multisource { grid-column: 1 / span 7; grid-row: 7; }
-.card--paper { grid-column: 8 / span 5; grid-row: 7; }
-.card--demo { grid-column: 1 / -1; grid-row: 8; }
-.card--quote { grid-column: 1 / -1; grid-row: 9; }
+.card--quote { grid-column: 1 / -1; grid-row: 2; }
+.card--import { grid-column: 1 / span 4; grid-row: 3; }
+.card--binary { grid-column: 5 / span 3; grid-row: 3; }
+.card--pipeline { grid-column: 8 / span 5; grid-row: 3; }
+.card--privacy { grid-column: 1 / span 3; grid-row: 4; }
+.card--install { grid-column: 4 / -1; grid-row: 4; }
+.card--ask { grid-column: 1 / -1; grid-row: 5; }
+.card--arch { grid-column: 1 / -1; grid-row: 6; }
+.card--whatsnew { grid-column: 1 / -1; grid-row: 7; }
+.card--multisource { grid-column: 1 / span 7; grid-row: 8; }
+.card--paper { grid-column: 8 / span 5; grid-row: 8; }
+.card--demo { grid-column: 1 / -1; grid-row: 9; }
 .card--flatfile { grid-column: 1 / span 4; grid-row: 11; }
 .card--kgraph { grid-column: 5 / span 4; grid-row: 11; }
 .card--hosted { grid-column: 9 / span 4; grid-row: 11; }
@@ -1899,7 +1899,7 @@ body {
 
 /* Landing card rebuild: editorial bento cards matched to the design comps. */
 .bento-grid {
-  grid-template-rows: minmax(320px, auto) minmax(300px, auto) auto auto auto auto minmax(280px, auto);
+  grid-template-rows: minmax(320px, auto) auto minmax(300px, auto) auto auto auto auto;
 }
 
 .bento-card.is-visible {
@@ -2053,6 +2053,45 @@ body {
   padding-top: 14px;
   border-top: 1px solid var(--color-rule);
   max-width: 560px;
+}
+
+.pull-quote__receipts {
+  margin-top: 14px;
+  max-width: 620px;
+}
+
+.pull-quote__receipts-label {
+  margin: 0 0 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-muted);
+}
+
+.pull-quote__receipts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.pull-quote__receipts-list li {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--color-muted);
+}
+
+.pull-quote__receipts-metric {
+  display: inline-block;
+  min-width: 88px;
+  margin-right: 8px;
+  font-weight: 700;
+  color: var(--color-ink);
 }
 
 .section-number {
@@ -2804,7 +2843,7 @@ body {
   }
   .card--ask         { min-height: 320px; }
   .card--arch        { min-height: 320px; }
-  .card--quote       { min-height: 220px; }
+  .card--quote       { min-height: 340px; }
 
   .ask-layout {
     grid-template-columns: 1fr;

--- a/docs-site/src/pages/Landing.jsx
+++ b/docs-site/src/pages/Landing.jsx
@@ -816,7 +816,7 @@ function KnowledgeGraphCard() {
 
 function PullQuoteCard() {
   return (
-    <BentoCard className="card--quote" delay={520}>
+    <BentoCard className="card--quote" delay={20}>
       <CardKicker number="—" label="FROM A LIVE SESSION" />
       <blockquote className="pull-quote">
         <span className="pull-quote__mark" aria-hidden="true">&ldquo;</span>
@@ -826,6 +826,15 @@ function PullQuoteCard() {
         </footer>
       </blockquote>
       <p className="pull-quote__support type-caption">A hand-curated memory note answered with stale information; CSR's search over past conversations surfaced the current thread in about 20ms.</p>
+      <div className="pull-quote__receipts">
+        <p className="pull-quote__receipts-label">One session's ledger, misses included — not a benchmark</p>
+        <ul className="pull-quote__receipts-list">
+          <li><span className="pull-quote__receipts-metric">0.728 / ~20ms</span>a pre-compaction turn, retrieved after the session had compacted twice</li>
+          <li><span className="pull-quote__receipts-metric">0.78</span>a minutes-old message, retrieved after compaction</li>
+          <li><span className="pull-quote__receipts-metric">stale</span>MEMORY.md's hand-curated note; retrieval held the current thread</li>
+          <li><span className="pull-quote__receipts-metric">2 / 5</span>queries that session came back weak — flagged uncalibrated by the tool itself</li>
+        </ul>
+      </div>
     </BentoCard>
   )
 }
@@ -1284,6 +1293,7 @@ export default function Landing() {
 
         <section className="bento-grid" aria-label="Claude Self-Reflect overview">
           <ForgettingCard />
+          <PullQuoteCard />
           <BentoCard className="card--demo" delay={40}>
             <CardKicker number="—" label="SEE IT IN ACTION" />
             <h2 className="type-hl-md">The Demo</h2>
@@ -1310,7 +1320,6 @@ export default function Landing() {
           <WhatsNewCard />
           <MultiSourceCard />
           <PaperCard />
-          <PullQuoteCard />
           <div className="bento-section-header">
             <span />
             <h2>How others do it</h2>


### PR DESCRIPTION
## Summary

Follow-up to #292 (merged). The quote card was landing at row 9 of 11, right above the "How others do it" comparison section — too far down the page for what's supposed to be an early emotional beat, not a footnote to the comparisons.

**Repositioned to the second card** — directly after "The Forgetting Problem" lead card, before "The Demo" / "Active Memory" / everything else. Moved it in both the CSS grid (`grid-row`) and the JSX render order, since the mobile breakpoint drops the grid and stacks cards by DOM order, not by grid row — moving only the CSS would have left it in the wrong spot on phones. Row 1 (Forgetting/Active/Search) is unchanged; the quote takes the new row 2; everything that was rows 2 through 9 shifted down by one. Row 10 (comparison section header) and row 11 (comparison cards) landed back on the same numbers they had before — removing the quote from its old slot at the tail and inserting it up front cancel out, so no other collisions.

**Added a receipts line** under the supporting sentence — four real numbers from the session the quote came from, explicitly labeled "one session's ledger, misses included — not a benchmark":
- `0.728 / ~20ms` — a pre-compaction turn, retrieved after the session had compacted twice
- `0.78` — a minutes-old message, retrieved after compaction
- `stale` — MEMORY.md's hand-curated note; retrieval held the current thread
- `2 / 5` — queries that session came back weak, flagged uncalibrated by the tool itself

That last line is deliberate — it's not a benchmark result, it's what actually happened, misses included, in keeping with the project's abstention-first stance elsewhere.

## Test plan

- [x] `npm run build` in `docs-site/` — clean
- [x] `vite preview` screenshots: desktop light, desktop dark, 390px mobile — quote card confirmed as the second card in both grid and DOM order; rows 3-4 and rows 9-11 (demo, comparison header, comparison cards) confirmed still aligned with no gaps or overlaps
- [x] `cargo test` (pre-commit hook) — 1153 passed, 0 failed

https://claude.ai/code/session_01HDtuT7shH68d1T3Hn2XuSD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session-ledger “receipts” section to the pull-quote card, highlighting retrieval metrics, stale-memory comparisons, and weak-query counts.
* **Style**
  * Repositioned the quote card near the top of the landing-page overview.
  * Updated the grid layout and card styling to accommodate the revised arrangement.
  * Improved receipt labels, stacked items, and emphasized metrics.
  * Increased the quote card’s minimum height on mobile for improved readability.
  * Improved card placement at intermediate screen widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->