### PR TITLE
fix(search): survive an interrupted HNSW index promotion

### DIFF
--- a/csr-engine/src/search/mod.rs
+++ b/csr-engine/src/search/mod.rs
@@ -423,6 +423,11 @@ impl SearchEngine {
             promote_to_canonical(dir, &basename, "reflections")?;
         }
 
+        // Both promotions are done, so nothing is half-renamed. Clear unconditionally:
+        // a marker left by an earlier crashed run would otherwise survive a dump whose
+        // own promotions both no-opped, and force a rebuild on every load from then on.
+        let _ = std::fs::remove_file(dir.join(PROMOTE_MARKER));
+
         // Write manifest atomically (tmp + rename)
         let manifest = IndexManifest {
             version: MANIFEST_VERSION,
@@ -475,6 +480,15 @@ impl SearchEngine {
             .open(&lock_path)
             .ok()
             .and_then(|f| f.lock_shared().ok().map(|_| f));
+
+        // A promotion that did not finish leaves the canonical .hnsw.graph and .hnsw.data
+        // from different generations. hnsw_rs asserts on that mismatch instead of
+        // returning an error, which aborts the process, so refuse the cache here and let
+        // the caller rebuild.
+        if promotion_interrupted(dir) {
+            tracing::warn!("index promotion did not complete; discarding cache and rebuilding");
+            return None;
+        }
 
         // Read and validate manifest
         let manifest_path = dir.join("manifest.json");
@@ -598,6 +612,20 @@ impl SearchEngine {
     }
 }
 
+/// Written while `promote_to_canonical` is renaming, removed once it finishes.
+///
+/// A promotion moves two files and cannot be made atomic. If the process dies between
+/// them the canonical pair straddles two generations — one file new, the other old —
+/// and `hnsw_rs` handles that with a debug assertion rather than an error, so the whole
+/// process aborts on the next load instead of falling back to a rebuild. This marker
+/// makes the half-finished state detectable, so the index can be rebuilt instead.
+pub(crate) const PROMOTE_MARKER: &str = ".promote-in-flight";
+
+/// True when a previous promotion did not run to completion.
+pub(crate) fn promotion_interrupted(dir: &Path) -> bool {
+    dir.join(PROMOTE_MARKER).exists()
+}
+
 /// If `file_dump` returned a numbered basename (e.g. "chunks-7905"), rename its files
 /// to the canonical name (e.g. "chunks.hnsw.data") so `load_from_disk` can find them.
 /// This happens when the Hnsw was loaded via `load_hnsw` (mmap active → `overwrite=false`).
@@ -605,7 +633,11 @@ fn promote_to_canonical(dir: &Path, returned_basename: &str, canonical: &str) ->
     if returned_basename == canonical {
         return Ok(()); // Already canonical, nothing to do
     }
-    for ext in &[".hnsw.data", ".hnsw.graph"] {
+    // Record the in-flight basename before touching anything. The numbered files are the
+    // only complete copy of this generation until both renames land, so a reader that
+    // finds this marker must rebuild rather than trust the canonical pair.
+    std::fs::write(dir.join(PROMOTE_MARKER), returned_basename)?;
+    for ext in &[".hnsw.graph", ".hnsw.data"] {
         let src = dir.join(format!("{}{}", returned_basename, ext));
         let dst = dir.join(format!("{}{}", canonical, ext));
         if src.exists() {
@@ -619,6 +651,8 @@ fn promote_to_canonical(dir: &Path, returned_basename: &str, canonical: &str) ->
             })?;
         }
     }
+    // Both files carry the canonical name now, so the pair is coherent again.
+    let _ = std::fs::remove_file(dir.join(PROMOTE_MARKER));
     Ok(())
 }
 
