### PR TITLE
perf(hooks): stop hnsw_rs stdout leaking into the injection channel

### DIFF
--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "fs2",
  "hnsw_rs",
  "ignore",
+ "libc",
  "minijinja",
  "notify",
  "ratatui",

--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -8,6 +8,7 @@ description = "Claude Self-Reflect: Rust MCP server with embedded vector search"
 rmcp = { version = "3.1", features = ["server", "transport-io", "macros", "elicitation"] }
 fastembed = "5.9"
 hnsw_rs = "0.3"
+libc = "0.2"
 rusqlite = { version = "0.40", features = ["bundled", "vtab"] }
 notify = "8"
 tokio = { version = "1", features = ["full"] }

--- a/csr-engine/src/hooks/mod.rs
+++ b/csr-engine/src/hooks/mod.rs
@@ -248,6 +248,28 @@ pub async fn import_current_transcript(input: &HookInput, engine: &Engine, cwd: 
     }
 }
 
+/// Redirect this process's stdout (fd 1) onto stderr (fd 2) for the rest of the
+/// hook.
+///
+/// Hook stdout is Claude Code's context-injection channel on `UserPromptSubmit`
+/// and `SessionStart`, so a stray library print lands in the model's context as
+/// if it were retrieved memory. `hnsw_rs` 0.3.4 has a bare `println!` in
+/// `generate_new_point` (hnsw.rs:520) that fires on every point insert, so any
+/// indexing performed *after* a hook has emitted its injection leaks
+/// `" setting number of points N "` into the prompt.
+///
+/// Call this once a hook has finished writing its intended output. There is no
+/// restore: the hook process exits immediately afterwards.
+pub fn suppress_stdout() {
+    // SAFETY: dup2 on this process's own standard descriptors. A failure here is
+    // non-fatal — the worst case is the pre-existing leak — so the result is
+    // deliberately ignored.
+    unsafe {
+        libc::dup2(libc::STDERR_FILENO, libc::STDOUT_FILENO);
+    }
+}
+
+
 /// Main hook dispatcher. Parses stdin, routes to handler.
 pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
     // Recursive-hook guard. The session-briefing hook spawns a nested `claude -p`
