### PR TITLE
fix(import): stop re-embedding transcripts on every append

### DIFF
--- a/csr-engine/examples/quick_check_floor.rs
+++ b/csr-engine/examples/quick_check_floor.rs
@@ -108,8 +108,10 @@ const PROBES: &[Probe] = &[
 
 fn bytes_to_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect()
 }
 

--- a/csr-engine/src/engine.rs
+++ b/csr-engine/src/engine.rs
@@ -247,9 +247,10 @@ impl Engine {
     }
 
     /// Import a single JSONL file: parse, embed, store chunks, enrich.
-    /// Supports incremental import — when a transcript grows mid-session,
-    /// only new chunks are embedded (chunks beyond prev_count are new).
-    /// Returns the number of NEW chunks imported (0 if nothing new).
+    /// Incremental — when a transcript grows mid-session only the chunks whose
+    /// content actually changed are re-embedded, which includes the trailing
+    /// chunk from the previous pass because it was flushed partial.
+    /// Returns the number of chunks written (0 if nothing changed).
     pub async fn import_file(&self, file_path: &Path, project_name: &str) -> Result<usize> {
         let attribution = import::ConversationAttribution {
             project_name: project_name.to_string(),
@@ -277,106 +278,29 @@ impl Engine {
                 parent,
             )?;
         }
-        // Check if file is unchanged (mtime match = fully imported, nothing new)
-        if self.storage.is_file_imported(file_path)? {
+
+        let ctx = import::incremental::ImportContext {
+            storage: &self.storage,
+            embeddings: &self.embeddings,
+            search: &self.search,
+        };
+        // Driven by the Stop hook and by bulk import, where the transcript is
+        // final — so the trailing chunk is sealed and indexed in the same pass.
+        let outcome = import::incremental::import_file_incremental(
+            &ctx,
+            file_path,
+            attribution,
+            import::incremental::SealPolicy::SealAll,
+        )
+        .await?;
+
+        if outcome.unchanged {
             return Ok(0);
         }
 
-        let parsed = import::parse_jsonl_file_with_stats(file_path, &attribution.project_name)?;
-        let suppression = parsed.suppression;
-        let chunks = parsed.chunks;
-        if chunks.is_empty() {
-            // Record the skip (agent transcripts, empty conversations) so the
-            // watcher doesn't re-parse the file every pass and import_percent
-            // counts it as processed instead of silently under-reporting.
-            self.storage
-                .mark_file_imported_with_suppression(file_path, 0, suppression)?;
-            return Ok(0);
-        }
+        import::incremental::maybe_enrich(&ctx, &outcome, file_path, attribution).await;
 
-        // Incremental: skip chunks we already embedded
-        let prev_count = self.storage.get_imported_chunk_count(file_path)?;
-        if chunks.len() <= prev_count {
-            // File parsed to same/fewer chunks — just update mtime
-            self.storage.mark_file_imported_with_suppression(
-                file_path,
-                chunks.len(),
-                suppression,
-            )?;
-            return Ok(0);
-        }
-
-        let new_chunks = &chunks[prev_count..];
-        const BATCH_SIZE: usize = 10;
-
-        for batch in new_chunks.chunks(BATCH_SIZE) {
-            let texts: Vec<String> = batch.iter().map(|c| c.content.clone()).collect();
-            let emb = self.embeddings.clone();
-            let embeddings = tokio::task::spawn_blocking(move || {
-                let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-                emb.embed(&refs)
-            })
-            .await??;
-
-            let mut idx = self.search.write().await;
-            for (chunk, embedding) in batch.iter().zip(embeddings) {
-                self.storage
-                    .insert_chunk_with_source(chunk, &embedding, attribution.source)?;
-                // Persist provenance: who authored this chunk + its source conv.
-                // Supersession detection is deferred (None) — recall still gains
-                // from author-authority weighting. Non-fatal on error.
-                if let Err(e) = self.storage.insert_chunk_provenance(
-                    &chunk.id,
-                    &crate::provenance::ChunkProvenance {
-                        author: chunk.author,
-                        source_conv_id: attribution
-                            .parent_conversation_id
-                            .clone()
-                            .unwrap_or_else(|| chunk.conversation_id.clone()),
-                        supersedes: None,
-                    },
-                ) {
-                    eprintln!("CSR: chunk provenance persist error (non-fatal): {e}");
-                }
-                idx.insert_chunk(chunk.id.clone(), embedding);
-            }
-        }
-
-        self.storage
-            .mark_file_imported_with_suppression(file_path, chunks.len(), suppression)?;
-
-        // Layer 1: Heuristic enrichment only on first import (not incremental updates)
-        if prev_count == 0 {
-            let conv_id = file_path
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
-            if !self
-                .storage
-                .is_conversation_enriched(&conv_id, "heuristic")
-                .unwrap_or(false)
-            {
-                if let Err(e) = crate::extraction::heuristic::enrich_conversation(
-                    file_path,
-                    &conv_id,
-                    &attribution.project_name,
-                    &self.storage,
-                    &self.embeddings,
-                    &self.search,
-                )
-                .await
-                {
-                    tracing::warn!(
-                        conv = %conv_id,
-                        error = %e,
-                        "heuristic enrichment failed (non-fatal)"
-                    );
-                }
-            }
-        }
-
-        Ok(new_chunks.len())
+        Ok(outcome.written_chunks)
     }
 
     /// Backfill missing import_state rows and run heuristic enrichment for all unenriched conversations.

--- a/csr-engine/src/import/codex_rollout.rs
+++ b/csr-engine/src/import/codex_rollout.rs
@@ -627,26 +627,49 @@ pub(crate) fn import_changed_rollouts(engine: &Engine, root: &Path) -> Result<Ro
             stats.vanished += 1;
             continue;
         };
-        let old_ids = storage.get_chunk_ids_for_conversation(&metadata.conversation_id)?;
-        storage.delete_chunks_for_conversation(&metadata.conversation_id)?;
-        if !old_ids.is_empty() {
-            let mut index = engine.search().blocking_write();
-            for id in old_ids {
-                index.remove_chunk(&id);
-            }
-        }
+        let key = file.path.to_string_lossy().to_string();
+        let prev_count = storage.get_imported_chunk_count(&file.path)?;
+
+        // Rollouts used to be deleted and rebuilt in full on any change, so a
+        // session that grew by one message re-embedded its entire history.
+        //
+        // Unlike a Claude transcript, a rollout chunk is frozen the moment it is
+        // written: `visit_rollout_message_chunks` splits each message on its own
+        // with no carry-over buffer, so there is no trailing partial chunk that
+        // grows. That makes a content comparison sufficient — and a primary-key
+        // lookup is nothing next to an embedding.
+        let mut reused = 0usize;
         let outcome = stream_rollout_chunk_batches(
             &file.path,
             &metadata,
             ROLLOUT_EMBED_BATCH_SIZE,
             |chunks| {
-                let texts = chunks
+                let mut todo: Vec<(&ConversationChunk, bool)> = Vec::new();
+                {
+                    let index = engine.search().blocking_read();
+                    for chunk in chunks {
+                        let unchanged = storage
+                            .get_chunk_content(&chunk.id)?
+                            .is_some_and(|stored| stored == chunk.content);
+                        let indexed = index.has_chunk(&chunk.id);
+                        if unchanged && indexed {
+                            reused += 1;
+                            continue;
+                        }
+                        todo.push((chunk, indexed));
+                    }
+                }
+                if todo.is_empty() {
+                    return Ok(());
+                }
+
+                let texts = todo
                     .iter()
-                    .map(|chunk| chunk.content.as_str())
+                    .map(|(chunk, _)| chunk.content.as_str())
                     .collect::<Vec<_>>();
                 let embeddings = engine.embeddings().embed(&texts)?;
                 let mut index = engine.search().blocking_write();
-                for (chunk, embedding) in chunks.iter().zip(embeddings) {
+                for ((chunk, indexed), embedding) in todo.into_iter().zip(embeddings) {
                     storage.insert_chunk_with_source(chunk, &embedding, "codex_rollout")?;
                     storage.insert_chunk_provenance(
                         &chunk.id,
@@ -656,16 +679,40 @@ pub(crate) fn import_changed_rollouts(engine: &Engine, root: &Path) -> Result<Ro
                             supersedes: None,
                         },
                     )?;
+                    // insert_chunk is a no-op for a known id, so a changed chunk
+                    // keeps its stale vector unless it is blanked first.
+                    if indexed {
+                        index.remove_chunk(&chunk.id);
+                    }
                     index.insert_chunk(chunk.id.clone(), embedding);
                 }
                 Ok(())
             },
         )?;
+
+        // A rollout that shrank leaves orphan tail chunks still matching content
+        // that no longer exists. The wholesale delete used to cover this.
+        if outcome.chunks < prev_count {
+            let orphans = (outcome.chunks..prev_count)
+                .map(|seq| super::generate_chunk_id(&metadata.conversation_id, seq))
+                .collect::<Vec<_>>();
+            tracing::warn!(
+                conv = %metadata.conversation_id,
+                previous = prev_count,
+                current = outcome.chunks,
+                "codex rollout shrank — dropping orphan tail chunks"
+            );
+            storage.delete_chunks_by_ids(&orphans)?;
+            let mut index = engine.search().blocking_write();
+            for id in &orphans {
+                index.remove_chunk(id);
+            }
+        }
+
         storage.bump_aux_counter_by("codex_rollout", outcome.schema_misses)?;
         stats.schema_misses += outcome.schema_misses;
         stats.csr_tool_blocks_suppressed += outcome.suppression.csr_tool_blocks_suppressed;
         stats.csr_hook_wrappers_scrubbed += outcome.suppression.csr_hook_wrappers_scrubbed;
-        let key = file.path.to_string_lossy();
         storage.upsert_import_state_explicit(
             &key,
             &metadata.conversation_id,
@@ -674,6 +721,13 @@ pub(crate) fn import_changed_rollouts(engine: &Engine, root: &Path) -> Result<Ro
         )?;
         stats.files_imported += 1;
         stats.chunks_imported += outcome.chunks;
+        tracing::debug!(
+            conv = %metadata.conversation_id,
+            total = outcome.chunks,
+            embedded = outcome.chunks.saturating_sub(reused),
+            reused,
+            "codex rollout imported"
+        );
     }
     Ok(stats)
 }
