### PR TITLE
fix: strip MCP config from ratification and story subprocesses

### DIFF
--- a/csr-engine/src/daemon/ratification.rs
+++ b/csr-engine/src/daemon/ratification.rs
@@ -130,6 +130,12 @@ fn ratification_model_candidates() -> Vec<Option<String>> {
 }
 
 async fn call_claude_for_acts(prompt: &str) -> Option<crate::narrative::ParsedNarrative> {
+    // The digest is embedded in `prompt`, so the extractor needs NO tools. Without
+    // an explicit empty MCP config this subprocess inherits the user's full MCP set
+    // and blows the context window on tool schemas alone (HTTP 400 prompt_too_long),
+    // failing every call before inference. See narrative::minimal_mcp_config.
+    let mcp_config_path = crate::narrative::minimal_mcp_config().ok();
+
     for candidate in ratification_model_candidates() {
         let attempt = tokio::time::timeout(RATIFICATION_TIMEOUT, async {
             let mut cmd = tokio::process::Command::new("claude");
@@ -140,8 +146,14 @@ async fn call_claude_for_acts(prompt: &str) -> Option<crate::narrative::ParsedNa
             if let Some(model) = &candidate {
                 cmd.args(["--model", model]);
             }
+            cmd.args(["-p", "-", "--output-format", "json"]);
+            // Must come LAST: --mcp-config is variadic in the claude CLI and would
+            // consume any positional arg that followed it.
+            if let Some(path) = &mcp_config_path {
+                cmd.args(["--strict-mcp-config", "--mcp-config"]);
+                cmd.arg(path);
+            }
             let mut child = match cmd
-                .args(["-p", "-", "--output-format", "json"])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .stdin(Stdio::piped())

--- a/csr-engine/src/daemon/ratification.rs
+++ b/csr-engine/src/daemon/ratification.rs
@@ -134,7 +134,14 @@ async fn call_claude_for_acts(prompt: &str) -> Option<crate::narrative::ParsedNa
     // an explicit empty MCP config this subprocess inherits the user's full MCP set
     // and blows the context window on tool schemas alone (HTTP 400 prompt_too_long),
     // failing every call before inference. See narrative::minimal_mcp_config.
-    let mcp_config_path = crate::narrative::minimal_mcp_config().ok();
+    let mcp_config_path = crate::narrative::minimal_mcp_config()
+        .inspect_err(|e| {
+            tracing::warn!(
+                "minimal MCP config unavailable; this call inherits the user's MCP set \
+                 and may fail with prompt_too_long: {e}"
+            )
+        })
+        .ok();
 
     for candidate in ratification_model_candidates() {
         let attempt = tokio::time::timeout(RATIFICATION_TIMEOUT, async {

--- a/csr-engine/src/hooks/session_briefing.rs
+++ b/csr-engine/src/hooks/session_briefing.rs
@@ -193,7 +193,7 @@ async fn handle_inner(_input: &HookInput, engine: &Engine, cwd: &Path) -> Result
 /// servers (not even csr-engine) — fastest possible `claude -p` startup and no
 /// recursive csr-engine spawn.
 fn invoke_narrative_briefing(prompt: &str) -> Result<crate::narrative::ParsedNarrative> {
-    let mcp_config_path = write_minimal_mcp_config()?;
+    let mcp_config_path = crate::narrative::minimal_mcp_config()?;
     let mut last_err: Option<anyhow::Error> = None;
 
     for candidate in crate::narrative::model_candidates() {
@@ -288,21 +288,6 @@ fn store_briefing(engine: &Engine, project: &str, briefing: &str) -> Result<()> 
         .insert_reflection(&id, briefing, &tags, &embedding)?;
 
     Ok(())
-}
-
-/// Write an EMPTY MCP config, used with `--strict-mcp-config` so the briefing
-/// subprocess loads ZERO MCP servers. Episodes are injected into the prompt, so
-/// Haiku needs no tools — this avoids loading any MCP server (including a recursive
-/// csr-engine) and gives the fastest possible `claude -p` startup.
-fn write_minimal_mcp_config() -> Result<std::path::PathBuf> {
-    let config = serde_json::json!({ "mcpServers": {} });
-    let dir = dirs::home_dir()
-        .map(|h| h.join(".claude-self-reflect"))
-        .ok_or_else(|| anyhow::anyhow!("no home dir"))?;
-    std::fs::create_dir_all(&dir).ok();
-    let path = dir.join("briefing-mcp.json");
-    std::fs::write(&path, serde_json::to_string(&config)?)?;
-    Ok(path)
 }
 
 /// Prompt-ready episode window plus stable (time-independent) precursors for
@@ -484,19 +469,6 @@ mod tests {
     fn test_briefing_timeout_reasonable() {
         // claude -p has ~30s startup; allow generous async budget up to 3 min
         assert!((60..=180).contains(&BRIEFING_TIMEOUT_SECS));
-    }
-
-    #[test]
-    fn test_minimal_mcp_config_is_empty() {
-        let path = write_minimal_mcp_config().unwrap();
-        let raw = std::fs::read_to_string(&path).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        let servers = v["mcpServers"].as_object().unwrap();
-        assert_eq!(
-            servers.len(),
-            0,
-            "briefing needs no tools — config must load zero MCP servers"
-        );
     }
 
     #[test]

--- a/csr-engine/src/narrative.rs
+++ b/csr-engine/src/narrative.rs
@@ -37,6 +37,32 @@ pub fn model_candidates() -> Vec<Option<String>> {
     chain
 }
 
+/// Path to an EMPTY MCP config, for use with `--strict-mcp-config` so a
+/// `claude -p` subprocess loads ZERO MCP servers.
+///
+/// Every headless `claude -p` invocation inherits the user's full MCP
+/// configuration and serialises every tool schema into the request. That is not
+/// a small overhead: on a machine with a typical plugin/connector set it is
+/// ~180k tokens of tool definitions before the prompt is even considered, which
+/// overruns the model's context window and fails the request with HTTP 400
+/// `prompt_too_long` — deterministically, before any inference happens, and
+/// therefore on every retry.
+///
+/// Every CSR subprocess call site embeds what the model needs directly in the
+/// prompt, so all of them need ZERO tools. Passing this alongside
+/// `--strict-mcp-config` also avoids spawning a recursive csr-engine MCP server
+/// and gives the fastest possible `claude -p` startup.
+pub fn minimal_mcp_config() -> anyhow::Result<std::path::PathBuf> {
+    let config = serde_json::json!({ "mcpServers": {} });
+    let dir = dirs::home_dir()
+        .map(|h| h.join(".claude-self-reflect"))
+        .ok_or_else(|| anyhow::anyhow!("no home dir"))?;
+    std::fs::create_dir_all(&dir).ok();
+    let path = dir.join("briefing-mcp.json");
+    std::fs::write(&path, serde_json::to_string(&config)?)?;
+    Ok(path)
+}
+
 #[derive(Debug)]
 pub struct ParsedNarrative {
     pub text: String,
@@ -296,5 +322,14 @@ mod tests {
             AttemptOutcome::Failed(msg) => assert!(msg.contains("real error")),
             other => panic!("expected Failed, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_minimal_mcp_config_is_empty() {
+        let path = minimal_mcp_config().unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let v: Value = serde_json::from_str(&raw).unwrap();
+        let servers = v["mcpServers"].as_object().unwrap();
+        assert_eq!(servers.len(), 0, "claude -p call sites need zero MCP servers");
     }
 }

--- a/csr-engine/src/narrative.rs
+++ b/csr-engine/src/narrative.rs
@@ -59,9 +59,29 @@ pub fn minimal_mcp_config() -> anyhow::Result<std::path::PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("no home dir"))?;
     std::fs::create_dir_all(&dir).ok();
     let path = dir.join("briefing-mcp.json");
-    std::fs::write(&path, serde_json::to_string(&config)?)?;
+
+    // Atomic write. All three call sites can run concurrently, so a plain
+    // truncating write would let one caller observe a 0-byte config while
+    // another rewrites it — failing that subprocess before inference, which is
+    // the exact class of silent failure this config exists to prevent.
+    //
+    // The temp name carries a counter as well as the pid: the daemon drives
+    // ratification and story generation from a single process, so a shared pid
+    // is precisely the case that needs distinguishing. (Sibling call sites in
+    // this repo use a fixed `.tmp` name; they have one writer each.)
+    let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let pid = std::process::id();
+    let tmp_path = dir.join(format!("briefing-mcp.json.{pid}.{seq}.tmp"));
+    std::fs::write(&tmp_path, serde_json::to_string(&config)?)?;
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e.into());
+    }
     Ok(path)
 }
+
+/// Distinguishes temp files written concurrently by `minimal_mcp_config`.
+static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 #[derive(Debug)]
 pub struct ParsedNarrative {

--- a/csr-engine/src/narrative.rs
+++ b/csr-engine/src/narrative.rs
@@ -350,6 +350,10 @@ mod tests {
         let raw = std::fs::read_to_string(&path).unwrap();
         let v: Value = serde_json::from_str(&raw).unwrap();
         let servers = v["mcpServers"].as_object().unwrap();
-        assert_eq!(servers.len(), 0, "claude -p call sites need zero MCP servers");
+        assert_eq!(
+            servers.len(),
+            0,
+            "claude -p call sites need zero MCP servers"
+        );
     }
 }

--- a/csr-engine/src/summarizer.rs
+++ b/csr-engine/src/summarizer.rs
@@ -101,7 +101,14 @@ async fn call_claude_headless(prompt: &str) -> Option<crate::narrative::ParsedNa
     // an explicit empty MCP config this subprocess inherits the user's full MCP set
     // and blows the context window on tool schemas alone (HTTP 400 prompt_too_long),
     // failing every call before inference. See narrative::minimal_mcp_config.
-    let mcp_config_path = crate::narrative::minimal_mcp_config().ok();
+    let mcp_config_path = crate::narrative::minimal_mcp_config()
+        .inspect_err(|e| {
+            tracing::warn!(
+                "minimal MCP config unavailable; this call inherits the user's MCP set \
+                 and may fail with prompt_too_long: {e}"
+            )
+        })
+        .ok();
 
     for candidate in crate::narrative::model_candidates() {
         let attempt = tokio::time::timeout(HAIKU_TIMEOUT, async {

--- a/csr-engine/src/summarizer.rs
+++ b/csr-engine/src/summarizer.rs
@@ -97,6 +97,12 @@ fn build_prompt(ctx: &StoryContext) -> String {
 async fn call_claude_headless(prompt: &str) -> Option<crate::narrative::ParsedNarrative> {
     use tokio::io::AsyncWriteExt;
 
+    // The transcript is embedded in `prompt`, so the analyst needs NO tools. Without
+    // an explicit empty MCP config this subprocess inherits the user's full MCP set
+    // and blows the context window on tool schemas alone (HTTP 400 prompt_too_long),
+    // failing every call before inference. See narrative::minimal_mcp_config.
+    let mcp_config_path = crate::narrative::minimal_mcp_config().ok();
+
     for candidate in crate::narrative::model_candidates() {
         let attempt = tokio::time::timeout(HAIKU_TIMEOUT, async {
             let mut cmd = tokio::process::Command::new("claude");
@@ -107,8 +113,14 @@ async fn call_claude_headless(prompt: &str) -> Option<crate::narrative::ParsedNa
             if let Some(model) = &candidate {
                 cmd.args(["--model", model]);
             }
+            cmd.args(["-p", "-", "--output-format", "json"]);
+            // Must come LAST: --mcp-config is variadic in the claude CLI and would
+            // consume any positional arg that followed it.
+            if let Some(path) = &mcp_config_path {
+                cmd.args(["--strict-mcp-config", "--mcp-config"]);
+                cmd.arg(path);
+            }
             let mut child = match cmd
-                .args(["-p", "-", "--output-format", "json"])
                 .stdout(Stdio::piped())
                 // Piped intentionally — required for model-not-found detection on the failure path; do not revert to null().
                 .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary

`invoke_narrative_briefing` passes `--strict-mcp-config` with an empty MCP config so its `claude -p` subprocess loads zero tools. The two other headless call sites don't:

| call site | `--strict-mcp-config` |
|---|---|
| `hooks::session_briefing::invoke_narrative_briefing` | ✅ |
| `daemon::ratification::call_claude_for_acts` | ❌ |
| `summarizer::call_claude_headless` | ❌ |

Both therefore inherit the user's full MCP configuration and serialise every tool schema into the request.

## Impact

On a machine with a normal plugin/connector set this is ~180k tokens of tool definitions *before the prompt is considered*, so the request fails with HTTP 400 `prompt_too_long` before any inference — and fails identically on every retry.

Measured by capturing the outgoing request body and running it through `count_tokens` (373 tools):

```
tool schemas   180,026 tokens
system prompt    6,316 tokens
messages ("hi")      8 tokens
───────────────────────────────
total          200,993 tokens   (limit 200,000)
```

It overruns by **993 tokens on an empty prompt**.

Observed symptom: ratification stuck at **68% coverage for ~20 hours**, re-attempting the same conversations at **~105 calls/hour with a 0% success rate**, holding ~2.2 cores continuously. `ai_narrative_completed` was `0` — the story path fails the same way.

The failure looks size-dependent but isn't. The digest is capped at ~2,700 tokens, so the ~186k of fixed overhead left ~14k of headroom; digests near the cap tipped over while smaller ones squeaked through. Conversation size and session model were never the variable — the overhead is constant per call.

## Fix

- Move `write_minimal_mcp_config` from `hooks::session_briefing` to `narrative::minimal_mcp_config`. `narrative.rs` already describes itself as the home for shared `claude -p` invocation logic. Its test moves with it and now covers all three call sites rather than one.
- Pass `--strict-mcp-config --mcp-config <empty>` from ratification and story.

Both append the pair **last**, because `--mcp-config` is variadic in the claude CLI and would otherwise consume a trailing positional arg — the same constraint already documented in `invoke_narrative_briefing`.

The path resolves once per call and is threaded in as an `Option`, so a home-dir failure degrades to current behaviour instead of dropping the call.

## Verification

The runtime fix is confirmed in production, not just reasoned about. I shimmed the binary to inject these exact flags and let it run:

| | before | after |
|---|---|---|
| coverage | 501/736 (68.1%), frozen ~20h | **773/773 (100%)** |
| call success rate | 0% | 95–100% |
| request size | 200,993 tok | ~41k tok |
| spawn rate | ~105/hr indefinitely | drained to 0 |
| daemon CPU | ~230% sustained | 0.0% idle |

The full backlog cleared in ~4.5h at 40–73 ratifications/hour.

**One caveat, stated plainly:** I have no Rust toolchain on this machine, so I could not run `cargo fmt`/`clippy`/`test` locally — I'm relying on CI. I kept the formatting conservative for that reason (method chains split into statements rather than sitting near rustfmt's `chain_width`), and I audited for orphaned imports by hand after removing the old helper and its test. If fmt or clippy flags anything, say the word and I'll push a fixup.

I also left the subprocess arg construction untested — asserting on it would need a refactor to make the arg vector inspectable, which felt out of scope for a focused fix. Happy to add it if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude-powered narrative briefings and summaries by ensuring command-line options are interpreted correctly.
  * Added stricter configuration handling to prevent unintended integrations from being used.
  * Standardized creation of an empty configuration for supported operations.
  * Improved reliability when generating configuration files, including safer handling of concurrent operations and write failures.
  * Reduced the risk of failures or unexpected behavior during automated briefing and summarization tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->