@@ -297,6 +319,8 @@ pub async fn dispatch_hook(hook_name: &str, engine: &Engine) -> Result<()> {
     let t_hook = t0.elapsed();
 
     // Flush HNSW index if any hook modified it
+    // Nothing after the handler should reach stdout; see suppress_stdout.
+    suppress_stdout();
     engine.flush_index().await;
     let t_total = t0.elapsed();
 

--- a/csr-engine/src/hooks/prompt_submit.rs
+++ b/csr-engine/src/hooks/prompt_submit.rs
@@ -60,10 +60,18 @@ pub async fn handle(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<()
     // Incremental: mtime check makes this a no-op when nothing changed (~0ms).
     // When new content exists: ~30-50ms for 1-2 chunks (well under perceptible lag).
     // Content becomes searchable by the next prompt submit.
+    // Injection is done; from here nothing may touch stdout. Indexing inserts
+    // HNSW points, and hnsw_rs prints to stdout on insert, which would land in
+    // the model's context as fake retrieved memory. See super::suppress_stdout.
+    super::suppress_stdout();
     super::import_current_transcript(input, engine, cwd).await;
 
     Ok(()) // Always succeed
 }
+
+/// Upper bound on `code_nodes_by_name` probes per prompt in `build_graph_slices`.
+/// Without it, cost scales with prompt word count.
+const MAX_SYMBOL_PROBES: usize = 12;
 
 /// Maximum age (in minutes) to apply continuity boost.
 const CONTINUITY_THRESHOLD_MINUTES: i64 = 2880;
@@ -239,8 +247,15 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
     // 1. Search for anti-patterns (highest priority)
     // Anti-patterns use a modified query ("failed approach don't retry: ...") so keep separate embedding.
     // TODO: scope anti-patterns by project once outcome reflections carry project tags (Codex H-1)
-    let anti_patterns =
-        anti_pattern::find_anti_patterns(storage, embeddings, search, prompt, 0.5, 2).await;
+    // Opt-out: this stage costs a second full embedding pass (the query is
+    // rewritten to "failed approach don't retry: ..."), which the upstream
+    // comment above keeps deliberately separate from the main query vector.
+    // Set CSR_NO_ANTI_PATTERNS=1 to trade that recall for latency.
+    let anti_patterns = if std::env::var("CSR_NO_ANTI_PATTERNS").as_deref() == Ok("1") {
+        Vec::new()
+    } else {
+        anti_pattern::find_anti_patterns(storage, embeddings, search, prompt, 0.5, 2).await
+    };
 
     // Route B pickup: episode correlation. A content prompt may be re-asking
     // an already-solved problem or retelling past context from lossy human
@@ -363,7 +378,15 @@ async fn handle_inner(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<
     // 5c. Code graph slice (v9.4) — capped relevant_context item within the
     // existing PROMPT_TOKEN_BUDGET (Codex #5: no separate budget). Surfaces the
     // 1-hop neighborhood of files/symbols named in the prompt, with provenance.
-    for slice in build_graph_slices(storage, prompt, &current_files, &current_project) {
+    // Opt-out: graph slices issue one SQLite query per qualifying prompt token
+    // (now bounded by MAX_SYMBOL_PROBES) plus a file-ledger read. Set
+    // CSR_NO_GRAPH_SLICES=1 to skip the stage entirely.
+    let graph_slices = if std::env::var("CSR_NO_GRAPH_SLICES").as_deref() == Ok("1") {
+        Vec::new()
+    } else {
+        build_graph_slices(storage, prompt, &current_files, &current_project)
+    };
+    for slice in graph_slices {
         review_items.push(InjectionItem {
             content: slice,
             score: 0.88,
@@ -767,9 +790,22 @@ async fn search_chunks_with_vec(
 
     let now = chrono::Utc::now();
     let mut raw_results = Vec::new();
+
+    // Batch the row fetch. `get_chunks_by_ids` already takes a slice, but was
+    // being called once per hit via `from_ref`, making this N+1 over the HNSW
+    // result set. Fetch once and index by id, preserving the original result
+    // order (and therefore score order) when rebuilding.
+    let chunk_ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+    let mut chunk_by_id: std::collections::HashMap<String, _> = storage
+        .get_chunks_by_ids(&chunk_ids)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|c| (c.id.clone(), c))
+        .collect();
+
     for result in &results {
-        if let Ok(chunks) = storage.get_chunks_by_ids(std::slice::from_ref(&result.id)) {
-            if let Some(chunk) = chunks.into_iter().next() {
+        {
+            if let Some(chunk) = chunk_by_id.remove(&result.id) {
                 // Project scope filter: skip chunks from other projects
                 if !project.is_empty() && chunk.project_name != project {
                     continue;
@@ -1035,7 +1071,16 @@ pub(crate) fn build_graph_slices(
     }
 
     // Symbol-anchored slice: callees of a symbol named in the prompt.
+    //
+    // Each qualifying token costs one `code_nodes_by_name` query, and the loop
+    // only breaks once a token actually yields a slice. A long prompt whose
+    // words match no graph node therefore issues one SQLite query per word with
+    // no upper bound. Cap the probes so worst-case cost is fixed.
+    let mut symbol_probes = 0usize;
     for word in prompt.split_whitespace() {
+        if symbol_probes >= MAX_SYMBOL_PROBES {
+            break;
+        }
         let token: String = word
             .chars()
             .filter(|c| c.is_alphanumeric() || *c == '_')
@@ -1043,6 +1088,7 @@ pub(crate) fn build_graph_slices(
         if token.len() < 6 {
             continue;
         }
+        symbol_probes += 1;
         // Ask for 2 so an ambiguous name (multiple definitions sharing the
         // same name) is detectable instead of silently picking one.
         let nodes = match storage.code_nodes_by_name(&token, project, 2) {


### PR DESCRIPTION
## The bug

Hook stdout is Claude Code's context-injection channel on `UserPromptSubmit` and `SessionStart`. `hnsw_rs` 0.3.4 has a bare `println!` in `generate_new_point`:

```rust
// hnsw.rs:520
if nb_point % 50000 == 0 {
    println!(" setting number of points {:?} ", nb_point);
}
```

`prompt_submit::handle` prints its injection and *then* calls `import_current_transcript`, which inserts HNSW points. Once the index crosses a 50k boundary, that line lands on stdout after the injection and reaches the model as if it were retrieved memory.

Observed on a 300k-chunk index — the model received exactly one line of context that turn:

```
UserPromptSubmit hook success: setting number of points 300000
```

It's intermittent by construction (1 in 50,000 inserts), which is what makes it easy to miss.

## Fix

`hooks::suppress_stdout()` redirects fd 1 onto fd 2, called once a hook has emitted its intended output — in `prompt_submit` before the post-injection import, and in `dispatch_hook` before `flush_index`. No restore: the hook process exits immediately after.

## Also included

Three things found while tracing the above, all in the `prompt_submit` path:

- **`build_graph_slices` was unbounded.** One `code_nodes_by_name` query per prompt token >= 6 chars, and the loop only breaks once a token yields a slice — so a long prompt matching no graph node issued one SQLite query per word. Capped at `MAX_SYMBOL_PROBES = 12`.
- **N+1 on chunk hydration.** `get_chunks_by_ids` already takes a slice but was called once per hit via `slice::from_ref`. Now one batched call, indexed by id to preserve score order.
- **`CSR_NO_GRAPH_SLICES` / `CSR_NO_ANTI_PATTERNS`** opt-outs, matching the existing `CSR_NO_*` convention. `prompt_submit` had no kill switch for any of its expensive stages, unlike `stop` (`CSR_NO_TASK_RESOLUTION`) or `session_briefing` (`CSR_NO_AI_NARRATIVES`).

The anti-pattern stage keeps its separate embedding pass — the existing comment says that's deliberate, so it's behind a switch rather than folded into the main query vector.

## Verification

1269 tests pass.

A/B with an emulated stray print at the same call site:

| probe placement | stdout bytes | leak on stdout |
|---|---|---|
| before `suppress_stdout()` | 34 | yes |
| after `suppress_stdout()` | 0 | no — routed to stderr |

Kill switches measured on a 301k-chunk index: in-hook time 92ms/38ms -> 37ms/20ms.

Running on my own install against a 301k-chunk index; `prompt-submit` injection confirmed still working (`items=2 stdout=386B`).

## Note

Adds `libc` as a direct dependency for `dup2`. It was already in the tree transitively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stray indexing and graph-processing output from appearing in the context-injection channel.
  * Improved prompt-submit indexing reliability when batch metadata retrieval fails.
  * Reduced unnecessary database queries during prompt-submit indexing.

* **Performance**
  * Limited graph symbol probing to improve responsiveness.
  * Added configuration options to disable anti-pattern and graph-slice retrieval when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->