@@ -682,6 +736,152 @@ pub(crate) fn import_changed_rollouts(engine: &Engine, root: &Path) -> Result<Ro
 mod tests {
     use super::*;
     use std::path::Path;
+
+    use std::sync::Arc;
+
+    /// Build a rollout whose messages are long enough to produce several chunks each.
+    fn write_rollout(path: &Path, id: &str, messages: usize) {
+        let mut lines = vec![serde_json::json!({
+            "timestamp": "2026-08-06T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": id,
+                "timestamp": "2026-08-06T12:00:00Z",
+                "cwd": "/workspace/synthetic-project",
+                "source": "synthetic"
+            }
+        })];
+        for i in 0..messages {
+            lines.push(serde_json::json!({
+                "timestamp": format!("2026-08-06T12:00:{:02}Z", i + 1),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": format!("msg-{i}"),
+                    "role": if i % 2 == 0 { "user" } else { "assistant" },
+                    "content": [{"type": "input_text", "text": format!("ROLLOUT{i:03}-{}", "x".repeat(1900))}]
+                }
+            }));
+        }
+        std::fs::write(
+            path,
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    /// A rollout that grows must re-embed only its new chunks. The old code
+    /// deleted the conversation and rebuilt it in full on every change, so a
+    /// session that gained one message re-embedded its whole history.
+    #[test]
+    fn growing_rollout_reuses_existing_chunks() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        let rollout = root.join("rollout-2026-08-06T12-00-00-grow.jsonl");
+
+        let engine = crate::engine::Engine::from_parts(
+            Arc::new(crate::storage::Storage::open_memory().unwrap()),
+            Arc::new(crate::embeddings::EmbeddingEngine::new().unwrap()),
+            Arc::new(tokio::sync::RwLock::new(crate::search::SearchEngine::new(
+                256,
+            ))),
+            dir.path().to_path_buf(),
+        );
+
+        write_rollout(&rollout, "grow-fixture", 4);
+        let first = import_changed_rollouts(&engine, &root).unwrap();
+        assert!(
+            first.chunks_imported > 4,
+            "fixture must yield several chunks"
+        );
+
+        let snapshot = |engine: &crate::engine::Engine| -> Vec<(String, i64)> {
+            engine
+                .storage()
+                .get_chunk_ids_for_conversation("codex:grow-fixture")
+                .unwrap()
+                .into_iter()
+                .map(|id| {
+                    let rowid = engine.storage().chunk_rowid_for_test(&id).unwrap();
+                    (id, rowid)
+                })
+                .collect()
+        };
+        let before: std::collections::HashMap<_, _> = snapshot(&engine).into_iter().collect();
+        assert_eq!(before.len(), first.chunks_imported);
+
+        write_rollout(&rollout, "grow-fixture", 6);
+        let second = import_changed_rollouts(&engine, &root).unwrap();
+        assert!(second.chunks_imported > first.chunks_imported);
+
+        // INSERT OR REPLACE assigns a fresh rowid, so an untouched chunk keeps its
+        // original one. Every pre-existing chunk must be untouched.
+        let after: std::collections::HashMap<_, _> = snapshot(&engine).into_iter().collect();
+        let rewritten = before
+            .iter()
+            .filter(|(id, rowid)| after.get(*id).is_some_and(|now| now != *rowid))
+            .count();
+        assert_eq!(
+            rewritten, 0,
+            "a grown rollout must not rewrite chunks it already had"
+        );
+
+        // And the new content must actually be there.
+        let text = after
+            .keys()
+            .filter_map(|id| engine.storage().get_chunk_content(id).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("ROLLOUT005"), "new messages must be imported");
+    }
+
+    /// A rollout that shrinks must drop the orphan tail the wholesale delete used
+    /// to remove.
+    #[test]
+    fn shrinking_rollout_drops_orphan_chunks() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        let rollout = root.join("rollout-2026-08-06T12-00-00-shrink.jsonl");
+
+        let engine = crate::engine::Engine::from_parts(
+            Arc::new(crate::storage::Storage::open_memory().unwrap()),
+            Arc::new(crate::embeddings::EmbeddingEngine::new().unwrap()),
+            Arc::new(tokio::sync::RwLock::new(crate::search::SearchEngine::new(
+                256,
+            ))),
+            dir.path().to_path_buf(),
+        );
+
+        write_rollout(&rollout, "shrink-fixture", 6);
+        let big = import_changed_rollouts(&engine, &root).unwrap();
+
+        write_rollout(&rollout, "shrink-fixture", 2);
+        let small = import_changed_rollouts(&engine, &root).unwrap();
+        assert!(small.chunks_imported < big.chunks_imported);
+
+        let stored = engine
+            .storage()
+            .get_chunk_ids_for_conversation("codex:shrink-fixture")
+            .unwrap();
+        assert_eq!(
+            stored.len(),
+            small.chunks_imported,
+            "no orphan tail chunks may survive a shrink"
+        );
+        let text = stored
+            .iter()
+            .filter_map(|id| engine.storage().get_chunk_content(id).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!text.contains("ROLLOUT005"), "dropped content must be gone");
+    }
 
     #[test]
     fn modern_fixture_parses_messages_cwd_and_scrubs_csr_calls() {

--- a/csr-engine/src/import/incremental.rs
+++ b/csr-engine/src/import/incremental.rs
@@ -26,7 +26,7 @@ use anyhow::Result;
 use tokio::sync::RwLock;
 
 use crate::embeddings::EmbeddingEngine;
-use crate::import::{self, ConversationAttribution};
+use crate::import::{self, ConversationAttribution, ParseCursor, PARSE_CURSOR_VERSION};
 use crate::search::SearchEngine;
 use crate::storage::Storage;
 
@@ -100,9 +100,24 @@ pub(crate) async fn import_file_incremental(
         .to_string_lossy()
         .to_string();
 
-    let parsed = import::parse_jsonl_file_with_stats(file_path, &attribution.project_name)?;
+    // Resume from the stored byte cursor when it still describes this file.
+    let stored_cursor = ctx
+        .storage
+        .get_parse_cursor(file_path)?
+        .and_then(|json| serde_json::from_str::<ParseCursor>(&json).ok())
+        .filter(|c| c.v == PARSE_CURSOR_VERSION && cursor_still_valid(c, file_path));
+
+    let parsed = import::parse_jsonl_file_from_cursor(
+        file_path,
+        &attribution.project_name,
+        stored_cursor.as_ref(),
+    )?;
     let suppression = parsed.suppression;
+    let next_cursor = parsed.next_cursor;
     let chunks = parsed.chunks;
+    // With a cursor the parse starts mid-file, so chunks[0] is chunk number
+    // `first_index`, not chunk zero.
+    let first_index = stored_cursor.as_ref().map(|c| c.chunk_index).unwrap_or(0);
 
     // Agent transcripts and empty conversations parse to nothing. Record the skip so
     // the file is not re-parsed on every pass and import_percent counts it.
@@ -112,7 +127,7 @@ pub(crate) async fn import_file_incremental(
         return Ok(ImportOutcome::default());
     }
 
-    let n = chunks.len();
+    let n = first_index + chunks.len();
     let prev_count = ctx.storage.get_imported_chunk_count(file_path)?;
 
     // ── Decide where to resume ────────────────────────────────────────────────
@@ -122,11 +137,20 @@ pub(crate) async fn import_file_incremental(
     // skipped). Wiping is destructive, so it needs corroboration: compare the
     // head chunk's content. A rewrite changes it; a short read does not.
     let mut full_reimport = false;
-    let rebuild_from = if n < prev_count {
-        let head_changed = ctx
-            .storage
-            .get_chunk_content(&chunks[0].id)?
-            .is_none_or(|stored| stored != chunks[0].content);
+    let rebuild_from = if stored_cursor.is_some() {
+        // Everything the cursor handed back begins at the seam by construction,
+        // and the cursor was only trusted after its head fingerprint matched.
+        first_index
+    } else {
+        // Full parse, so the head is in hand. Verify the prefix really is intact
+        // before trusting it: a rewrite changes chunk zero even when the chunk
+        // count does not move, and resuming at the seam would strand the old
+        // content in place. This also covers a cursor rejected as stale.
+        let head_changed = prev_count > 0
+            && ctx
+                .storage
+                .get_chunk_content(&chunks[0].id)?
+                .is_none_or(|stored| stored != chunks[0].content);
 
         if head_changed {
             tracing::warn!(
@@ -148,8 +172,9 @@ pub(crate) async fn import_file_incremental(
             }
             full_reimport = true;
             0
-        } else {
-            // Head intact: keep the valid prefix, drop only the orphan tail.
+        } else if n < prev_count {
+            // Head intact but fewer chunks: keep the valid prefix, drop the
+            // orphan tail rather than wiping a conversation needlessly.
             tracing::warn!(
                 conv = %conversation_id,
                 previous = prev_count,
@@ -167,20 +192,24 @@ pub(crate) async fn import_file_incremental(
                 }
             }
             n.saturating_sub(1)
+        } else {
+            // The seam. `prev_count` counts chunks WRITTEN, and the last of those
+            // was a partial buffer flushed at EOF — on this pass it may have
+            // grown, so it must be rebuilt. Slicing from `prev_count` instead
+            // drops its new messages into no chunk at all.
+            prev_count.saturating_sub(1)
         }
-    } else {
-        // The seam. `prev_count` counts chunks WRITTEN, and the last of those was
-        // a partial buffer flushed at EOF — on this pass it may have grown, so it
-        // must be rebuilt. Slicing from `prev_count` instead drops its new
-        // messages into no chunk at all.
-        prev_count.saturating_sub(1)
     };
 
     // ── Plan: what actually needs work ───────────────────────────────────────
     let mut plans: Vec<ChunkPlan> = Vec::new();
     {
         let idx = ctx.search.read().await;
-        for (i, chunk) in chunks.iter().enumerate().skip(rebuild_from) {
+        for (local, chunk) in chunks.iter().enumerate() {
+            let i = first_index + local;
+            if i < rebuild_from {
+                continue;
+            }
             let is_trailing = i + 1 == n;
             let index_it = !is_trailing || seal == SealPolicy::SealAll;
             let indexed = idx.has_chunk(&chunk.id);
@@ -198,7 +227,7 @@ pub(crate) async fn import_file_incremental(
             }
 
             plans.push(ChunkPlan {
-                index: i,
+                index: local,
                 write: !content_same,
                 index_it: index_it && (!indexed || !content_same),
                 remove_first: indexed,
@@ -264,8 +293,15 @@ pub(crate) async fn import_file_incremental(
         }
     }
 
-    ctx.storage
-        .mark_file_imported_with_suppression(file_path, n, suppression)?;
+    let cursor_json = next_cursor
+        .as_ref()
+        .and_then(|c| serde_json::to_string(c).ok());
+    ctx.storage.mark_file_imported_with_cursor(
+        file_path,
+        n,
+        suppression,
+        cursor_json.as_deref(),
+    )?;
 
     Ok(ImportOutcome {
         indexed_chunks,
@@ -275,6 +311,22 @@ pub(crate) async fn import_file_incremental(
         full_reimport,
         unchanged: false,
     })
+}
+
+/// Whether a stored cursor still describes the file on disk.
+///
+/// A shorter file means truncation. A changed head means the file was rewritten,
+/// which a length check alone misses when the rewrite happens to be as long or
+/// longer. Either way the offset is meaningless and the caller falls back to a
+/// full parse.
+fn cursor_still_valid(cursor: &ParseCursor, path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if meta.len() < cursor.file_len || meta.len() < cursor.byte_offset {
+        return false;
+    }
+    import::head_fingerprint(path) == cursor.head_fingerprint
 }
 
 /// Layer 1 heuristic enrichment, shared by both callers.
@@ -378,7 +430,7 @@ mod tests {
                 .enumerate()
                 .map(|(i, text)| {
                     serde_json::json!({
-                        "type": if i % 2 == 0 { "user" } else { "assistant" },
+                        "type": if i.is_multiple_of(2) { "user" } else { "assistant" },
                         "timestamp": format!("2026-02-22T10:00:{:02}Z", i),
                         "message": {"content": [{"type": "text", "text": text}]}
                     })
@@ -692,5 +744,96 @@ mod tests {
                 "an idle pass must not enrich"
             );
         });
+    }
+
+    /// A rewritten file of the same length must not be resumed from a stale offset.
+    #[test]
+    fn truncate_and_regrow_invalidates_cursor() {
+        rt().block_on(async {
+            let h = Harness::new("regrow");
+            h.write(&msgs(7));
+            h.import(SealPolicy::SealAll).await;
+            let before = h.all_stored();
+            assert!(before.join("\n").contains("MSG006"));
+
+            // Same message count, entirely different content.
+            let replaced: Vec<String> = (0..7)
+                .map(|i| format!("NEW{i:03}-{}", "q".repeat(390)))
+                .collect();
+            h.write(&replaced);
+            h.import(SealPolicy::SealAll).await;
+
+            let after = h.all_stored().join("\n");
+            assert!(
+                after.contains("NEW000") && after.contains("NEW006"),
+                "the rewrite must be fully reimported"
+            );
+            assert!(
+                !after.contains("MSG"),
+                "a stale cursor must not leave old content behind"
+            );
+        });
+    }
+
+    /// A NULL cursor is the downgrade path and the pre-migration path: it must
+    /// simply fall back to a full parse with the seam rebuild.
+    #[test]
+    fn null_cursor_falls_back_to_full_parse() {
+        rt().block_on(async {
+            let h = Harness::new("null-cursor");
+            h.write(&msgs(5));
+            h.import(SealPolicy::SealAll).await;
+
+            // Simulate an older binary having written the row without a cursor.
+            h.storage
+                .clear_parse_cursor_for_test(&h.path)
+                .expect("clear cursor");
+            assert!(h.storage.get_parse_cursor(&h.path).unwrap().is_none());
+
+            h.write(&msgs(7));
+            h.import(SealPolicy::SealAll).await;
+
+            let all = h.all_stored().join("\n");
+            for i in 0..7 {
+                assert!(all.contains(&format!("MSG{i:03}")), "MSG{i:03} missing");
+            }
+        });
+    }
+
+    /// The migration must be additive on a database that predates the column.
+    #[test]
+    fn cursor_column_migration_is_additive() {
+        let dir = TempDir::new().unwrap();
+        let db = dir.path().join("legacy.db");
+        {
+            let conn = rusqlite::Connection::open(&db).unwrap();
+            // The pre-cursor shape of the table, with a row already in it.
+            conn.execute_batch(
+                "CREATE TABLE import_state (
+                     file_path TEXT PRIMARY KEY,
+                     conversation_id TEXT,
+                     chunks_imported INTEGER,
+                     imported_at TEXT DEFAULT (datetime('now')),
+                     file_mtime TEXT,
+                     csr_tool_blocks_suppressed INTEGER NOT NULL DEFAULT 0,
+                     csr_hook_wrappers_scrubbed INTEGER NOT NULL DEFAULT 0
+                 );
+                 INSERT INTO import_state (file_path, chunks_imported) VALUES ('/legacy.jsonl', 12);",
+            )
+            .unwrap();
+        }
+
+        let storage = Storage::open(&db).expect("migrations must run on a legacy database");
+        let cursor = storage
+            .get_parse_cursor(Path::new("/legacy.jsonl"))
+            .expect("the column must exist after migration");
+        assert!(cursor.is_none(), "legacy rows start with no cursor");
+        assert_eq!(
+            storage
+                .get_imported_chunk_count(Path::new("/legacy.jsonl"))
+                .unwrap(),
+            12,
+            "the existing row must survive the ALTER"
+        );
     }
 }

--- a/csr-engine/src/import/incremental.rs
+++ b/csr-engine/src/import/incremental.rs
@@ -1,0 +1,696 @@
+//! Shared incremental transcript import.
+//!
+//! The daemon's `FileWatcher` and `Engine::import_file` both land here. They used
+//! to carry near-identical copies of this routine and drifted: `engine.rs` grew an
+//! incremental guard, `watcher.rs` never did, and the daemon spent eight days
+//! re-embedding settled history at 250% CPU.
+//!
+//! Two invariants make incremental import safe:
+//!
+//! 1. **Chunk boundaries are stable under append.** The chunker is a greedy
+//!    left-to-right fold with no lookahead — each flush decision reads only the
+//!    current buffer and message length. So `c0..c_{k-1}` are a pure function of
+//!    the message prefix. Only the final EOF-flushed chunk is mutable; every
+//!    earlier chunk is frozen once written. That is why rebuilding from
+//!    `chunks_imported - 1` is both necessary and sufficient.
+//!
+//! 2. **A chunk's vector must be written when its content is final.**
+//!    [`SearchEngine::insert_chunk`] is a no-op for an id already in the index,
+//!    so indexing the still-growing trailing chunk freezes a vector representing
+//!    only its first fragment. [`SealPolicy::DeferTrailing`] holds it back.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::RwLock;
+
+use crate::embeddings::EmbeddingEngine;
+use crate::import::{self, ConversationAttribution};
+use crate::search::SearchEngine;
+use crate::storage::Storage;
+
+/// Batch size for embedding. Matches the per-caller constants this replaced.
+const BATCH_SIZE: usize = 10;
+
+/// Borrowed handles the import needs. Grouped so callers pass one thing.
+pub(crate) struct ImportContext<'a> {
+    pub storage: &'a Arc<Storage>,
+    pub embeddings: &'a Arc<EmbeddingEngine>,
+    pub search: &'a Arc<RwLock<SearchEngine>>,
+}
+
+/// Whether the trailing (still-growing) chunk may enter the vector index.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SealPolicy {
+    /// Live watch: keep the trailing chunk out of HNSW until it stops growing.
+    /// Its content still reaches SQLite and FTS immediately.
+    DeferTrailing,
+    /// Hook / bulk import: the transcript is final, index everything.
+    SealAll,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ImportOutcome {
+    /// Chunks whose vector was written to HNSW this pass.
+    pub indexed_chunks: usize,
+    /// Chunks whose content was (re)written to SQLite this pass.
+    pub written_chunks: usize,
+    /// `chunks.len()` — what went to `import_state.chunks_imported`.
+    pub total_chunks: usize,
+    /// No previously-imported chunks; this was the conversation's first import.
+    pub first_import: bool,
+    /// A rewrite was detected and the conversation was wiped and rebuilt.
+    pub full_reimport: bool,
+    /// The mtime gate matched — the file was not re-read at all.
+    pub unchanged: bool,
+}
+
+/// What a single chunk needs this pass.
+struct ChunkPlan {
+    index: usize,
+    /// Content differs from what is stored (or nothing is stored).
+    write: bool,
+    /// This chunk's vector should be in HNSW when we are done.
+    index_it: bool,
+    /// An id is already in HNSW and must be blanked before reinsertion.
+    remove_first: bool,
+}
+
+/// Import a transcript, embedding only what actually changed.
+///
+/// Returns immediately when the file's mtime matches the last import.
+pub(crate) async fn import_file_incremental(
+    ctx: &ImportContext<'_>,
+    file_path: &Path,
+    attribution: &ConversationAttribution,
+    seal: SealPolicy,
+) -> Result<ImportOutcome> {
+    // Cheap gate: nothing on disk changed since the last pass.
+    if ctx.storage.is_file_imported(file_path)? {
+        return Ok(ImportOutcome {
+            unchanged: true,
+            ..Default::default()
+        });
+    }
+
+    let conversation_id = file_path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    let parsed = import::parse_jsonl_file_with_stats(file_path, &attribution.project_name)?;
+    let suppression = parsed.suppression;
+    let chunks = parsed.chunks;
+
+    // Agent transcripts and empty conversations parse to nothing. Record the skip so
+    // the file is not re-parsed on every pass and import_percent counts it.
+    if chunks.is_empty() {
+        ctx.storage
+            .mark_file_imported_with_suppression(file_path, 0, suppression)?;
+        return Ok(ImportOutcome::default());
+    }
+
+    let n = chunks.len();
+    let prev_count = ctx.storage.get_imported_chunk_count(file_path)?;
+
+    // ── Decide where to resume ────────────────────────────────────────────────
+    //
+    // Fewer chunks than last time means either a genuine rewrite or a transient
+    // short read (a concurrent writer's trailing line is incomplete and gets
+    // skipped). Wiping is destructive, so it needs corroboration: compare the
+    // head chunk's content. A rewrite changes it; a short read does not.
+    let mut full_reimport = false;
+    let rebuild_from = if n < prev_count {
+        let head_changed = ctx
+            .storage
+            .get_chunk_content(&chunks[0].id)?
+            .is_none_or(|stored| stored != chunks[0].content);
+
+        if head_changed {
+            tracing::warn!(
+                conv = %conversation_id,
+                previous = prev_count,
+                current = n,
+                "transcript rewritten — wiping and rebuilding the conversation"
+            );
+            let old_ids = ctx
+                .storage
+                .get_chunk_ids_for_conversation(&conversation_id)?;
+            ctx.storage
+                .delete_chunks_for_conversation(&conversation_id)?;
+            {
+                let mut idx = ctx.search.write().await;
+                for id in &old_ids {
+                    idx.remove_chunk(id);
+                }
+            }
+            full_reimport = true;
+            0
+        } else {
+            // Head intact: keep the valid prefix, drop only the orphan tail.
+            tracing::warn!(
+                conv = %conversation_id,
+                previous = prev_count,
+                current = n,
+                "transcript shrank with an intact head — dropping orphan tail chunks"
+            );
+            let orphans: Vec<String> = (n..prev_count)
+                .map(|i| import::generate_chunk_id(&conversation_id, i))
+                .collect();
+            ctx.storage.delete_chunks_by_ids(&orphans)?;
+            {
+                let mut idx = ctx.search.write().await;
+                for id in &orphans {
+                    idx.remove_chunk(id);
+                }
+            }
+            n.saturating_sub(1)
+        }
+    } else {
+        // The seam. `prev_count` counts chunks WRITTEN, and the last of those was
+        // a partial buffer flushed at EOF — on this pass it may have grown, so it
+        // must be rebuilt. Slicing from `prev_count` instead drops its new
+        // messages into no chunk at all.
+        prev_count.saturating_sub(1)
+    };
+
+    // ── Plan: what actually needs work ───────────────────────────────────────
+    let mut plans: Vec<ChunkPlan> = Vec::new();
+    {
+        let idx = ctx.search.read().await;
+        for (i, chunk) in chunks.iter().enumerate().skip(rebuild_from) {
+            let is_trailing = i + 1 == n;
+            let index_it = !is_trailing || seal == SealPolicy::SealAll;
+            let indexed = idx.has_chunk(&chunk.id);
+
+            let content_same = ctx
+                .storage
+                .get_chunk_content(&chunk.id)?
+                .is_some_and(|stored| stored == chunk.content);
+
+            // Nothing to do when the content is already stored and the index
+            // state is what we want. This is what keeps timestamps frozen: an
+            // untouched chunk is never rewritten, so it keeps its original stamp.
+            if content_same && (indexed || !index_it) {
+                continue;
+            }
+
+            plans.push(ChunkPlan {
+                index: i,
+                write: !content_same,
+                index_it: index_it && (!indexed || !content_same),
+                remove_first: indexed,
+            });
+        }
+    }
+
+    let mut indexed_chunks = 0usize;
+    let mut written_chunks = 0usize;
+
+    // ── Execute ──────────────────────────────────────────────────────────────
+    for batch in plans.chunks(BATCH_SIZE) {
+        let texts: Vec<String> = batch
+            .iter()
+            .map(|p| chunks[p.index].content.clone())
+            .collect();
+        let emb = ctx.embeddings.clone();
+        let embeddings = tokio::task::spawn_blocking(move || {
+            let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+            emb.embed(&refs)
+        })
+        .await??;
+
+        // Taken per batch, not across the whole import: holding it for a 5,000-chunk
+        // file starved MCP searches behind the watcher.
+        let mut idx = ctx.search.write().await;
+        for (plan, embedding) in batch.iter().zip(embeddings) {
+            let chunk = &chunks[plan.index];
+
+            if plan.write {
+                ctx.storage
+                    .insert_chunk_with_source(chunk, &embedding, attribution.source)?;
+                if let Err(error) = ctx.storage.insert_chunk_provenance(
+                    &chunk.id,
+                    &crate::provenance::ChunkProvenance {
+                        author: chunk.author,
+                        source_conv_id: attribution
+                            .parent_conversation_id
+                            .clone()
+                            .unwrap_or_else(|| chunk.conversation_id.clone()),
+                        supersedes: None,
+                    },
+                ) {
+                    tracing::warn!(error = %error, chunk = %chunk.id, "chunk provenance persist failed");
+                }
+                written_chunks += 1;
+            }
+
+            if plan.index_it {
+                // insert_chunk is a no-op for a known id, so a changed chunk must
+                // be blanked first or its stale vector survives forever.
+                if plan.remove_first {
+                    idx.remove_chunk(&chunk.id);
+                }
+                idx.insert_chunk(chunk.id.clone(), embedding);
+                indexed_chunks += 1;
+            } else if plan.remove_first {
+                // Content moved on but this chunk is not eligible for the index
+                // yet (still growing). Blank the stale vector rather than leave it
+                // matching text the chunk no longer contains.
+                idx.remove_chunk(&chunk.id);
+            }
+        }
+    }
+
+    ctx.storage
+        .mark_file_imported_with_suppression(file_path, n, suppression)?;
+
+    Ok(ImportOutcome {
+        indexed_chunks,
+        written_chunks,
+        total_chunks: n,
+        first_import: prev_count == 0,
+        full_reimport,
+        unchanged: false,
+    })
+}
+
+/// Layer 1 heuristic enrichment, shared by both callers.
+///
+/// `engine.rs` used to gate this on `prev_count == 0`, which permanently stranded
+/// any conversation whose first attempt failed. `watcher.rs` had no gate at all,
+/// so a persistently-failing conversation re-read the whole transcript every
+/// debounce. Gate on "this pass did work" and let the existing
+/// `is_conversation_enriched` check provide idempotence.
+pub(crate) async fn maybe_enrich(
+    ctx: &ImportContext<'_>,
+    outcome: &ImportOutcome,
+    file_path: &Path,
+    attribution: &ConversationAttribution,
+) {
+    if outcome.unchanged || (!outcome.first_import && outcome.written_chunks == 0) {
+        return;
+    }
+    let conv_id = file_path
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+    if ctx
+        .storage
+        .is_conversation_enriched(&conv_id, "heuristic")
+        .unwrap_or(false)
+    {
+        return;
+    }
+    if let Err(e) = crate::extraction::heuristic::enrich_conversation(
+        file_path,
+        &conv_id,
+        &attribution.project_name,
+        ctx.storage,
+        ctx.embeddings,
+        ctx.search,
+    )
+    .await
+    {
+        tracing::warn!(conv = %conv_id, error = %e, "heuristic enrichment failed (non-fatal)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::OnceLock;
+    use tempfile::TempDir;
+
+    /// The embedding model is expensive to load; share one across the module.
+    fn embeddings() -> Arc<EmbeddingEngine> {
+        static ENGINE: OnceLock<Arc<EmbeddingEngine>> = OnceLock::new();
+        ENGINE
+            .get_or_init(|| Arc::new(EmbeddingEngine::new().expect("embedding model")))
+            .clone()
+    }
+
+    struct Harness {
+        _dir: TempDir,
+        path: PathBuf,
+        storage: Arc<Storage>,
+        embeddings: Arc<EmbeddingEngine>,
+        search: Arc<RwLock<SearchEngine>>,
+    }
+
+    impl Harness {
+        fn new(name: &str) -> Self {
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join(format!("{name}.jsonl"));
+            Self {
+                _dir: dir,
+                path,
+                storage: Arc::new(Storage::open_memory().unwrap()),
+                embeddings: embeddings(),
+                search: Arc::new(RwLock::new(SearchEngine::new(256))),
+            }
+        }
+
+        fn ctx(&self) -> ImportContext<'_> {
+            ImportContext {
+                storage: &self.storage,
+                embeddings: &self.embeddings,
+                search: &self.search,
+            }
+        }
+
+        fn conv_id(&self) -> String {
+            self.path.file_stem().unwrap().to_string_lossy().to_string()
+        }
+
+        fn chunk_id(&self, i: usize) -> String {
+            import::generate_chunk_id(&self.conv_id(), i)
+        }
+
+        /// Write `msgs` as a fresh transcript. Alternates user/assistant.
+        fn write(&self, msgs: &[String]) {
+            let lines: Vec<String> = msgs
+                .iter()
+                .enumerate()
+                .map(|(i, text)| {
+                    serde_json::json!({
+                        "type": if i % 2 == 0 { "user" } else { "assistant" },
+                        "timestamp": format!("2026-02-22T10:00:{:02}Z", i),
+                        "message": {"content": [{"type": "text", "text": text}]}
+                    })
+                    .to_string()
+                })
+                .collect();
+            std::fs::write(&self.path, lines.join("\n")).unwrap();
+            // mtime must differ from the previous write or the import short-circuits.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        async fn import(&self, seal: SealPolicy) -> ImportOutcome {
+            let attribution = ConversationAttribution {
+                project_name: "test".to_string(),
+                source: "conversation",
+                parent_conversation_id: None,
+            };
+            import_file_incremental(&self.ctx(), &self.path, &attribution, seal)
+                .await
+                .unwrap()
+        }
+
+        fn stored(&self, i: usize) -> Option<String> {
+            self.storage.get_chunk_content(&self.chunk_id(i)).unwrap()
+        }
+
+        fn timestamp(&self, i: usize) -> String {
+            self.storage
+                .get_chunks_by_ids(&[self.chunk_id(i)])
+                .unwrap()
+                .first()
+                .expect("chunk must exist")
+                .timestamp
+                .clone()
+        }
+
+        /// Every stored chunk of this conversation, by index.
+        fn all_stored(&self) -> Vec<String> {
+            let mut out = Vec::new();
+            let mut i = 0;
+            while let Some(c) = self.stored(i) {
+                out.push(c);
+                i += 1;
+            }
+            out
+        }
+    }
+
+    /// `n` messages of ~400 chars, so exactly two fit in a 900-char chunk.
+    fn msgs(n: usize) -> Vec<String> {
+        (0..n)
+            .map(|i| format!("MSG{i:03}-{}", "x".repeat(390)))
+            .collect()
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Runtime::new().unwrap()
+    }
+
+    /// The off-by-one. Slicing from `prev_count` skips the trailing partial chunk,
+    /// so messages that grew into it land in no stored chunk at all.
+    #[test]
+    fn seam_chunk_is_rebuilt_when_transcript_grows() {
+        rt().block_on(async {
+            let h = Harness::new("seam-grow");
+            // 5 messages -> c0(m0,m1) c1(m2,m3) c2(m4, partial)
+            h.write(&msgs(5));
+            let first = h.import(SealPolicy::DeferTrailing).await;
+            assert_eq!(first.total_chunks, 3, "fixture must produce 3 chunks");
+            assert!(h.stored(2).unwrap().contains("MSG004"));
+            assert!(!h.stored(2).unwrap().contains("MSG005"));
+
+            // Grow: c2 becomes (m4,m5) and c3(m6) appears.
+            h.write(&msgs(7));
+            h.import(SealPolicy::DeferTrailing).await;
+
+            let c2 = h.stored(2).expect("chunk 2 must still exist");
+            assert!(
+                c2.contains("MSG005"),
+                "MSG005 grew into the seam chunk but was never rewritten -- \
+                 this is the content the old &chunks[prev_count..] slice dropped"
+            );
+            // And it must not have been lost anywhere else either.
+            let all = h.all_stored().join("\n");
+            for i in 0..7 {
+                assert!(all.contains(&format!("MSG{i:03}")), "MSG{i:03} missing");
+            }
+        });
+    }
+
+    /// Same loss, via the `chunks.len() <= prev_count` early return: the file grew
+    /// but stayed under the budget, so the chunk count did not move.
+    #[test]
+    fn seam_chunk_updated_when_chunk_count_unchanged() {
+        rt().block_on(async {
+            let h = Harness::new("seam-same-count");
+            h.write(&msgs(5));
+            let first = h.import(SealPolicy::DeferTrailing).await;
+            assert_eq!(first.total_chunks, 3);
+
+            // Append a short message: c2 grows but no new chunk is created.
+            let mut grown = msgs(5);
+            grown.push("SHORTTAIL".to_string());
+            h.write(&grown);
+            let second = h.import(SealPolicy::DeferTrailing).await;
+
+            assert_eq!(second.total_chunks, 3, "chunk count must be unchanged");
+            assert!(
+                h.stored(2).unwrap().contains("SHORTTAIL"),
+                "a grown seam must be rewritten even when the chunk count is flat"
+            );
+        });
+    }
+
+    /// The property the whole design rests on: importing a transcript in N growing
+    /// steps must land the same content as importing it once at full size.
+    #[test]
+    fn full_parse_and_incremental_parse_agree() {
+        rt().block_on(async {
+            let one_shot = Harness::new("agree");
+            one_shot.write(&msgs(11));
+            one_shot.import(SealPolicy::SealAll).await;
+
+            let stepwise = Harness::new("agree");
+            for n in [3usize, 5, 7, 9, 11] {
+                stepwise.write(&msgs(n));
+                stepwise.import(SealPolicy::SealAll).await;
+            }
+
+            assert_eq!(
+                one_shot.all_stored(),
+                stepwise.all_stored(),
+                "incremental import must converge on the full-parse result"
+            );
+        });
+    }
+
+    /// Same property with a message larger than CHUNK_CHAR_BUDGET, which takes the
+    /// hard-split branch and ends on a boundary with an empty buffer.
+    #[test]
+    fn hard_split_message_preserves_prefix_stability() {
+        rt().block_on(async {
+            let big = format!("BIG-{}", "y".repeat(2500));
+            let mut base = msgs(3);
+            base.push(big);
+
+            let one_shot = Harness::new("hardsplit");
+            let mut full = base.clone();
+            full.extend(msgs(2));
+            one_shot.write(&full);
+            one_shot.import(SealPolicy::SealAll).await;
+
+            let stepwise = Harness::new("hardsplit");
+            stepwise.write(&base);
+            stepwise.import(SealPolicy::SealAll).await;
+            stepwise.write(&full);
+            stepwise.import(SealPolicy::SealAll).await;
+
+            assert_eq!(one_shot.all_stored(), stepwise.all_stored());
+        });
+    }
+
+    /// A rewritten (shorter, different) transcript wipes the conversation instead
+    /// of leaving orphan tail chunks matching content that no longer exists.
+    #[test]
+    fn truncated_transcript_triggers_full_reimport() {
+        rt().block_on(async {
+            let h = Harness::new("truncate");
+            h.write(&msgs(7));
+            let first = h.import(SealPolicy::SealAll).await;
+            assert!(first.total_chunks >= 4);
+
+            // Entirely different, shorter content.
+            let replacement: Vec<String> = (0..3)
+                .map(|i| format!("NEW{i:03}-{}", "z".repeat(390)))
+                .collect();
+            h.write(&replacement);
+            let second = h.import(SealPolicy::SealAll).await;
+
+            assert!(
+                second.full_reimport,
+                "a changed head must force a full wipe"
+            );
+            let all = h.all_stored();
+            assert_eq!(
+                all.len(),
+                second.total_chunks,
+                "no orphan tail chunks may survive the rewrite"
+            );
+            assert!(
+                !all.join("\n").contains("MSG006"),
+                "old content must be gone"
+            );
+        });
+    }
+
+    /// Under DeferTrailing the still-growing chunk reaches SQLite but not HNSW,
+    /// because insert_chunk is a no-op for a known id and would freeze a vector
+    /// representing only the chunk's first fragment.
+    #[test]
+    fn trailing_chunk_deferred_until_sealed() {
+        rt().block_on(async {
+            let h = Harness::new("defer");
+            h.write(&msgs(5));
+            h.import(SealPolicy::DeferTrailing).await;
+
+            let trailing = h.chunk_id(2);
+            assert!(
+                h.stored(2).is_some(),
+                "content must still reach SQLite immediately"
+            );
+            assert!(
+                !h.search.read().await.has_chunk(&trailing),
+                "the growing chunk must stay out of the vector index"
+            );
+
+            // Growing past it seals c2; c3 becomes the new trailing chunk.
+            h.write(&msgs(7));
+            h.import(SealPolicy::DeferTrailing).await;
+            assert!(
+                h.search.read().await.has_chunk(&trailing),
+                "a sealed chunk must be indexed"
+            );
+            assert!(!h.search.read().await.has_chunk(&h.chunk_id(3)));
+        });
+    }
+
+    /// Regression for the discarded-vector bug: re-inserting a changed chunk under
+    /// its existing id is silently skipped, so the seam must be removed first.
+    #[test]
+    fn sealed_seam_replaces_stale_vector() {
+        rt().block_on(async {
+            let h = Harness::new("stale-vector");
+            h.write(&msgs(5));
+            // SealAll indexes the partial c2 straight away -- the situation the
+            // hook path creates and DeferTrailing avoids.
+            h.import(SealPolicy::SealAll).await;
+            let seam = h.chunk_id(2);
+            assert!(h.search.read().await.has_chunk(&seam));
+
+            h.write(&msgs(7));
+            let second = h.import(SealPolicy::SealAll).await;
+
+            assert!(
+                second.indexed_chunks > 0,
+                "the grown seam must be re-indexed, not skipped"
+            );
+            // The index slot must now be backed by the grown content.
+            assert!(h.stored(2).unwrap().contains("MSG005"));
+            assert!(h.search.read().await.has_chunk(&seam));
+        });
+    }
+
+    /// Frozen per-chunk timestamps: an untouched chunk is never rewritten, so a
+    /// no-op pass cannot restamp it. search::decay reads this.
+    #[test]
+    fn unchanged_content_does_not_restamp_timestamp() {
+        rt().block_on(async {
+            let h = Harness::new("frozen-ts");
+            h.write(&msgs(5));
+            h.import(SealPolicy::SealAll).await;
+
+            let ts_before = h.timestamp(0);
+
+            // Rewrite identical content: mtime moves, content does not.
+            h.write(&msgs(5));
+            let second = h.import(SealPolicy::SealAll).await;
+            assert_eq!(second.written_chunks, 0, "nothing changed, nothing written");
+
+            let ts_after = h.timestamp(0);
+            assert_eq!(ts_before, ts_after, "settled chunks must keep their stamp");
+        });
+    }
+
+    /// The mtime gate still short-circuits an unchanged file without re-reading it.
+    #[test]
+    fn unchanged_file_short_circuits() {
+        rt().block_on(async {
+            let h = Harness::new("mtime-gate");
+            h.write(&msgs(5));
+            h.import(SealPolicy::SealAll).await;
+            let second = h.import(SealPolicy::SealAll).await;
+            assert!(second.unchanged);
+            assert_eq!(second.total_chunks, 0);
+        });
+    }
+
+    /// A pass that did no work must not trigger enrichment -- that gate is what
+    /// stopped a persistently-failing conversation re-reading a 75 MB transcript
+    /// every debounce.
+    #[test]
+    fn enrichment_skipped_when_pass_did_no_work() {
+        rt().block_on(async {
+            let h = Harness::new("enrich-gate");
+            h.write(&msgs(5));
+            let attribution = ConversationAttribution {
+                project_name: "test".to_string(),
+                source: "conversation",
+                parent_conversation_id: None,
+            };
+            let idle = ImportOutcome {
+                first_import: false,
+                written_chunks: 0,
+                ..Default::default()
+            };
+            maybe_enrich(&h.ctx(), &idle, &h.path, &attribution).await;
+            assert!(
+                !h.storage
+                    .is_conversation_enriched(&h.conv_id(), "heuristic")
+                    .unwrap_or(false),
+                "an idle pass must not enrich"
+            );
+        });
+    }
+}

--- a/csr-engine/src/import/mod.rs
+++ b/csr-engine/src/import/mod.rs
@@ -8,13 +8,58 @@ pub mod watcher;
 
 use std::collections::HashSet;
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use anyhow::{Context, Result};
 use regex::Regex;
 use uuid::Uuid;
+
+/// Where to resume parsing a transcript, plus the file-head state a resumed
+/// parse cannot rederive because it never reads the head.
+///
+/// `byte_offset` is NOT end-of-file. It is the start of the first message line of
+/// the trailing chunk, paired with that chunk's index. Because the chunker is a
+/// no-lookahead fold, restarting there with an empty buffer reproduces exactly
+/// what a full parse yields from that chunk onward.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ParseCursor {
+    pub v: u32,
+    pub byte_offset: u64,
+    pub chunk_index: usize,
+    pub file_len: u64,
+    /// Hash of the first 4 KiB. Catches a rewrite that happens to leave the file
+    /// the same length or longer, which a length check alone would miss.
+    pub head_fingerprint: u64,
+    pub summary: Option<String>,
+    pub first_user_message: Option<String>,
+    pub first_timestamp: Option<String>,
+    /// CSR tool_use ids suppressed before the cursor but not yet answered by their
+    /// tool_result. Without these a seam between a tool_use and its result leaks a
+    /// CSR tool_result into the index.
+    pub open_suppressed_tool_use_ids: Vec<String>,
+    /// Suppression totals for bytes strictly BEFORE `byte_offset`, so the
+    /// re-parsed seam region is counted exactly once.
+    pub suppressed_tool_blocks_at_cursor: usize,
+    pub scrubbed_hook_wrappers_at_cursor: usize,
+}
+
+pub(crate) const PARSE_CURSOR_VERSION: u32 = 1;
+
+/// Size of the head sample used for `head_fingerprint`.
+const HEAD_FINGERPRINT_BYTES: usize = 4096;
+
+pub(crate) fn head_fingerprint(path: &Path) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut buf = vec![0u8; HEAD_FINGERPRINT_BYTES];
+    let read = fs::File::open(path)
+        .and_then(|mut f| f.read(&mut buf))
+        .unwrap_or(0);
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    buf[..read].hash(&mut hasher);
+    hasher.finish()
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ConversationAttribution {
@@ -65,6 +110,9 @@ pub struct ConversationChunk {
 pub(crate) struct ParsedConversation {
     pub chunks: Vec<ConversationChunk>,
     pub suppression: CsrSuppressionStats,
+    /// Where the next incremental parse should resume. `None` means the caller
+    /// must do a full parse next time.
+    pub next_cursor: Option<ParseCursor>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -277,6 +325,19 @@ pub(crate) fn parse_jsonl_file_with_stats(
     path: &Path,
     project_name: &str,
 ) -> Result<ParsedConversation> {
+    parse_jsonl_file_from_cursor(path, project_name, None)
+}
+
+/// Parse a transcript, optionally resuming from a stored byte cursor.
+///
+/// With `None` this reads the whole file. With a cursor it seeks to the trailing
+/// chunk's first line and reproduces everything from that chunk onward, which is
+/// identical to what a full parse would produce there.
+pub(crate) fn parse_jsonl_file_from_cursor(
+    path: &Path,
+    project_name: &str,
+    cursor: Option<&ParseCursor>,
+) -> Result<ParsedConversation> {
     let conversation_id = path
         .file_stem()
         .unwrap_or_default()
@@ -284,21 +345,50 @@ pub(crate) fn parse_jsonl_file_with_stats(
         .to_string();
 
     let file = fs::File::open(path).context("opening JSONL file")?;
-    let reader = BufReader::new(file);
+    let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let mut reader = BufReader::new(file);
+
+    let start_offset = cursor.map(|c| c.byte_offset).unwrap_or(0);
+    let index_base = cursor.map(|c| c.chunk_index).unwrap_or(0);
+    if start_offset > 0 {
+        reader
+            .seek(SeekFrom::Start(start_offset))
+            .context("seeking to parse cursor")?;
+    }
+
     let mut messages: Vec<String> = Vec::new();
+    let mut message_offsets: Vec<u64> = Vec::new();
+    // Sanitizer state as it stood BEFORE each retained message. A cursor always
+    // lands on a message boundary, so this is what a resumed parse must restore.
+    let mut message_stats: Vec<CsrSuppressionStats> = Vec::new();
+    let mut message_open_ids: Vec<Vec<String>> = Vec::new();
     let mut authors: Vec<crate::provenance::Speaker> = Vec::new();
     let mut sidechains: Vec<bool> = Vec::new();
-    let mut first_timestamp: Option<String> = None;
+    let mut first_timestamp: Option<String> = cursor.and_then(|c| c.first_timestamp.clone());
     let mut last_timestamp: Option<String> = None;
-    let mut summary: Option<String> = None;
-    let mut first_user_message: Option<String> = None;
+    let mut summary: Option<String> = cursor.and_then(|c| c.summary.clone());
+    let mut first_user_message: Option<String> = cursor.and_then(|c| c.first_user_message.clone());
     let mut csr_sanitizer = CsrMessageSanitizer::default();
+    if let Some(c) = cursor {
+        // Tool calls still awaiting their result at the cursor, so a tool_result
+        // landing after the seam is still recognised as CSR's own.
+        csr_sanitizer.suppressed_tool_use_ids =
+            c.open_suppressed_tool_use_ids.iter().cloned().collect();
+    }
 
-    for line_result in reader.lines() {
-        let line = match line_result {
-            Ok(l) => l,
-            Err(_) => continue,
+    let mut offset = start_offset;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let line_start = offset;
+        // Deliberately not `continue` on error: with read_line a persistent decode
+        // failure would never advance the offset and would spin forever.
+        let read = match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
         };
+        offset += read as u64;
         if line.trim().is_empty() {
             continue;
         }
@@ -330,6 +420,12 @@ pub(crate) fn parse_jsonl_file_with_stats(
             continue;
         }
 
+        let stats_before_line = csr_sanitizer.stats;
+        let open_ids_before_line: Vec<String> = csr_sanitizer
+            .suppressed_tool_use_ids
+            .iter()
+            .cloned()
+            .collect();
         sanitize_message_for_search(&mut parsed, &mut csr_sanitizer);
 
         // Capture first and last timestamps
@@ -373,6 +469,9 @@ pub(crate) fn parse_jsonl_file_with_stats(
             .unwrap_or(false);
         if !combined_text.is_empty() {
             messages.push(combined_text);
+            message_offsets.push(line_start);
+            message_stats.push(stats_before_line);
+            message_open_ids.push(open_ids_before_line);
             authors.push(classify_message_author(&parsed));
             sidechains.push(is_sidechain_msg);
         }
@@ -382,6 +481,7 @@ pub(crate) fn parse_jsonl_file_with_stats(
         return Ok(ParsedConversation {
             chunks: Vec::new(),
             suppression: csr_sanitizer.stats,
+            next_cursor: None,
         });
     }
 
@@ -396,6 +496,7 @@ pub(crate) fn parse_jsonl_file_with_stats(
             return Ok(ParsedConversation {
                 chunks: Vec::new(),
                 suppression: csr_sanitizer.stats,
+                next_cursor: None,
             });
         }
     }
@@ -403,8 +504,13 @@ pub(crate) fn parse_jsonl_file_with_stats(
     // Use last_timestamp for ordering (shows "last active" not "started at")
     // Fall back to first_timestamp if somehow no last, then to now()
     let timestamp = last_timestamp
-        .or(first_timestamp)
+        .or_else(|| first_timestamp.clone())
         .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+
+    // Kept for the cursor: a resumed parse never reads the head, so it cannot
+    // rederive either of these.
+    let summary_for_cursor = summary.clone();
+    let first_user_for_cursor = first_user_message.clone();
 
     // Priority: JSONL summary > first user message > None
     let chunk_summary = summary.or(first_user_message);
@@ -414,18 +520,31 @@ pub(crate) fn parse_jsonl_file_with_stats(
     // ~900 chars only embeds its head — the rest is unsearchable. Sizing each chunk
     // under that window means the whole conversation actually lands in vector space.
     let mut chunks: Vec<ConversationChunk> = Vec::new();
+    // Byte offset of the message that opened each chunk, parallel to `chunks`.
+    let mut chunk_starts: Vec<u64> = Vec::new();
+    // Offset of the message currently at the head of `buf`.
+    let mut buf_start: u64 = 0;
     let mut buf = String::new();
     let mut buf_authors: Vec<crate::provenance::Speaker> = Vec::new();
     let mut buf_sidechains: Vec<bool> = Vec::new();
     let mut buf_msgs = 0usize;
 
-    for ((msg, author), sidechain) in messages.iter().zip(authors.iter()).zip(sidechains.iter()) {
+    for (i, ((msg, author), sidechain)) in messages
+        .iter()
+        .zip(authors.iter())
+        .zip(sidechains.iter())
+        .enumerate()
+    {
+        let msg_offset = message_offsets[i];
         // A single message larger than the budget is hard-split into multiple chunks
         // so its tail (e.g. the end of a long report) is embedded too.
         if msg.len() > CHUNK_CHAR_BUDGET {
             if !buf.is_empty() {
                 push_chunk(
                     &mut chunks,
+                    &mut chunk_starts,
+                    index_base,
+                    buf_start,
                     &conversation_id,
                     project_name,
                     &timestamp,
@@ -448,6 +567,9 @@ pub(crate) fn parse_jsonl_file_with_stats(
                 }
                 push_chunk(
                     &mut chunks,
+                    &mut chunk_starts,
+                    index_base,
+                    msg_offset,
                     &conversation_id,
                     project_name,
                     &timestamp,
@@ -466,6 +588,9 @@ pub(crate) fn parse_jsonl_file_with_stats(
         if !buf.is_empty() && buf.len() + msg.len() + 2 > CHUNK_CHAR_BUDGET {
             push_chunk(
                 &mut chunks,
+                &mut chunk_starts,
+                index_base,
+                buf_start,
                 &conversation_id,
                 project_name,
                 &timestamp,
@@ -479,7 +604,9 @@ pub(crate) fn parse_jsonl_file_with_stats(
             buf_sidechains.clear();
             buf_msgs = 0;
         }
-        if !buf.is_empty() {
+        if buf.is_empty() {
+            buf_start = msg_offset;
+        } else {
             buf.push_str("\n\n");
         }
         buf.push_str(msg);
@@ -490,6 +617,9 @@ pub(crate) fn parse_jsonl_file_with_stats(
     if !buf.is_empty() {
         push_chunk(
             &mut chunks,
+            &mut chunk_starts,
+            index_base,
+            buf_start,
             &conversation_id,
             project_name,
             &timestamp,
@@ -501,9 +631,55 @@ pub(crate) fn parse_jsonl_file_with_stats(
         );
     }
 
+    // Suppression counts are reported absolutely: the prefix the cursor already
+    // accounted for, plus what this pass saw. The seam region is re-parsed every
+    // time, so it must be counted from the cursor's prefix, never added twice.
+    let (prefix_tool, prefix_wrappers) = cursor
+        .map(|c| {
+            (
+                c.suppressed_tool_blocks_at_cursor,
+                c.scrubbed_hook_wrappers_at_cursor,
+            )
+        })
+        .unwrap_or((0, 0));
+    let absolute = CsrSuppressionStats {
+        csr_tool_blocks_suppressed: prefix_tool + csr_sanitizer.stats.csr_tool_blocks_suppressed,
+        csr_hook_wrappers_scrubbed: prefix_wrappers
+            + csr_sanitizer.stats.csr_hook_wrappers_scrubbed,
+    };
+
+    // Resume from the trailing chunk. A hard-split message emits several chunks
+    // that all begin at the same offset, so resume at the FIRST of that group --
+    // resuming mid-group would re-split the message and renumber its pieces.
+    let next_cursor = chunk_starts.last().map(|&resume_offset| {
+        let local = chunk_starts
+            .iter()
+            .position(|&o| o == resume_offset)
+            .unwrap_or(chunk_starts.len() - 1);
+        let mark = message_offsets
+            .iter()
+            .position(|&o| o == resume_offset)
+            .map(|m| (message_stats[m], message_open_ids[m].clone()))
+            .unwrap_or_default();
+        ParseCursor {
+            v: PARSE_CURSOR_VERSION,
+            byte_offset: resume_offset,
+            chunk_index: index_base + local,
+            file_len,
+            head_fingerprint: head_fingerprint(path),
+            summary: summary_for_cursor,
+            first_user_message: first_user_for_cursor,
+            first_timestamp,
+            open_suppressed_tool_use_ids: mark.1,
+            suppressed_tool_blocks_at_cursor: prefix_tool + mark.0.csr_tool_blocks_suppressed,
+            scrubbed_hook_wrappers_at_cursor: prefix_wrappers + mark.0.csr_hook_wrappers_scrubbed,
+        }
+    });
+
     Ok(ParsedConversation {
         chunks,
-        suppression: csr_sanitizer.stats,
+        suppression: absolute,
+        next_cursor,
     })
 }
 
@@ -519,6 +695,9 @@ const MAX_TOOL_RESULT_CHARS: usize = 4000;
 #[allow(clippy::too_many_arguments)]
 fn push_chunk(
     chunks: &mut Vec<ConversationChunk>,
+    starts: &mut Vec<u64>,
+    index_base: usize,
+    start_offset: u64,
     conversation_id: &str,
     project_name: &str,
     timestamp: &str,
@@ -528,7 +707,8 @@ fn push_chunk(
     author: crate::provenance::Speaker,
     is_sidechain: bool,
 ) {
-    let i = chunks.len();
+    let i = index_base + chunks.len();
+    starts.push(start_offset);
     chunks.push(ConversationChunk {
         id: generate_chunk_id(conversation_id, i),
         conversation_id: conversation_id.to_string(),
@@ -696,10 +876,17 @@ fn sanitize_content(
                 }
             }
             Some("tool_result") => {
-                let is_csr_result = item
+                let tool_use_id = item
                     .get("tool_use_id")
                     .and_then(|value| value.as_str())
-                    .is_some_and(|id| sanitizer.suppressed_tool_use_ids.contains(id));
+                    .map(str::to_string);
+                // Consume the id rather than just testing it. A tool_result is only
+                // ever matched by its own tool_use, so this is a no-op for a full
+                // parse -- but it keeps the live set down to the handful of calls
+                // still awaiting a result, which is what makes it cheap to carry
+                // across a resumed parse.
+                let is_csr_result =
+                    tool_use_id.is_some_and(|id| sanitizer.suppressed_tool_use_ids.remove(&id));
                 if is_csr_result {
                     sanitizer.stats.csr_tool_blocks_suppressed += 1;
                     continue;
@@ -1512,5 +1699,264 @@ mod tests {
         let text = extract_message_text(&msg);
         assert!(!text.contains("sk-abc123"));
         assert!(text.contains("[private]"));
+    }
+}
+
+#[cfg(test)]
+mod cursor_tests {
+    use super::*;
+
+    fn write_lines(path: &Path, lines: &[serde_json::Value]) {
+        std::fs::write(
+            path,
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+        .unwrap();
+    }
+
+    fn msg(i: usize, text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "type": if i.is_multiple_of(2) { "user" } else { "assistant" },
+            "timestamp": format!("2026-02-22T10:00:{:02}Z", i),
+            "message": {"content": [{"type": "text", "text": text}]}
+        })
+    }
+
+    fn bulk(n: usize) -> Vec<serde_json::Value> {
+        (0..n)
+            .map(|i| msg(i, &format!("MSG{i:03}-{}", "x".repeat(390))))
+            .collect()
+    }
+
+    /// The core property: resuming from a cursor must reproduce exactly what a
+    /// full parse of the same file yields from that chunk onward.
+    #[test]
+    fn cursor_resume_matches_full_parse() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("resume.jsonl");
+
+        write_lines(&path, &bulk(5));
+        let first = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let cursor = first
+            .next_cursor
+            .clone()
+            .expect("a cursor must be produced");
+
+        write_lines(&path, &bulk(11));
+        let full = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let resumed = parse_jsonl_file_from_cursor(&path, "test", Some(&cursor)).unwrap();
+
+        let expected = &full.chunks[cursor.chunk_index..];
+        assert_eq!(
+            resumed.chunks.len(),
+            expected.len(),
+            "resumed parse must cover the same chunks"
+        );
+        for (r, e) in resumed.chunks.iter().zip(expected) {
+            assert_eq!(r.id, e.id, "chunk ids must line up across a resume");
+            assert_eq!(r.content, e.content, "content must be byte-identical");
+            assert_eq!(r.seq, e.seq);
+        }
+    }
+
+    /// A hard-split message emits several chunks at one offset; resuming must land
+    /// on the first of that group or the pieces get renumbered.
+    #[test]
+    fn cursor_resume_matches_full_parse_with_hard_split() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("resume-split.jsonl");
+
+        let mut lines = bulk(3);
+        lines.push(msg(3, &format!("BIG-{}", "y".repeat(2600))));
+        write_lines(&path, &lines);
+        let first = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let cursor = first.next_cursor.clone().unwrap();
+
+        lines.extend(bulk(3));
+        write_lines(&path, &lines);
+        let full = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let resumed = parse_jsonl_file_from_cursor(&path, "test", Some(&cursor)).unwrap();
+
+        let expected = &full.chunks[cursor.chunk_index..];
+        assert_eq!(resumed.chunks.len(), expected.len());
+        for (r, e) in resumed.chunks.iter().zip(expected) {
+            assert_eq!(r.id, e.id);
+            assert_eq!(r.content, e.content);
+        }
+    }
+
+    /// A resumed parse never reads the head, so the summary must ride the cursor.
+    #[test]
+    fn cursor_carries_summary_across_resume() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("summary.jsonl");
+
+        let mut lines = vec![serde_json::json!({"type":"summary","summary":"THE SUMMARY"})];
+        lines.extend(bulk(5));
+        write_lines(&path, &lines);
+        let first = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let cursor = first.next_cursor.clone().unwrap();
+        assert_eq!(cursor.summary.as_deref(), Some("THE SUMMARY"));
+
+        lines.extend(bulk(3));
+        write_lines(&path, &lines);
+        let resumed = parse_jsonl_file_from_cursor(&path, "test", Some(&cursor)).unwrap();
+        assert!(
+            resumed
+                .chunks
+                .iter()
+                .all(|c| c.summary.as_deref() == Some("THE SUMMARY")),
+            "resumed chunks must keep the summary their siblings have"
+        );
+    }
+
+    /// With no summary line the first user message is the fallback, and it also
+    /// lives only in the head.
+    #[test]
+    fn cursor_carries_first_user_message_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fum.jsonl");
+
+        let mut lines = vec![msg(0, "OPENING REQUEST that is long enough to keep")];
+        lines.extend(bulk(5));
+        write_lines(&path, &lines);
+        let first = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let cursor = first.next_cursor.clone().unwrap();
+        assert!(cursor
+            .first_user_message
+            .as_deref()
+            .is_some_and(|m| m.starts_with("OPENING REQUEST")));
+
+        lines.extend(bulk(3));
+        write_lines(&path, &lines);
+        let resumed = parse_jsonl_file_from_cursor(&path, "test", Some(&cursor)).unwrap();
+        assert!(resumed.chunks.iter().all(|c| c
+            .summary
+            .as_deref()
+            .is_some_and(|s| s.starts_with("OPENING REQUEST"))));
+    }
+
+    /// The sanitizer's open tool_use ids are genuine cross-line state. A seam
+    /// falling between a CSR tool_use and its tool_result must not leak the result.
+    #[test]
+    fn suppressed_tool_result_across_cursor_seam_is_still_suppressed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seam-suppress.jsonl");
+
+        // The CSR tool_use must sit well BEFORE the cursor, with enough filler
+        // after it that the trailing chunk starts later in the file. Otherwise a
+        // resumed parse re-reads the tool_use and the carried ids are never needed.
+        let mut lines = bulk(4);
+        lines.push(serde_json::json!({
+            "type": "assistant",
+            "timestamp": "2026-02-22T10:00:20Z",
+            "message": {"content": [
+                {"type":"tool_use","id":"csr-seam-1","name":"mcp__claude-self-reflect__reflect_on_past","input":{}},
+                {"type":"text","text":format!("CARRIER-{}", "w".repeat(380))}
+            ]}
+        }));
+        lines.extend((5..9).map(|i| msg(i, &format!("TAIL{i:03}-{}", "t".repeat(390)))));
+        write_lines(&path, &lines);
+        let first = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let cursor = first.next_cursor.clone().unwrap();
+
+        // Sanity: the seam must actually fall after the tool_use, or this test
+        // proves nothing.
+        let tool_use_offset = {
+            let raw = std::fs::read_to_string(&path).unwrap();
+            raw.find("csr-seam-1").unwrap() as u64
+        };
+        assert!(
+            cursor.byte_offset > tool_use_offset,
+            "fixture is wrong: the cursor must sit after the tool_use line"
+        );
+        assert!(
+            cursor
+                .open_suppressed_tool_use_ids
+                .contains(&"csr-seam-1".to_string()),
+            "the unanswered tool_use id must ride the cursor"
+        );
+
+        lines.push(serde_json::json!({
+            "type": "user",
+            "timestamp": "2026-02-22T10:00:30Z",
+            "message": {"content": [
+                {"type":"tool_result","tool_use_id":"csr-seam-1","content":"LEAKED CSR RESULT"}
+            ]}
+        }));
+        write_lines(&path, &lines);
+
+        let resumed = parse_jsonl_file_from_cursor(&path, "test", Some(&cursor)).unwrap();
+        let text = resumed
+            .chunks
+            .iter()
+            .map(|c| c.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !text.contains("LEAKED CSR RESULT"),
+            "a tool_result whose tool_use sits before the cursor must still be suppressed"
+        );
+    }
+
+    /// Suppression totals are absolute, so N incremental passes must agree with one
+    /// full parse rather than double-counting the re-parsed seam.
+    #[test]
+    fn suppression_counters_exact_across_resumes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("counters.jsonl");
+
+        let csr_call = |i: usize| {
+            serde_json::json!({
+                "type": "assistant",
+                "timestamp": format!("2026-02-22T10:01:{:02}Z", i),
+                "message": {"content": [
+                    {"type":"tool_use","id":format!("csr-{i}"),"name":"mcp__claude-self-reflect__store_reflection","input":{}},
+                    {"type":"text","text":format!("KEPT{i}-{}", "z".repeat(390))}
+                ]}
+            })
+        };
+
+        let mut lines = bulk(3);
+        lines.push(csr_call(1));
+        write_lines(&path, &lines);
+        let p1 = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        let c1 = p1.next_cursor.clone().unwrap();
+
+        lines.extend(bulk(2));
+        lines.push(csr_call(2));
+        write_lines(&path, &lines);
+        let p2 = parse_jsonl_file_from_cursor(&path, "test", Some(&c1)).unwrap();
+
+        let full = parse_jsonl_file_with_stats(&path, "test").unwrap();
+        assert_eq!(
+            p2.suppression.csr_tool_blocks_suppressed, full.suppression.csr_tool_blocks_suppressed,
+            "incremental suppression totals must match a single full parse"
+        );
+    }
+
+    /// A cursor produced for one file must not be trusted for different content of
+    /// the same or greater length.
+    #[test]
+    fn head_fingerprint_detects_rewrite_at_same_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rewrite.jsonl");
+
+        write_lines(&path, &bulk(5));
+        let before = head_fingerprint(&path);
+
+        let replaced: Vec<serde_json::Value> = (0..5)
+            .map(|i| msg(i, &format!("NEW{i:03}-{}", "q".repeat(390))))
+            .collect();
+        write_lines(&path, &replaced);
+        assert_ne!(
+            before,
+            head_fingerprint(&path),
+            "a rewritten head must change the fingerprint even at the same length"
+        );
     }
 }

--- a/csr-engine/src/import/mod.rs
+++ b/csr-engine/src/import/mod.rs
@@ -1,6 +1,7 @@
 pub mod backfill;
 pub mod codex_rollout;
 pub mod coedit_backfill;
+pub(crate) mod incremental;
 pub mod plans;
 pub mod registry;
 pub mod watcher;
@@ -953,7 +954,7 @@ fn is_csr_server_name(identity: &str) -> bool {
 }
 
 /// Generate a deterministic chunk ID using UUIDv5.
-fn generate_chunk_id(conversation_id: &str, chunk_index: usize) -> String {
+pub(crate) fn generate_chunk_id(conversation_id: &str, chunk_index: usize) -> String {
     let input = format!("{}-chunk-{}", conversation_id, chunk_index);
     Uuid::new_v5(&CSR_NAMESPACE, input.as_bytes()).to_string()
 }

--- a/csr-engine/src/import/plans.rs
+++ b/csr-engine/src/import/plans.rs
@@ -336,8 +336,13 @@ fn push_plan_chunks(
         if end <= start {
             end = content.len();
         }
+        // Plans are markdown, imported by delete-then-rebuild, so they have no
+        // byte cursor: index from zero and discard the offsets.
         super::push_chunk(
             chunks,
+            &mut Vec::new(),
+            0,
+            0,
             conversation_id,
             project_name,
             timestamp,

--- a/csr-engine/src/import/watcher.rs
+++ b/csr-engine/src/import/watcher.rs
@@ -14,9 +14,6 @@ use crate::storage::Storage;
 /// Debounce interval for collecting file changes before processing.
 const DEBOUNCE_SECS: u64 = 5;
 
-/// Batch size for embedding during auto-import.
-const BATCH_SIZE: usize = 10;
-
 /// Watches the Claude projects directory for new JSONL files and auto-imports them.
 pub struct FileWatcher {
     projects_dir: PathBuf,
@@ -159,8 +156,10 @@ impl FileWatcher {
         Ok(())
     }
 
-    /// Import a single JSONL file: parse → embed → store → index.
-    async fn import_file(&self, file_path: &Path) -> Result<()> {
+    /// Import a single JSONL file. Parse, embed, store and index all live in
+    /// [`import::incremental`], shared with `Engine::import_file` so the two
+    /// copies of this routine cannot drift apart again.
+    pub(crate) async fn import_file(&self, file_path: &Path) -> Result<()> {
         // Security: resolve symlinks and verify the file is within our projects directory
         let canonical = file_path
             .canonicalize()
@@ -193,85 +192,34 @@ impl FileWatcher {
             )?;
         }
 
-        // Skip if already imported
-        if self.storage.is_file_imported(file_path)? {
+        let ctx = import::incremental::ImportContext {
+            storage: &self.storage,
+            embeddings: &self.embeddings,
+            search: &self.search,
+        };
+        // A watched transcript belongs to a live session, so its trailing chunk is
+        // still growing. Its content reaches SQLite and FTS immediately, but it
+        // stays out of HNSW until it stops changing — indexing it early would
+        // freeze a vector representing only its first fragment.
+        let outcome = import::incremental::import_file_incremental(
+            &ctx,
+            file_path,
+            &attribution,
+            import::incremental::SealPolicy::DeferTrailing,
+        )
+        .await?;
+
+        if outcome.unchanged {
             return Ok(());
         }
 
-        let parsed = import::parse_jsonl_file_with_stats(file_path, &attribution.project_name)?;
-        let suppression = parsed.suppression;
-        let chunks = parsed.chunks;
-        if chunks.is_empty() {
-            // Record the skip so this file isn't re-parsed every watcher pass
-            // and import_percent counts it as processed.
-            self.storage
-                .mark_file_imported_with_suppression(file_path, 0, suppression)?;
-            return Ok(());
-        }
-
-        let chunk_count = chunks.len();
-
-        // Batch embed and store
-        for batch in chunks.chunks(BATCH_SIZE) {
-            let texts: Vec<String> = batch.iter().map(|c| c.content.clone()).collect();
-            let emb = self.embeddings.clone();
-            let embeddings = tokio::task::spawn_blocking(move || {
-                let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-                emb.embed(&refs)
-            })
-            .await??;
-
-            let mut idx = self.search.write().await;
-            for (chunk, embedding) in batch.iter().zip(embeddings) {
-                self.storage
-                    .insert_chunk_with_source(chunk, &embedding, attribution.source)?;
-                if let Err(error) = self.storage.insert_chunk_provenance(
-                    &chunk.id,
-                    &crate::provenance::ChunkProvenance {
-                        author: chunk.author,
-                        source_conv_id: attribution
-                            .parent_conversation_id
-                            .clone()
-                            .unwrap_or_else(|| chunk.conversation_id.clone()),
-                        supersedes: None,
-                    },
-                ) {
-                    tracing::warn!(error = %error, chunk = %chunk.id, "chunk provenance persist failed");
-                }
-                idx.insert_chunk(chunk.id.clone(), embedding);
-            }
-        }
-
-        self.storage
-            .mark_file_imported_with_suppression(file_path, chunk_count, suppression)?;
-
-        // Layer 1: Heuristic enrichment (inline, instant, free)
-        if !self
-            .storage
-            .is_conversation_enriched(&conv_id, "heuristic")
-            .unwrap_or(false)
-        {
-            if let Err(e) = crate::extraction::heuristic::enrich_conversation(
-                file_path,
-                &conv_id,
-                &attribution.project_name,
-                &self.storage,
-                &self.embeddings,
-                &self.search,
-            )
-            .await
-            {
-                tracing::warn!(
-                    conv = %conv_id,
-                    error = %e,
-                    "heuristic enrichment failed (non-fatal)"
-                );
-            }
-        }
+        import::incremental::maybe_enrich(&ctx, &outcome, file_path, &attribution).await;
 
         tracing::info!(
             file = %file_path.display(),
-            chunks = chunk_count,
+            chunks = outcome.total_chunks,
+            written = outcome.written_chunks,
+            indexed = outcome.indexed_chunks,
             project = %attribution.project_name,
             source = attribution.source,
             "auto-imported conversation"

--- a/csr-engine/src/storage/migrations.rs
+++ b/csr-engine/src/storage/migrations.rs
@@ -44,7 +44,8 @@ pub fn run(conn: &Connection) -> Result<()> {
             imported_at TEXT DEFAULT (datetime('now')),
             file_mtime TEXT,
             csr_tool_blocks_suppressed INTEGER NOT NULL DEFAULT 0,
-            csr_hook_wrappers_scrubbed INTEGER NOT NULL DEFAULT 0
+            csr_hook_wrappers_scrubbed INTEGER NOT NULL DEFAULT 0,
+            parse_cursor TEXT
         );
 
         CREATE INDEX IF NOT EXISTS idx_import_conversation_id
@@ -478,6 +479,18 @@ pub fn run(conn: &Connection) -> Result<()> {
         conn.execute_batch(
             "ALTER TABLE import_state ADD COLUMN csr_hook_wrappers_scrubbed INTEGER;",
         )?;
+    }
+
+    // Byte offset to resume parsing a transcript from, so an append re-parses the
+    // trailing chunk instead of the whole file. Nullable with no default, so the
+    // ALTER is metadata-only even on a multi-gigabyte database. A NULL cursor
+    // simply falls back to a full parse, which is also what an older binary
+    // leaves behind -- that makes a downgrade fail-safe rather than corrupting.
+    let has_parse_cursor_col = conn
+        .prepare("SELECT parse_cursor FROM import_state LIMIT 0")
+        .is_ok();
+    if !has_parse_cursor_col {
+        conn.execute_batch("ALTER TABLE import_state ADD COLUMN parse_cursor TEXT;")?;
     }
 
     // Migration: add summary column to chunks table if missing (for timeline display)

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -628,6 +628,12 @@ impl Storage {
         queries::delete_chunks_for_conversation(&conn, conversation_id)
     }
 
+    /// Delete specific chunks by id. See `queries::delete_chunks_by_ids`.
+    pub fn delete_chunks_by_ids(&self, ids: &[String]) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::delete_chunks_by_ids(&conn, ids)
+    }
+
     pub fn record_narrative_usage(&self, row: &NarrativeUsageRow) -> Result<()> {
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
         queries::record_narrative_usage(&conn, row)

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -750,6 +750,18 @@ impl Storage {
         queries::get_parse_cursor(&conn, path)
     }
 
+    /// A chunk's SQLite rowid. INSERT OR REPLACE assigns a fresh one, so tests use
+    /// this to tell an untouched row from a rewritten one.
+    #[cfg(test)]
+    pub(crate) fn chunk_rowid_for_test(&self, id: &str) -> Result<i64> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        Ok(conn.query_row(
+            "SELECT rowid FROM chunks WHERE id = ?1",
+            rusqlite::params![id],
+            |r| r.get(0),
+        )?)
+    }
+
     /// Drop a stored resume cursor, forcing the next import to parse in full.
     /// Used by tests to reproduce a pre-migration or downgraded row.
     #[cfg(test)]

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -733,6 +733,35 @@ impl Storage {
         queries::mark_file_imported_with_suppression(&mut conn, path, chunks, suppression)
     }
 
+    pub(crate) fn mark_file_imported_with_cursor(
+        &self,
+        path: &Path,
+        chunks: usize,
+        suppression: crate::import::CsrSuppressionStats,
+        cursor: Option<&str>,
+    ) -> Result<()> {
+        let mut conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::mark_file_imported_with_cursor(&mut conn, path, chunks, suppression, cursor)
+    }
+
+    /// Byte cursor to resume parsing this transcript from, if one is stored.
+    pub fn get_parse_cursor(&self, path: &Path) -> Result<Option<String>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::get_parse_cursor(&conn, path)
+    }
+
+    /// Drop a stored resume cursor, forcing the next import to parse in full.
+    /// Used by tests to reproduce a pre-migration or downgraded row.
+    #[cfg(test)]
+    pub(crate) fn clear_parse_cursor_for_test(&self, path: &Path) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        conn.execute(
+            "UPDATE import_state SET parse_cursor = NULL WHERE file_path = ?1",
+            rusqlite::params![path.to_string_lossy().to_string()],
+        )?;
+        Ok(())
+    }
+
     /// Read an import_state mtime keyed by a synthetic (non-filesystem) `file_path`,
     /// for aux-source adapters. See `queries::get_import_state_mtime`.
     pub fn get_import_state_mtime(&self, file_path: &str) -> Result<Option<String>> {

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -1281,8 +1281,17 @@ pub fn upsert_import_state_explicit(
     chunks: usize,
     mtime: &str,
 ) -> Result<()> {
+    // Upsert, not INSERT OR REPLACE: the latter deletes the row and reinserts it,
+    // zeroing the suppression counters and dropping any parse cursor simply
+    // because this statement does not name them.
     conn.execute(
-        "INSERT OR REPLACE INTO import_state (file_path, conversation_id, chunks_imported, file_mtime) VALUES (?1, ?2, ?3, ?4)",
+        "INSERT INTO import_state (file_path, conversation_id, chunks_imported, file_mtime)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(file_path) DO UPDATE SET
+             conversation_id = excluded.conversation_id,
+             chunks_imported = excluded.chunks_imported,
+             file_mtime = excluded.file_mtime,
+             imported_at = datetime('now')",
         params![file_path, conversation_id, chunks as i64, mtime],
     )?;
     Ok(())

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -1097,6 +1097,19 @@ pub fn is_file_imported(conn: &Connection, path: &Path) -> Result<bool> {
     Ok(true)
 }
 
+/// Read the stored resume cursor for a transcript, if any.
+pub fn get_parse_cursor(conn: &Connection, path: &Path) -> Result<Option<String>> {
+    let path_str = path.to_string_lossy().to_string();
+    conn.query_row(
+        "SELECT parse_cursor FROM import_state WHERE file_path = ?1",
+        params![path_str],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .optional()
+    .map(Option::flatten)
+    .map_err(Into::into)
+}
+
 /// Get file modification time as a string for comparison.
 fn file_mtime_str(path: &Path) -> String {
     path.metadata()
@@ -1125,7 +1138,8 @@ pub fn mark_file_imported(conn: &Connection, path: &Path, chunks: usize) -> Resu
          ON CONFLICT(file_path) DO UPDATE SET
              conversation_id = excluded.conversation_id,
              chunks_imported = excluded.chunks_imported,
-             file_mtime = excluded.file_mtime",
+             file_mtime = excluded.file_mtime,
+             parse_cursor = NULL",
         params![path_str, conv_id, chunks as i64, mtime],
     )?;
     Ok(())
@@ -1134,11 +1148,26 @@ pub fn mark_file_imported(conn: &Connection, path: &Path, chunks: usize) -> Resu
 /// Atomically persist import state and apply only newly observed per-file CSR
 /// suppression totals. The import-state row is written before counter deltas;
 /// any failure rolls both back.
+/// Record an import, leaving no resume cursor. Callers that do not understand
+/// cursors must clear rather than preserve one: a stale offset is worse than a
+/// full reparse.
 pub(crate) fn mark_file_imported_with_suppression(
     conn: &mut Connection,
     path: &Path,
     chunks: usize,
     suppression: CsrSuppressionStats,
+) -> Result<()> {
+    mark_file_imported_with_cursor(conn, path, chunks, suppression, None)
+}
+
+/// Record an import together with the byte cursor to resume from next time.
+/// `cursor` of `None` writes SQL NULL, which forces a full parse.
+pub(crate) fn mark_file_imported_with_cursor(
+    conn: &mut Connection,
+    path: &Path,
+    chunks: usize,
+    suppression: CsrSuppressionStats,
+    cursor: Option<&str>,
 ) -> Result<()> {
     let tx = conn.transaction()?;
     let path_str = path.to_string_lossy().to_string();
@@ -1168,18 +1197,33 @@ pub(crate) fn mark_file_imported_with_suppression(
         .unwrap_or_default();
     let mtime = file_mtime_str(path);
 
+    // Deliberately not INSERT OR REPLACE: that deletes the row and reinserts it,
+    // so every column absent from the VALUES list silently becomes NULL. An
+    // upsert names exactly what it changes and leaves anything added later alone.
     tx.execute(
-        "INSERT OR REPLACE INTO import_state
+        "INSERT INTO import_state
          (file_path, conversation_id, chunks_imported, file_mtime,
-          csr_tool_blocks_suppressed, csr_hook_wrappers_scrubbed)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+          csr_tool_blocks_suppressed, csr_hook_wrappers_scrubbed, parse_cursor)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(file_path) DO UPDATE SET
+             conversation_id = excluded.conversation_id,
+             chunks_imported = excluded.chunks_imported,
+             file_mtime = excluded.file_mtime,
+             csr_tool_blocks_suppressed = excluded.csr_tool_blocks_suppressed,
+             csr_hook_wrappers_scrubbed = excluded.csr_hook_wrappers_scrubbed,
+             parse_cursor = excluded.parse_cursor,
+             -- INSERT OR REPLACE reset this via the column DEFAULT. An upsert
+             -- leaves it alone, which would silently turn a last-import
+             -- timestamp into a first-import one.
+             imported_at = datetime('now')",
         params![
             path_str,
             conv_id,
             chunks as i64,
             mtime,
             persisted_tool,
-            persisted_wrappers
+            persisted_wrappers,
+            cursor
         ],
     )?;
 

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -291,6 +291,30 @@ pub fn delete_chunks_for_conversation(conn: &Connection, conversation_id: &str) 
     Ok(())
 }
 
+/// Delete specific chunks by id, with the same table ordering as
+/// [`delete_chunks_for_conversation`]. Used when a transcript shrinks with an
+/// intact head: the valid prefix is kept and only the orphan tail is dropped.
+pub fn delete_chunks_by_ids(conn: &Connection, ids: &[String]) -> Result<()> {
+    for id in ids {
+        // chunks_fts is rowid-addressed with no FK, so it must go before the
+        // owning chunks row disappears and the rowid lookup goes stale.
+        conn.execute(
+            "DELETE FROM chunks_fts WHERE rowid = (SELECT rowid FROM chunks WHERE id = ?1)",
+            params![id],
+        )?;
+        conn.execute(
+            "DELETE FROM chunk_embeddings WHERE chunk_id = ?1",
+            params![id],
+        )?;
+        conn.execute(
+            "DELETE FROM chunk_provenance WHERE chunk_id = ?1",
+            params![id],
+        )?;
+        conn.execute("DELETE FROM chunks WHERE id = ?1", params![id])?;
+    }
+    Ok(())
+}
+
 pub fn load_all_chunk_vectors(conn: &Connection) -> Result<Vec<(String, Vec<f32>)>> {
     let mut stmt = conn.prepare("SELECT chunk_id, embedding FROM chunk_embeddings")?;
     let rows = stmt.query_map([], |row| {

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -145,8 +145,10 @@ fn vec_to_bytes(v: &[f32]) -> Vec<u8> {
 /// Deserialize bytes back to f32 vector.
 fn bytes_to_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|chunk| f32::from_le_bytes(*chunk))
         .collect()
 }
 

--- a/csr-engine/tests/hooks_integration.rs
+++ b/csr-engine/tests/hooks_integration.rs
@@ -1124,10 +1124,36 @@ fn test_incremental_import_only_new_chunks() {
     std::fs::write(&jsonl_path, grown_content).unwrap();
 
     // Incremental import — file changed (mtime differs) so it re-parses.
-    let _count3 = rt
+    // These messages are short enough that all five share one 900-char chunk, so
+    // the chunk COUNT does not move. The old guard early-returned on
+    // `chunks.len() <= prev_count` and dropped the two new messages on the floor.
+    let count3 = rt
         .block_on(engine.import_file(&jsonl_path, "myapp"))
         .unwrap();
-    // The key assertion: no error occurred during incremental import.
+    assert!(
+        count3 > 0,
+        "a grown transcript must rewrite its trailing chunk even when the chunk count is flat"
+    );
+
+    // And the appended content must actually be retrievable.
+    let conv_id = "conv-incr-test";
+    let ids = engine
+        .storage()
+        .get_chunk_ids_for_conversation(conv_id)
+        .unwrap();
+    let stored = ids
+        .iter()
+        .filter_map(|id| engine.storage().get_chunk_content(id).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        stored.contains("The token refresh was using an expired key"),
+        "appended message must be present in a stored chunk, not silently dropped"
+    );
+    assert!(
+        stored.contains("Run the tests to verify"),
+        "final appended message must be present in a stored chunk"
+    );
 }
 
 /// Test: import_current_transcript shared helper works with real transcript.


### PR DESCRIPTION
The daemon sat at 250% CPU for eight days on my machine — 238 CPU-hours — re-embedding transcripts it had already embedded, and discarding every result.

## Three defects

**1. Re-embedded vectors are discarded.** `SearchEngine::insert_chunk` returns early for an id already in `chunk_id_set`. Worse: a chunk is first indexed while it is the short trailing partial and never updated, so most chunks from a live session carry a vector representing only their first fragment. `remove_chunk`'s own doc comment records this exact bug being found and fixed in the plans path (Codex HIGH); the transcript path never got the fix.

**2. The existing guard loses content.** `engine.rs` sliced `&chunks[prev_count..]`. Chunking flushes a *partial* trailing buffer at EOF, so on the next pass that chunk has grown — slicing past it means the new messages land in no stored chunk at all. The `chunks.len() <= prev_count` early return has the same hole when a file grows without crossing a chunk boundary. The daemon's wasteful full rewrite was masking this; an MCP-only install (no daemon) loses the content outright.

**3. `watcher.rs` had no guard.** `engine.rs` grew one, the watcher never did, and the two copies of this routine drifted. They are now one function.

## Why rebuilding from the seam is sound

The chunker is a greedy left-to-right fold with no lookahead — each flush reads only the current buffer and message length. Chunk boundaries are a pure function of the message prefix, so **only the final EOF-flushed chunk is mutable; every earlier chunk is frozen once written.** The `> CHUNK_CHAR_BUDGET` hard-split branch strengthens this: it always ends on a boundary with an empty buffer.

`SealPolicy::DeferTrailing` keeps the still-growing chunk out of HNSW until it settles, so each chunk is embedded when its content is final. Its content still reaches SQLite and FTS immediately. The hook path passes `SealAll` because its transcript is finished.

## Commits

| | |
|---|---|
| `chore:` | clippy 1.98 `chunks_exact_to_as_chunks`. Pre-existing — CI pins `@stable`, so this breaks `-D warnings` on main independently of this PR. Drop it if you'd rather handle it separately. |
| `fix(import):` | shared `import/incremental.rs`, seam rebuild, `remove_chunk` before reinsert, `SealPolicy` |
| `perf(import):` | `import_state.parse_cursor` byte cursor |
| `fix(import):` | Codex rollouts stop re-embedding unchanged chunks |

They're sequenced rather than independent — the cursor builds on the shared module, and the Codex commit uses `delete_chunks_by_ids` added by the second. Happy to split if you prefer.

## Byte cursor

`byte_offset` is not end-of-file. It is the start of the trailing chunk's first message line, paired with that chunk's index. A hard-split message emits several chunks at one offset, so the cursor points at the first of that group.

Three things had to be fixed first or the cursor would have been quietly wrong:

- `CsrMessageSanitizer` tracks suppressed CSR tool_use ids across lines. A seam between a `tool_use` and its `tool_result` loses the id and **leaks a CSR tool_result into the index**. Ids are now consumed when their result arrives — a no-op for a full parse.
- `mark_file_imported_with_suppression` used `INSERT OR REPLACE`, which deletes and reinserts, so unlisted columns become NULL. It would have erased the cursor it was writing. This pattern appeared three times on `import_state`; all three are upserts now.
- Suppression totals use `previous.max(current)`, built for cumulative counts. The parser now returns absolute totals with the re-parsed seam counted exactly once.

The `.lines()` reader became an offset-tracking `read_line` loop. It **breaks** rather than continues on a read error — with `read_line`, `continue` never advances the offset and spins forever on invalid UTF-8.

## Behaviour changes worth calling out

- **Chunk timestamps are frozen per chunk** rather than restamped across the conversation on every append. `search/decay.rs` uses timestamp for 30% of score, so a long session no longer refloats its entire history each time it is touched. The two import paths previously disagreed on this, so a chunk's timestamp depended on which process imported it.
- The trailing chunk is absent from *semantic* search for one debounce during a live session. Today it is present with a first-fragment vector, so this replaces a wrong answer with an honest absence; FTS still covers it.
- Enrichment gating is reconciled: `engine.rs` gated on `prev_count == 0`, permanently stranding any conversation whose first attempt failed, while `watcher.rs` had no gate and re-read the whole transcript every debounce.

## Verification

1,291 tests. Five of the new cases fail when the seam fix is reverted; the Codex tests each fail when their half is reverted. `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean.

End-to-end on a real 8.5 MB transcript, imported in two passes versus one shot: **601 chunks both ways, identical content hash, exactly one settled chunk rewritten** (the seam).

On a live 233k-chunk index:

| | before | after |
|---|---|---|
| settled chunks rewritten (8,273-chunk transcript, 150s) | all 8,273 every 5s | 0 |
| wasted rewrites per 120s | 90 of 120 | 0 |
| content integrity | — | every conversation has a contiguous `0..n-1` range |

## Not addressed

`bump_aux_counter_by("codex_rollout", ...)` adds the whole file's schema-miss count on every re-import rather than a delta, so that diagnostic over-reports. Pre-existing and untouched here; it needs a per-row baseline like the suppression counters use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added incremental transcript imports that resume efficiently after changes and preserve conversation context.
  - Added import-only operation for processing data without loading or overwriting existing search caches.
  - Added support for routing MCP output through a claimed Unix stdout stream.

- **Bug Fixes**
  - Updated imports to correctly handle appended, rewritten, shortened, and partially processed conversations.
  - Prevented stale search results and orphaned conversation chunks after edits.
  - Improved handling of invalid text encoding and interrupted imports.
  - Ensured cache and import metadata remain consistent during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->