@@ -630,6 +664,13 @@ fn promote_to_canonical(dir: &Path, returned_basename: &str, canonical: &str) ->
 /// Called after every `dump_to_disk` and at engine startup.
 /// Must be called while holding `index.lock` (dump_to_disk) or at startup before serving.
 pub fn cleanup_stale_index_files(dir: &Path) {
+    // Mid-promotion the numbered files are the only intact copy of the new generation,
+    // and the canonical pair is mismatched. Deleting them here would throw away the one
+    // thing a recovery could use.
+    if promotion_interrupted(dir) {
+        tracing::warn!("promotion in flight; skipping stale-file cleanup");
+        return;
+    }
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -791,6 +832,56 @@ mod tests {
         // Numbered files should be gone (renamed)
         assert!(!dir.join("chunks-4567.hnsw.data").exists());
         assert!(!dir.join("chunks-4567.hnsw.graph").exists());
+    }
+
+    #[test]
+    fn test_promote_clears_marker_on_success() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("chunks-77.hnsw.data"), "new_data").unwrap();
+        std::fs::write(dir.join("chunks-77.hnsw.graph"), "new_graph").unwrap();
+
+        promote_to_canonical(dir, "chunks-77", "chunks").unwrap();
+
+        assert!(
+            !promotion_interrupted(dir),
+            "marker must be gone once both renames land"
+        );
+    }
+
+    #[test]
+    fn test_interrupted_promotion_is_detected() {
+        // Reproduces the crash of 2026-08-26: a process died between the two renames,
+        // leaving chunks.hnsw.graph from generation N and chunks.hnsw.data from N+1.
+        // hnsw_rs asserts on the origin_id mismatch and aborts, so the mismatch has to
+        // be caught before the files are opened.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("chunks.hnsw.graph"), "new_graph").unwrap();
+        std::fs::write(dir.join("chunks.hnsw.data"), "old_data").unwrap();
+        std::fs::write(dir.join(PROMOTE_MARKER), "chunks-77").unwrap();
+
+        assert!(promotion_interrupted(dir));
+        assert!(
+            SearchEngine::load_from_disk(dir, 0, 0).is_none(),
+            "a half-promoted index must be refused, not loaded"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_spares_numbered_files_mid_promotion() {
+        // The numbered files are the only intact copy of the new generation until both
+        // renames land, so cleanup must leave them alone while the marker is present.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("chunks-77.hnsw.data"), "new_data").unwrap();
+        std::fs::write(dir.join("chunks-77.hnsw.graph"), "new_graph").unwrap();
+        std::fs::write(dir.join(PROMOTE_MARKER), "chunks-77").unwrap();
+
+        cleanup_stale_index_files(dir);
+
+        assert!(dir.join("chunks-77.hnsw.data").exists());
+        assert!(dir.join("chunks-77.hnsw.graph").exists());
     }
 
     #[test]


### PR DESCRIPTION
## The failure

`csr-engine hook stop` exits 101 and takes the process down:

```
thread 'main' panicked at hnsw_rs: origin_id incoherent between graph and data, left: 32, right: 295798
```

Once it starts, every hook invocation in every session fails the same way, until some later dump happens to rewrite both files and the index heals by luck.

## Cause

`promote_to_canonical` renames the two files a dumped index consists of:

```rust
for ext in &[".hnsw.data", ".hnsw.graph"] {
```

Those two files have to describe the same generation, and two renames cannot be made atomic. A process that dies in the gap leaves `chunks.hnsw.data` from generation N+1 next to `chunks.hnsw.graph` from generation N. `hnsw_rs` meets that mismatch with a debug assertion rather than a `Result`, so the next `load_from_disk` aborts the process instead of falling back to the rebuild path that already exists for every other kind of bad cache.

Reversing the rename order does not fix it — new-graph + old-data is equally incoherent.

There is a second, latent bug in the same window. Mid-promotion the numbered files (`chunks-9962.hnsw.*`) are the only intact copy of the new generation, and `cleanup_stale_index_files` deletes exactly that pattern. In the incident above it would have destroyed the only material a recovery could have used.

## Fix

Make the window observable rather than trying to make it atomic.

- `promote_to_canonical` writes `.promote-in-flight` before the first rename and removes it after the second.
- `load_from_disk` returns `None` when the marker is present, so a torn index costs a rebuild instead of a crash.
- `cleanup_stale_index_files` returns early while the marker is present, preserving the numbered files.
- `dump_to_disk` clears the marker unconditionally once both promotions finish. Without this, a marker orphaned by an earlier crash survives any later dump whose promotions both no-op, and forces a rebuild on every load from then on.

Rename order is now graph-then-data. That is not load-bearing; it just keeps the marker's meaning easy to read.

## Tests

Three added alongside the existing promotion tests:

- `test_promote_clears_marker_on_success`
- `test_interrupted_promotion_is_detected` — builds the exact mismatched on-disk state and asserts `load_from_disk` refuses it
- `test_cleanup_spares_numbered_files_mid_promotion`

Full suite passes (1,156 lib + 116 integration), `clippy` adds no new warnings, `cargo fmt --check` clean.

## Verified live

Built and installed over the affected machine's `~/.local/bin/csr-engine`, then ran the real Stop hook against a 298,320-chunk index: exit 0, cache loaded, no panic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search index recovery after interrupted updates.
  * Prevented incomplete index promotions from being loaded as valid data.
  * Preserved index files during in-progress recovery operations to avoid data loss.
  * Added safeguards to ensure stale recovery state is cleared after successful updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->