### PR TITLE
perf(engine): startup memory hygiene on the 9.5 line (9.5.5)

### DIFF
--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -42,6 +42,7 @@ ignore = "0.4"
 toml = "0.9"
 
 [dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tempfile = "3"
 

--- a/csr-engine/examples/quick_check_floor.rs
+++ b/csr-engine/examples/quick_check_floor.rs
@@ -108,8 +108,10 @@ const PROBES: &[Probe] = &[
 
 fn bytes_to_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|chunk| f32::from_le_bytes(*chunk))
         .collect()
 }
 

--- a/csr-engine/scripts/profile-memory.sh
+++ b/csr-engine/scripts/profile-memory.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# Memory profiling harness for csr-engine (macOS only — relies on `/usr/bin/time -l`
+# and `vmmap`, both BSD tools; runs on the stock /bin/bash 3.2). Reproduces the
+# per-process startup cost of the engine (HNSW cache load + model) across the MCP
+# and hook entry points.
+#
+# Usage: profile-memory.sh <binary> <db-path> [--label NAME]
+#
+# Prints ONE markdown table to stdout (peak RSS + wall time per scenario, plus a
+# steady-state footprint row and a drift-reconciliation row). Diagnostic chatter
+# goes to stderr so stdout stays a clean report — redirect stdout to capture it:
+#   scripts/profile-memory.sh <binary> <db> --label baseline > report.md
+#
+# Isolation: every child process runs with HOME pointed at a scratch directory
+# (so hook-timing.log, mcp-binary.txt and the probe caches land there, never in
+# the real ~/.claude-self-reflect), with an explicit --projects-dir inside that
+# scratch HOME, and with the fastembed model cache COPIED in from the real
+# ~/Library/Caches so no scenario ever downloads. <db-path> itself is only ever
+# read (sqlite3 .backup + a copy of its index dir): rows 1-4 run on one fresh
+# snapshot, the drift row on another, so a rebuilt index or a hook's writes
+# never land in the caller's directory. Every trial must also report the
+# "cached" startup path; a trial that rebuilt the index invalidates its row.
+# The real live data dir is refused as <db-path> even through a symlink, and
+# it is checked before and after for harness-tagged hook lines and for a
+# rewritten serving-binary stamp.
+#
+# Every trial must exit 0 AND leave the marker its scenario is expected to
+# produce (the MCP initialize response, the hook's own timing line); a row with
+# any failed trial is reported as unmeasured with the reason, never as a number.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <binary> <db-path> [--label NAME]" >&2
+    exit 1
+fi
+
+BINARY="$1"
+DB_PATH="$2"
+shift 2
+LABEL="profile"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --label)
+            LABEL="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "Binary not found or not executable: $BINARY" >&2
+    exit 1
+fi
+if [[ ! -f "$DB_PATH" ]]; then
+    echo "DB not found: $DB_PATH" >&2
+    exit 1
+fi
+
+for tool in timeout vmmap /usr/bin/time sqlite3 python3; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Required tool not found on PATH: $tool" >&2
+        exit 1
+    fi
+done
+
+# Fully resolve both paths (symlinks included) before any guard looks at them.
+BINARY="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$BINARY")"
+DB_PATH="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$DB_PATH")"
+
+# Never touch the live data dir, no matter what caller passes.
+LIVE_DATA_DIR="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$HOME/.claude-self-reflect")"
+case "$DB_PATH" in
+    "$LIVE_DATA_DIR"/*)
+        echo "Refusing to run against live data dir: $DB_PATH" >&2
+        exit 1
+        ;;
+esac
+
+# Prefer Homebrew's sqlite3 (has fts5) over the system one when available —
+# see CLAUDE.md: "System sqlite3 (macOS): cannot load fts5".
+SQLITE3=sqlite3
+if [[ -x /opt/homebrew/opt/sqlite/bin/sqlite3 ]]; then
+    SQLITE3=/opt/homebrew/opt/sqlite/bin/sqlite3
+fi
+
+TIMEOUT_SECS=90
+# Per-user temp root (never a predictable shared /tmp path), fully resolved:
+# macOS /tmp and /var are symlinks, and the hooks compare their canonicalized
+# cwd against $HOME, so the scratch HOME must be canonical.
+WORK_DIR="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$(mktemp -d "${TMPDIR:-/tmp}/csr-mem-profile.XXXXXX")")"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+log() { echo "[profile-memory] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Isolated HOME for every child process
+# ---------------------------------------------------------------------------
+FAKE_HOME="$WORK_DIR/home"
+PROJECTS_DIR="$FAKE_HOME/.claude/projects"
+HOOK_CWD="$FAKE_HOME/project"
+mkdir -p "$FAKE_HOME/.claude-self-reflect" "$PROJECTS_DIR" "$HOOK_CWD" "$FAKE_HOME/Library/Caches/csr-engine"
+
+REAL_MODEL_CACHE="$HOME/Library/Caches/csr-engine/fastembed"
+if [[ ! -d "$REAL_MODEL_CACHE" ]]; then
+    echo "fastembed model cache not found at $REAL_MODEL_CACHE — run \`csr-engine setup\` once so no scenario has to download" >&2
+    exit 1
+fi
+cp -R "$REAL_MODEL_CACHE" "$FAKE_HOME/Library/Caches/csr-engine/fastembed"
+# Probe caches (intent/reaction exemplar embeddings): copying them keeps
+# prompt-submit at its steady-state cost instead of a first-run re-embed.
+for probe in intent_probes.json reaction_probes.json; do
+    if [[ -f "$LIVE_DATA_DIR/$probe" ]]; then
+        cp "$LIVE_DATA_DIR/$probe" "$FAKE_HOME/.claude-self-reflect/$probe"
+    fi
+done
+# A real file for the Edit hook to track — the installed PostToolUse matcher
+# (Edit|Write|MultiEdit|NotebookEdit) is what fires this hook in production.
+printf 'fn probe() -> u32 {\n    42\n}\n' >"$HOOK_CWD/probe.rs"
+
+# Isolation receipts. The operator's own Claude Code session keeps appending
+# to the live hook-timing.log while this runs, so an mtime check would flag
+# it; instead count the lines only this harness's fixtures can produce (its
+# hook cwd resolves to the project name "project") and compare the serving
+# binary stamp, which only an MCP server started with the real HOME rewrites.
+live_probe_lines() {
+    local f="$LIVE_DATA_DIR/hook-timing.log"
+    if [[ -e "$f" ]]; then grep -c 'CSR hook [a-z-]* \[project\]' "$f" || true; else echo 0; fi
+}
+live_stamp() {
+    local f="$LIVE_DATA_DIR/mcp-binary.txt"
+    if [[ -e "$f" ]]; then cat "$f"; else echo "absent"; fi
+}
+LIVE_PROBE_LINES_BEFORE="$(live_probe_lines)"
+LIVE_STAMP_BEFORE="$(live_stamp)"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Run one scenario under `/usr/bin/time -l` with the isolated HOME.
+# Args: stdin_file expect_regex db_path [engine args...]
+# Prints "rss_bytes wall_s footprint_bytes ok" on success, "0 0 0 fail" on any
+# failure (non-zero exit, timeout, missing marker, unparsable timing), with
+# diagnostics on stderr. RSS counts file-backed pages too; the footprint is the
+# private dirty peak, which is what memory pressure actually sees.
+# The child's stderr is copied to $LAST_STDERR for the caller to inspect
+# (a fixed file, because callers invoke this inside command substitution).
+LAST_STDERR="$WORK_DIR/last_stderr.log"
+# Set to e.g. "info" around a trial that needs the engine's tracing lines
+# (stderr) as evidence; empty leaves the binary's default (warn).
+TRIAL_RUST_LOG=""
+run_timed_once() {
+    local stdin_file="$1" expect="$2" db="$3"
+    shift 3
+    local timefile="$WORK_DIR/time.$$.$RANDOM.log"
+    local outfile="$WORK_DIR/out.$$.$RANDOM.log"
+    local status=0
+    (
+        export HOME="$FAKE_HOME"
+        unset CSR_DISABLE_RECURSIVE_HOOKS
+        if [[ -n "$TRIAL_RUST_LOG" ]]; then export RUST_LOG="$TRIAL_RUST_LOG"; fi
+        timeout "$TIMEOUT_SECS" /usr/bin/time -l "$BINARY" --db-path "$db" --projects-dir "$PROJECTS_DIR" "$@" \
+            <"$stdin_file" >"$outfile" 2>"$timefile"
+    ) || status=$?
+    cp "$timefile" "$LAST_STDERR"
+    local rss wall fp
+    rss=$(awk '/maximum resident set size/{print $1; exit}' "$timefile")
+    wall=$(awk '/ real /{print $1; exit}' "$timefile")
+    fp=$(awk '/peak memory footprint/{print $1; exit}' "$timefile")
+    local reason=""
+    if [[ $status -ne 0 ]]; then
+        reason="exit status $status"
+    elif [[ -z "$rss" || -z "$wall" || -z "$fp" ]]; then
+        reason="could not parse /usr/bin/time -l output"
+    elif [[ -n "$expect" ]] && ! grep -Eq -- "$expect" "$outfile" "$timefile"; then
+        reason="expected marker /$expect/ not found in stdout/stderr"
+    fi
+    if [[ -n "$reason" ]]; then
+        log "FAILED trial ($reason): $BINARY --db-path $db $*"
+        grep -v 'maximum resident\|page reclaims\|page faults\|swaps\|block \|messages \|signals \|context switches\|instructions retired\|cycles elapsed\|peak memory\|^ *[0-9.]* real ' "$timefile" | tail -15 >&2 || true
+        echo "0 0 0 fail"
+        return
+    fi
+    rm -f "$outfile"
+    echo "$rss $wall $fp ok"
+}
+
+median_of() {
+    # args: N numbers -> prints median (bash 3.2 compatible: no mapfile)
+    local -a sorted
+    sorted=($(printf '%s\n' "$@" | sort -n))
+    local n=${#sorted[@]}
+    local mid=$((n / 2))
+    if ((n % 2 == 1)); then
+        echo "${sorted[$mid]}"
+    else
+        awk -v a="${sorted[$((mid - 1))]}" -v b="${sorted[$mid]}" 'BEGIN{printf "%.4f", (a+b)/2}'
+    fi
+}
+
+bytes_to_mb() {
+    awk -v b="$1" 'BEGIN{printf "%.1f", b/1024/1024}'
+}
+
+# Run N timed trials of a scenario. Prints "median_rss_mb median_wall_s
+# median_footprint_mb" when every trial passed, or "fail" if any trial failed.
+median_trials() {
+    local trials="$1" stdin_file="$2" expect="$3" db="$4"
+    shift 4
+    local -a rss_vals=()
+    local -a wall_vals=()
+    local -a fp_vals=()
+    local i out r w f s
+    for ((i = 1; i <= trials; i++)); do
+        out=$(run_timed_once "$stdin_file" "$expect" "$db" "$@")
+        r=$(echo "$out" | awk '{print $1}')
+        w=$(echo "$out" | awk '{print $2}')
+        f=$(echo "$out" | awk '{print $3}')
+        s=$(echo "$out" | awk '{print $4}')
+        if [[ "$s" != "ok" ]]; then
+            echo "fail"
+            return
+        fi
+        if ! grep -q 'CSR startup:.*cached)' "$LAST_STDERR"; then
+            log "FAILED trial $i/$trials: startup did not take the cached path (index rebuilt or startup line missing); the row would mix two startup paths"
+            echo "fail"
+            return
+        fi
+        rss_vals+=("$r")
+        wall_vals+=("$w")
+        fp_vals+=("$f")
+        log "trial $i/$trials: rss=${r}B footprint=${f}B wall=${w}s -- $BINARY --db-path $db $*"
+    done
+    local med_rss med_wall med_fp
+    med_rss=$(median_of "${rss_vals[@]}")
+    med_wall=$(median_of "${wall_vals[@]}")
+    med_fp=$(median_of "${fp_vals[@]}")
+    echo "$(bytes_to_mb "$med_rss") $med_wall $(bytes_to_mb "$med_fp")"
+}
+
+# Fresh SQLite backup of DB_PATH plus a copy of its index dir, into $1.
+# Prints the new db path, or nothing (with diagnostics) on failure.
+snapshot_db() {
+    local dir="$1"
+    mkdir -p "$dir"
+    local db="$dir/csr-engine.db"
+    if ! "$SQLITE3" "$DB_PATH" ".backup '$db'" 2>"$dir/backup_err.log"; then
+        log "sqlite3 .backup failed: $(tr '\n' ' ' <"$dir/backup_err.log")"
+        return
+    fi
+    if [[ -d "$(dirname "$DB_PATH")/index" ]]; then
+        cp -R "$(dirname "$DB_PATH")/index" "$dir/index"
+    fi
+    echo "$db"
+}
+
+# Parse a right-justified vmmap --summary REGION TYPE table column for a row
+# whose name starts with `target`. vmmap right-justifies values so a wide
+# value can overflow left past its header's "=" underline — we extract
+# [prev_column_end+1, this_column_end] rather than [this_column_start, end]
+# to capture that overflow correctly. col: 1=VIRTUAL 2=RESIDENT 3=DIRTY
+# 4=SWAPPED 5=VOLATILE 6=NONVOL 7=EMPTY 8=COUNT.
+parse_vmmap_col() {
+    local vmmap_file="$1" target="$2" col="$3"
+    awk -v target="$target" -v col="$col" '
+        BEGIN { have_sep = 0; found = 0 }
+        !have_sep && /^===========/ {
+            n = 0; i = 1; len = length($0)
+            while (i <= len) {
+                c = substr($0, i, 1)
+                if (c == "=") {
+                    while (i <= len && substr($0, i, 1) == "=") i++
+                    n++; ends[n] = i - 1
+                } else { i++ }
+            }
+            have_sep = 1
+            next
+        }
+        have_sep && !found && index($0, target) == 1 {
+            lo = ends[col] + 1
+            hi = ends[col + 1]
+            val = substr($0, lo, hi - lo + 1)
+            gsub(/^[ \t]+|[ \t]+$/, "", val)
+            print val
+            found = 1
+        }
+    ' "$vmmap_file"
+}
+
+vmmap_size_to_mb() {
+    local v="$1"
+    if [[ -z "$v" ]]; then
+        echo "n/a"
+        return
+    fi
+    local num="${v%[KMG]}"
+    local suf="${v: -1}"
+    case "$suf" in
+        K) awk -v n="$num" 'BEGIN{printf "%.2f", n/1024}' ;;
+        M) awk -v n="$num" 'BEGIN{printf "%.2f", n}' ;;
+        G) awk -v n="$num" 'BEGIN{printf "%.2f", n*1024}' ;;
+        *) echo "$v" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Binary identity
+# ---------------------------------------------------------------------------
+BIN_SIZE_BYTES=$(stat -f%z "$BINARY")
+BIN_SIZE_MB=$(bytes_to_mb "$BIN_SIZE_BYTES")
+BIN_SHA256=$(shasum -a 256 "$BINARY" | awk '{print $1}')
+
+# ---------------------------------------------------------------------------
+# Snapshot for rows 1-4. Engine::new persists a rebuilt index next to the db
+# it was given, and hooks write, so the caller's directory is never handed
+# to the binary.
+# ---------------------------------------------------------------------------
+MAIN_DB="$(snapshot_db "$WORK_DIR/main")"
+if [[ -z "$MAIN_DB" ]]; then
+    echo "could not snapshot $DB_PATH (see stderr)" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Row 1: bare MCP initialize
+# ---------------------------------------------------------------------------
+log "=== Row 1: bare MCP initialize (median of 3) ==="
+INIT_INPUT="$WORK_DIR/init_input.jsonl"
+{
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"profile-harness","version":"0.1.0"}}}'
+    printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+} >"$INIT_INPUT"
+INIT_EXPECT='"serverInfo"'
+ROW1_RESULT="$(median_trials 3 "$INIT_INPUT" "$INIT_EXPECT" "$MAIN_DB")"
+ROW1_RSS_MB="unmeasured"; ROW1_WALL_S="n/a"; ROW1_FP_MB="n/a"
+if [[ "$ROW1_RESULT" != "fail" ]]; then
+    read -r ROW1_RSS_MB ROW1_WALL_S ROW1_FP_MB <<<"$ROW1_RESULT"
+fi
+
+# ---------------------------------------------------------------------------
+# Rows 2-3: hooks (they may write to the snapshot; row 1 was measured first)
+# ---------------------------------------------------------------------------
+HOOK_DB="$MAIN_DB"
+ROW2_RSS_MB="unmeasured"; ROW2_WALL_S="n/a"; ROW2_FP_MB="n/a"; ROW2_NOTE="-"
+ROW3_RSS_MB="unmeasured"; ROW3_WALL_S="n/a"; ROW3_FP_MB="n/a"; ROW3_NOTE="-"
+# Row 2: post-tool-use for an Edit — the installed matcher's case. cwd sits
+# inside the isolated HOME, which is what the hook's cwd guard requires,
+# and the edit carries a real old/new pair so code-evolution tracking and
+# the code-graph re-extraction both run. No transcript_path: the fixture
+# measures engine startup plus edit tracking, not a transcript import.
+log "=== Row 2: hook post-tool-use Edit, installed matcher (median of 3) ==="
+PTU_INPUT="$WORK_DIR/post_tool_use.json"
+printf '{"session_id":"probe","tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"    42\n","new_string":"    43\n"},"cwd":"%s"}' \
+    "$HOOK_CWD/probe.rs" "$HOOK_CWD" >"$PTU_INPUT"
+ROW2_RESULT="$(median_trials 3 "$PTU_INPUT" 'CSR hook post-tool-use' "$HOOK_DB" hook post-tool-use)"
+if [[ "$ROW2_RESULT" != "fail" ]]; then
+    read -r ROW2_RSS_MB ROW2_WALL_S ROW2_FP_MB <<<"$ROW2_RESULT"
+    ROW2_NOTE="edit tracked; no transcript in fixture"
+else
+    ROW2_NOTE="a trial failed (see stderr)"
+fi
+
+# Row 3: prompt-submit with a real, search-worthy prompt so the hook runs
+# its full path (intent classification + injection search), not the
+# short-prompt early return. The marker is the hook's own "Injected N
+# items" stderr line, which it only prints after the prompt was embedded
+# and searched — the timing line alone would also appear when embedding
+# failed silently.
+log "=== Row 3: hook prompt-submit (median of 3) ==="
+PS_INPUT="$WORK_DIR/prompt_submit.json"
+printf '{"session_id":"probe","prompt":"why does the engine load the whole HNSW index at startup and how do I reduce its memory","cwd":"%s"}' \
+    "$HOOK_CWD" >"$PS_INPUT"
+ROW3_RESULT="$(median_trials 3 "$PS_INPUT" 'CSR: Injected [0-9]+ items' "$HOOK_DB" hook prompt-submit)"
+if [[ "$ROW3_RESULT" != "fail" ]]; then
+    read -r ROW3_RSS_MB ROW3_WALL_S ROW3_FP_MB <<<"$ROW3_RESULT"
+    ROW3_NOTE="embedded + searched (Injected line present)"
+else
+    ROW3_NOTE="a trial failed (see stderr)"
+fi
+
+# ---------------------------------------------------------------------------
+# Row 4: steady-state private footprint, 6s after the initialize response.
+# Three separate servers, because the number is bimodal run to run (the
+# allocator keeps a variable amount of freed-but-dirty pages after the index
+# load): the row reports the median with the min-max spread.
+# ---------------------------------------------------------------------------
+log "=== Row 4: steady-state private footprint (vmmap 6s after the initialize response, 3 servers) ==="
+ROW4_STATUS="ok"
+ROW4_FOOTPRINT="n/a"
+ROW4_RANGE="n/a"
+ROW4_MALLOC_DIRTY="n/a"
+ROW4_MAPPED_FILE="n/a"
+ROW4_FP_VALS=()
+ROW4_MD_VALS=()
+ROW4_MF_VALS=()
+ROW4_HEAP_VALS=()
+ROW4_HEAP="n/a"
+for ((k = 1; k <= 3; k++)); do
+    VMMAP_OUT="$WORK_DIR/vmmap.$k.txt"
+    STEADY_OUT="$WORK_DIR/steady_stdout.$k.log"
+    STEADY_ERR="$WORK_DIR/steady_stderr.$k.log"
+    (
+        export HOME="$FAKE_HOME"
+        unset CSR_DISABLE_RECURSIVE_HOOKS
+        { cat "$INIT_INPUT"; /bin/sleep 60; } | "$BINARY" --db-path "$MAIN_DB" --projects-dir "$PROJECTS_DIR" \
+            >"$STEADY_OUT" 2>"$STEADY_ERR" &
+        SERVER_PID=$!
+        # Start the 6s clock from the initialize response, not from launch.
+        waited=0
+        until grep -q '"serverInfo"' "$STEADY_OUT" 2>/dev/null || ((waited >= 150)); do
+            sleep 0.2
+            waited=$((waited + 1))
+        done
+        sleep 6
+        if kill -0 "$SERVER_PID" 2>/dev/null; then
+            vmmap --summary "$SERVER_PID" >"$VMMAP_OUT" 2>&1 || true
+            # Live malloc bytes: the deterministic steady-state number. The
+            # footprint above also counts freed-but-not-yet-returned pages,
+            # which is why it swings ~130MB between otherwise identical runs.
+            heap -s "$SERVER_PID" 2>/dev/null | awk '/^All zones:.*bytes\)/{gsub(/[()]/, "", $(NF-1)); print $(NF-1); exit}' >"$WORK_DIR/heap.$k.txt" || true
+        fi
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    ) &
+    STEADY_WRAPPER_PID=$!
+    wait "$STEADY_WRAPPER_PID" || true
+
+    if ! grep -q '"serverInfo"' "$STEADY_OUT" 2>/dev/null; then
+        ROW4_STATUS="unmeasured: server $k never answered initialize"
+        tail -5 "$STEADY_ERR" >&2 || true
+        break
+    elif [[ -s "$VMMAP_OUT" ]]; then
+        RAW_FOOTPRINT=$(awk '/^Physical footprint:/{print $3; exit}' "$VMMAP_OUT")
+        RAW_MALLOC_DIRTY=$(parse_vmmap_col "$VMMAP_OUT" "MALLOC_SMALL " 3)
+        RAW_MAPPED_FILE=$(parse_vmmap_col "$VMMAP_OUT" "mapped file" 2)
+        if [[ -z "$RAW_FOOTPRINT" ]]; then
+            ROW4_STATUS="unmeasured: could not find 'Physical footprint:' in vmmap output (server $k)"
+            break
+        fi
+        ROW4_FP_VALS+=("$(vmmap_size_to_mb "$RAW_FOOTPRINT")")
+        [[ -n "$RAW_MALLOC_DIRTY" ]] && ROW4_MD_VALS+=("$(vmmap_size_to_mb "$RAW_MALLOC_DIRTY")")
+        [[ -n "$RAW_MAPPED_FILE" ]] && ROW4_MF_VALS+=("$(vmmap_size_to_mb "$RAW_MAPPED_FILE")")
+        HEAP_BYTES=$(cat "$WORK_DIR/heap.$k.txt" 2>/dev/null || true)
+        [[ "$HEAP_BYTES" =~ ^[0-9]+$ ]] && ROW4_HEAP_VALS+=("$(bytes_to_mb "$HEAP_BYTES")")
+        log "server $k/3: footprint=${ROW4_FP_VALS[$((k - 1))]}MB heap_live=${HEAP_BYTES:-?}B"
+    else
+        ROW4_STATUS="unmeasured: vmmap produced no output for server $k (process may have exited before t=6s)"
+        break
+    fi
+done
+if [[ "$ROW4_STATUS" == "ok" ]]; then
+    ROW4_FOOTPRINT="$(median_of "${ROW4_FP_VALS[@]}")"
+    ROW4_RANGE="$(printf '%s\n' "${ROW4_FP_VALS[@]}" | sort -n | head -1)-$(printf '%s\n' "${ROW4_FP_VALS[@]}" | sort -n | tail -1)"
+    [[ ${#ROW4_MD_VALS[@]} -gt 0 ]] && ROW4_MALLOC_DIRTY="$(median_of "${ROW4_MD_VALS[@]}") MB"
+    [[ ${#ROW4_MF_VALS[@]} -gt 0 ]] && ROW4_MAPPED_FILE="$(median_of "${ROW4_MF_VALS[@]}") MB"
+    [[ ${#ROW4_HEAP_VALS[@]} -gt 0 ]] && ROW4_HEAP="$(median_of "${ROW4_HEAP_VALS[@]}") MB"
+fi
+
+# ---------------------------------------------------------------------------
+# Row 5: drift +1 — one chunk_embeddings row the on-disk HNSW cache doesn't
+# know about, on a fresh snapshot. The startup line is checked so the row
+# says whether the engine took the additive-reconciliation path ("cached")
+# or fell back to a full rebuild.
+# ---------------------------------------------------------------------------
+log "=== Row 5: drift +1 (bare initialize against a db with one un-cached chunk) ==="
+ROW5_STATUS="ok"
+ROW5_RSS_MB="n/a"
+ROW5_WALL_S="n/a"
+ROW5_FP_MB="n/a"
+ROW5_DELTA_MB="n/a"
+ROW5_PATH="unknown"
+DRIFT_ID="csr-profile-drift-synthetic-$(date +%s)"
+DRIFT_DB="$(snapshot_db "$WORK_DIR/drift")"
+
+if [[ -n "$DRIFT_DB" ]]; then
+    # Schema-inspect chunk_embeddings first rather than assuming shape:
+    # chunk_id TEXT PK REFERENCES chunks(id), embedding BLOB (little-endian
+    # f32, one row per chunk — 384 dims == 1536 bytes, matching
+    # EmbeddingEngine::dimension()).
+    EMBED_SCHEMA=$("$SQLITE3" "$DRIFT_DB" ".schema chunk_embeddings" 2>/dev/null || true)
+    log "chunk_embeddings schema: $EMBED_SCHEMA"
+    BEFORE_COUNT=$("$SQLITE3" "$DRIFT_DB" "SELECT COUNT(*) FROM chunk_embeddings;" 2>/dev/null || echo "")
+
+    if [[ -n "$EMBED_SCHEMA" && -n "$BEFORE_COUNT" ]]; then
+        INSERT_ERR="$WORK_DIR/drift_insert_err.log"
+        # The chunks insert fires the chunks_fts FTS5 trigger, so it has to go
+        # through an FTS5-capable client ($SQLITE3), not python's sqlite3
+        # module. python only renders the 384-dim f32 blob as a hex literal.
+        DRIFT_HEX=$(python3 -c 'import struct, random; random.seed(42); print(struct.pack("<384f", *[random.uniform(-0.1, 0.1) for _ in range(384)]).hex())')
+        if "$SQLITE3" "$DRIFT_DB" "PRAGMA foreign_keys=ON;
+INSERT INTO chunks (id, conversation_id, project_name, timestamp, content, message_count, source)
+VALUES ('$DRIFT_ID', 'csr-profile-drift-conv', 'csr-profile-drift-project', '2026-09-08T00:00:00Z', 'synthetic drift probe row (profile-memory.sh)', 1, 'conversation');
+INSERT INTO chunk_embeddings (chunk_id, embedding) VALUES ('$DRIFT_ID', X'$DRIFT_HEX');" >"$WORK_DIR/drift_insert_out.log" 2>"$INSERT_ERR"
+        then
+            AFTER_COUNT=$("$SQLITE3" "$DRIFT_DB" "SELECT COUNT(*) FROM chunk_embeddings;" 2>/dev/null || echo "")
+            FK_VIOLATIONS=$("$SQLITE3" "$DRIFT_DB" "PRAGMA foreign_key_check;" 2>/dev/null || echo "")
+            if [[ "$AFTER_COUNT" == "$((BEFORE_COUNT + 1))" && -z "$FK_VIOLATIONS" ]]; then
+                log "drift row loaded cleanly: chunk_embeddings $BEFORE_COUNT -> $AFTER_COUNT"
+                # RUST_LOG=info exposes the engine's reconciliation receipt
+                # ("backfilled missing chunks into HNSW cache added=N"); the
+                # startup line alone is printed before reconciliation runs.
+                TRIAL_RUST_LOG="info"
+                DRIFT_OUT="$(run_timed_once "$INIT_INPUT" "$INIT_EXPECT" "$DRIFT_DB")"
+                TRIAL_RUST_LOG=""
+                if [[ "$(echo "$DRIFT_OUT" | awk '{print $4}')" == "ok" ]]; then
+                    read -r ROW5_RSS_MB ROW5_WALL_S ROW5_FP_MB _ <<<"$DRIFT_OUT"
+                    ROW5_RSS_MB=$(bytes_to_mb "$ROW5_RSS_MB")
+                    ROW5_FP_MB=$(bytes_to_mb "$ROW5_FP_MB")
+                    # tracing colors its output; strip the ANSI codes before parsing.
+                    BACKFILLED=$(sed $'s/\x1b\\[[0-9;]*m//g' "$LAST_STDERR" | grep 'backfilled missing chunks into HNSW cache' | sed -n 's/.*added=\([0-9]*\).*/\1/p' | head -1)
+                    if grep -q 'CSR startup:.*rebuilt)' "$LAST_STDERR"; then
+                        ROW5_PATH="full rebuild"
+                    elif grep -q 'CSR startup:.*cached)' "$LAST_STDERR" && [[ -n "$BACKFILLED" ]]; then
+                        ROW5_PATH="cached, backfilled added=$BACKFILLED"
+                    elif grep -q 'CSR startup:.*cached)' "$LAST_STDERR"; then
+                        ROW5_PATH="cached, backfill receipt missing"
+                    fi
+                    if [[ "$ROW1_RSS_MB" != "unmeasured" ]]; then
+                        ROW5_DELTA_MB=$(awk -v a="$ROW5_RSS_MB" -v b="$ROW1_RSS_MB" 'BEGIN{printf "%+.1f", a-b}')
+                    fi
+                else
+                    ROW5_STATUS="unmeasured: the drift initialize trial failed (see stderr)"
+                fi
+            else
+                ROW5_STATUS="unmeasured: post-insert verification failed (count $BEFORE_COUNT -> $AFTER_COUNT, fk_violations='$FK_VIOLATIONS')"
+            fi
+        else
+            ROW5_STATUS="unmeasured: chunk_embeddings insert failed: $(tr '\n' ' ' <"$INSERT_ERR")"
+        fi
+    else
+        ROW5_STATUS="unmeasured: could not read chunk_embeddings schema/count from db copy"
+    fi
+else
+    ROW5_STATUS="unmeasured: snapshot of the db failed (see stderr)"
+fi
+
+# ---------------------------------------------------------------------------
+# Live data dir must be untouched
+# ---------------------------------------------------------------------------
+LIVE_PROBE_LINES_AFTER="$(live_probe_lines)"
+LIVE_STAMP_AFTER="$(live_stamp)"
+LIVE_DIR_NOTE="untouched (no harness-tagged hook lines added to hook-timing.log, mcp-binary.txt unchanged)"
+if [[ "$LIVE_PROBE_LINES_BEFORE" != "$LIVE_PROBE_LINES_AFTER" || "$LIVE_STAMP_BEFORE" != "$LIVE_STAMP_AFTER" ]]; then
+    LIVE_DIR_NOTE="WRITTEN DURING THE RUN — isolation failed (harness-tagged hook lines $LIVE_PROBE_LINES_BEFORE -> $LIVE_PROBE_LINES_AFTER, mcp-binary.txt changed: $([[ "$LIVE_STAMP_BEFORE" != "$LIVE_STAMP_AFTER" ]] && echo yes || echo no))"
+    log "$LIVE_DIR_NOTE"
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+echo "# csr-engine memory profile — label: $LABEL"
+echo
+echo "- Binary: \`$BINARY\`"
+echo "- Size: ${BIN_SIZE_MB} MB (${BIN_SIZE_BYTES} bytes)"
+echo "- SHA256: \`$BIN_SHA256\`"
+echo "- DB: \`$DB_PATH\`"
+echo "- Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "- Isolation: child HOME = scratch dir (model cache copied in, probe caches copied in); rows 1-4 on one fresh db+index snapshot, row 5 on another; every trial confirmed the cached startup path"
+echo "- Live data dir ($LIVE_DATA_DIR): $LIVE_DIR_NOTE"
+echo
+echo "| # | Scenario | Peak RSS (MB) | Peak footprint (MB) | Wall (s) | Notes |"
+echo "|---|----------|--------------:|--------------------:|---------:|-------|"
+printf '| 1 | bare MCP initialize (median of 3) | %s | %s | %s | - |\n' "$ROW1_RSS_MB" "$ROW1_FP_MB" "$ROW1_WALL_S"
+printf '| 2 | hook post-tool-use Edit, installed matcher (median of 3) | %s | %s | %s | %s |\n' "$ROW2_RSS_MB" "$ROW2_FP_MB" "$ROW2_WALL_S" "$ROW2_NOTE"
+printf '| 3 | hook prompt-submit, real prompt (median of 3) | %s | %s | %s | %s |\n' "$ROW3_RSS_MB" "$ROW3_FP_MB" "$ROW3_WALL_S" "$ROW3_NOTE"
+if [[ "$ROW4_STATUS" == "ok" ]]; then
+    printf '| 4 | steady-state private footprint, 6s after initialize (median of 3 servers) | n/a | %s | n/a | spread %s MB; live heap=%s; vmmap MALLOC_SMALL dirty=%s; mapped file resident=%s |\n' \
+        "$ROW4_FOOTPRINT" "$ROW4_RANGE" "$ROW4_HEAP" "$ROW4_MALLOC_DIRTY" "$ROW4_MAPPED_FILE"
+else
+    printf '| 4 | steady-state private footprint, 6s after initialize (median of 3 servers) | n/a | unmeasured | n/a | %s |\n' "$ROW4_STATUS"
+fi
+if [[ "$ROW5_STATUS" == "ok" ]]; then
+    printf '| 5 | drift +1 bare initialize | %s | %s | %s | RSS delta vs row 1 = %s MB; startup path = %s |\n' "$ROW5_RSS_MB" "$ROW5_FP_MB" "$ROW5_WALL_S" "$ROW5_DELTA_MB" "$ROW5_PATH"
+else
+    printf '| 5 | drift +1 bare initialize | unmeasured | n/a | n/a | %s |\n' "$ROW5_STATUS"
+fi

--- a/csr-engine/src/daemon/mod.rs
+++ b/csr-engine/src/daemon/mod.rs
@@ -946,15 +946,49 @@ async fn run_consolidation(
     Ok(())
 }
 
+/// Resolve the MCP-server enrichment loops' initial delay:
+/// `CSR_ENRICH_INITIAL_DELAY_SECS` if it parses as a non-negative `u64`,
+/// else the default 120s. Junk/unset falls back to the default rather than
+/// erroring — this is read once at server startup and must never fail.
+/// A value of `0` is honored (explicit opt-out of the delay).
+fn resolve_enrich_initial_delay() -> std::time::Duration {
+    const DEFAULT_SECS: u64 = 120;
+    let secs = std::env::var("CSR_ENRICH_INITIAL_DELAY_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+/// Hold an MCP-side enrichment loop back for `delay` before its first tick.
+/// Every loop `spawn_enrichment_loops` starts goes through this — extraction,
+/// narration and consolidation all embed (consolidation runs before its
+/// first sleep), so gating only one of them would still load the model at
+/// t=0 whenever the others have queued work.
+async fn delayed<F: std::future::Future<Output = ()>>(delay: std::time::Duration, fut: F) {
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
+    fut.await;
+}
+
 /// Spawn enrichment loops as background tokio tasks (for embedding in MCP server).
 /// Returns join handles that can be aborted on shutdown. Does NOT acquire the daemon lockfile
 /// (so the standalone `csr-engine daemon` can still run alongside if needed).
+///
+/// All three loops wait `CSR_ENRICH_INITIAL_DELAY_SECS` (default 120s)
+/// before their first tick: this function only runs inside `csr-engine serve`
+/// (src/engine.rs `serve_mcp`), where an MCP session that never calls a tool
+/// would otherwise start embedding at t=0 with no user request behind it.
+/// The standalone `csr-engine daemon` (`Daemon::run` above) spawns its loops
+/// directly and keeps its immediate-start behavior.
 pub fn spawn_enrichment_loops(
     storage: Arc<Storage>,
     embeddings: Arc<EmbeddingEngine>,
     search: Arc<RwLock<SearchEngine>>,
 ) -> Vec<tokio::task::JoinHandle<()>> {
     let shutdown = Arc::new(AtomicBool::new(false));
+    let initial_delay = resolve_enrich_initial_delay();
 
     // Layer 2: V3 extraction (free, runs every 60s — less aggressive than standalone daemon)
     let ext_handle = {
@@ -962,9 +996,7 @@ pub fn spawn_enrichment_loops(
         let e = embeddings.clone();
         let idx = search.clone();
         let sd = shutdown.clone();
-        tokio::spawn(async move {
-            extraction_loop(s, e, idx, 60, sd).await;
-        })
+        tokio::spawn(delayed(initial_delay, extraction_loop(s, e, idx, 60, sd)))
     };
 
     // Layer 3: AI narrative (only if API key set)
@@ -974,9 +1006,10 @@ pub fn spawn_enrichment_loops(
         let e = embeddings.clone();
         let idx = search.clone();
         let sd = shutdown.clone();
-        Some(tokio::spawn(async move {
-            narrator_loop(s, e, idx, client, 10, 1800, 60, sd).await;
-        }))
+        Some(tokio::spawn(delayed(
+            initial_delay,
+            narrator_loop(s, e, idx, client, 10, 1800, 60, sd),
+        )))
     } else {
         None
     };
@@ -987,9 +1020,7 @@ pub fn spawn_enrichment_loops(
         let e = embeddings.clone();
         let idx = search.clone();
         let sd = shutdown;
-        tokio::spawn(async move {
-            consolidation_loop(s, e, idx, sd).await;
-        })
+        tokio::spawn(delayed(initial_delay, consolidation_loop(s, e, idx, sd)))
     };
 
     let mut handles = vec![ext_handle, consol_handle];
@@ -1066,5 +1097,94 @@ mod tests {
         assert_eq!(*sampled[49], 49);
         assert_eq!(*sampled[50], 150); // first of the tail
         assert_eq!(*sampled[99], 199);
+    }
+
+    #[test]
+    fn enrich_initial_delay_env() {
+        // Unique to this module — no shared mutex needed, same rationale as
+        // memory_registry_kill_switch_env above.
+        std::env::remove_var("CSR_ENRICH_INITIAL_DELAY_SECS");
+        assert_eq!(
+            resolve_enrich_initial_delay(),
+            std::time::Duration::from_secs(120)
+        );
+        std::env::set_var("CSR_ENRICH_INITIAL_DELAY_SECS", "5");
+        assert_eq!(
+            resolve_enrich_initial_delay(),
+            std::time::Duration::from_secs(5)
+        );
+        // 0 is a valid, explicit opt-out — must be honored, not treated as unset.
+        std::env::set_var("CSR_ENRICH_INITIAL_DELAY_SECS", "0");
+        assert_eq!(resolve_enrich_initial_delay(), std::time::Duration::ZERO);
+        std::env::set_var("CSR_ENRICH_INITIAL_DELAY_SECS", "not-a-number");
+        assert_eq!(
+            resolve_enrich_initial_delay(),
+            std::time::Duration::from_secs(120)
+        );
+        std::env::remove_var("CSR_ENRICH_INITIAL_DELAY_SECS");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_holds_the_loop_body_until_the_delay_elapses() {
+        use std::sync::Mutex;
+        let start = tokio::time::Instant::now();
+        let ran_at: Arc<Mutex<Option<tokio::time::Instant>>> = Arc::new(Mutex::new(None));
+        let slot = ran_at.clone();
+        let handle = tokio::spawn(delayed(std::time::Duration::from_secs(120), async move {
+            *slot.lock().unwrap() = Some(tokio::time::Instant::now());
+        }));
+        // Let the spawned wrapper poll once so its sleep timer is registered
+        // before the clock moves; otherwise advance() has nothing to fire.
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(119)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            ran_at.lock().unwrap().is_none(),
+            "body ran before the delay elapsed"
+        );
+        tokio::time::advance(std::time::Duration::from_secs(2)).await;
+        tokio::task::yield_now().await;
+        let at = ran_at
+            .lock()
+            .unwrap()
+            .expect("body never ran after the delay");
+        let elapsed = at.duration_since(start);
+        assert!(
+            elapsed >= std::time::Duration::from_secs(120)
+                && elapsed <= std::time::Duration::from_secs(121),
+            "body ran at {elapsed:?}, expected ~120s"
+        );
+        handle.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_aborted_before_the_deadline_never_runs_the_body() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = ran.clone();
+        let handle = tokio::spawn(delayed(std::time::Duration::from_secs(120), async move {
+            flag.store(true, Ordering::SeqCst);
+        }));
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_secs(60)).await;
+        // serve_mcp aborts the enrichment handles on shutdown; an abort
+        // during the delay must drop the pending loop, not run it later.
+        handle.abort();
+        assert!(handle.await.unwrap_err().is_cancelled());
+        tokio::time::advance(std::time::Duration::from_secs(120)).await;
+        tokio::task::yield_now().await;
+        assert!(!ran.load(Ordering::SeqCst), "aborted body still ran");
+    }
+
+    #[tokio::test]
+    async fn delayed_with_zero_delay_runs_immediately() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = ran.clone();
+        delayed(std::time::Duration::ZERO, async move {
+            flag.store(true, Ordering::SeqCst);
+        })
+        .await;
+        assert!(ran.load(Ordering::SeqCst));
     }
 }

--- a/csr-engine/src/embeddings/mod.rs
+++ b/csr-engine/src/embeddings/mod.rs
@@ -6,9 +6,18 @@ use anyhow::Result;
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 
 /// Wraps fastembed for 384-dim all-MiniLM-L6-v2 embeddings.
-/// Thread-safe via Mutex (TextEmbedding::embed requires &mut self).
+///
+/// The ONNX model (fp32 AllMiniLML6V2) is NOT loaded by `new()` — it is
+/// loaded lazily, on first `embed`/`embed_single` call, behind a
+/// `Mutex<Option<TextEmbedding>>` acting as a fallible once-cell (a plain
+/// `OnceLock<TextEmbedding>` cannot hold the `Result` from a failed init).
+/// `new()` is cheap on purpose: it runs unconditionally in every
+/// `Engine::new` (MCP server startup, every hook invocation), and most
+/// hook invocations never call `embed` at all. Callers that DO know they
+/// are about to embed and want the load off the hot path (import/daemon)
+/// should call `warm()` right after construction.
 pub struct EmbeddingEngine {
-    model: Mutex<TextEmbedding>,
+    model: Mutex<Option<TextEmbedding>>,
 }
 
 /// Serializes first-run model downloads within this process. Concurrent
@@ -17,15 +26,70 @@ pub struct EmbeddingEngine {
 /// "Lock acquisition failed" instead of waiting.
 static MODEL_INIT_LOCK: Mutex<()> = Mutex::new(());
 
+/// Resolve the ONNX intra-op thread cap: `CSR_EMBED_THREADS` if it parses
+/// as `1..=runtime::MAX_THREAD_OVERRIDE`, else `min(4, available_parallelism)`.
+/// Junk, zero, or oversized values fall back to the default rather than
+/// erroring — this runs on the lazy-init path of every hook process and must
+/// never fail, and ORT narrows the count to a C int, so an unbounded value
+/// could wrap to zero.
+fn resolve_intra_threads() -> usize {
+    if let Ok(raw) = std::env::var("CSR_EMBED_THREADS") {
+        if let Ok(n) = raw.trim().parse::<usize>() {
+            if (1..=crate::runtime::MAX_THREAD_OVERRIDE).contains(&n) {
+                return n;
+            }
+        }
+    }
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(4))
+        .unwrap_or(4)
+}
+
 impl EmbeddingEngine {
-    /// Initialize the embedding model (downloads ~30MB on first run).
+    /// Construct the engine without loading the ONNX model. Cheap and
+    /// infallible in practice (no I/O beyond what `Mutex::new` does).
     pub fn new() -> Result<Self> {
+        Ok(Self {
+            model: Mutex::new(None),
+        })
+    }
+
+    /// True once the ONNX model has been loaded into memory. Never
+    /// triggers a load itself.
+    pub fn is_loaded(&self) -> bool {
+        matches!(self.model.lock(), Ok(guard) if guard.is_some())
+    }
+
+    /// Force the model to load now instead of on first `embed`. Use where
+    /// first-embed latency or an early failure matters more than startup
+    /// memory (daemon, --import/--enrich, setup, eval) — not the MCP server
+    /// or hooks, which stay lazy so a process that never embeds never pays
+    /// the model load (~130MB resident, ~45ms).
+    pub fn warm(&self) -> Result<()> {
+        self.ensure_loaded()
+    }
+
+    /// Load the model if it isn't already loaded (downloads ~30MB on first
+    /// run). Idempotent: a second call after a successful load is a cheap
+    /// lock-and-check. A failed load leaves the cell empty so the next
+    /// call retries from scratch.
+    fn ensure_loaded(&self) -> Result<()> {
+        let mut guard = self
+            .model
+            .lock()
+            .map_err(|e| anyhow::anyhow!("embedding lock: {e}"))?;
+        if guard.is_some() {
+            return Ok(());
+        }
+
         let cache_dir = cache::cache_dir();
         std::fs::create_dir_all(&cache_dir)?;
 
         let _init_guard = MODEL_INIT_LOCK
             .lock()
             .map_err(|e| anyhow::anyhow!("model init lock: {e}"))?;
+
+        let threads = resolve_intra_threads();
 
         // Retry across processes: another csr-engine may hold the hf-hub blob
         // lock mid-download; once it finishes, the cached model loads instantly.
@@ -36,12 +100,12 @@ impl EmbeddingEngine {
             }
             let options = InitOptions::new(EmbeddingModel::AllMiniLML6V2)
                 .with_cache_dir(cache_dir.clone())
-                .with_show_download_progress(true);
+                .with_show_download_progress(true)
+                .with_intra_threads(threads);
             match TextEmbedding::try_new(options) {
                 Ok(model) => {
-                    return Ok(Self {
-                        model: Mutex::new(model),
-                    })
+                    *guard = Some(model);
+                    return Ok(());
                 }
                 Err(e) => last_err = Some(e),
             }
@@ -53,12 +117,17 @@ impl EmbeddingEngine {
     }
 
     /// Embed a batch of texts. Returns one 384-dim vector per input.
+    /// Loads the model on first call if it hasn't been `warm()`ed already.
     pub fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.ensure_loaded()?;
         let docs: Vec<String> = texts.iter().map(|s| s.to_string()).collect();
-        let mut model = self
+        let mut guard = self
             .model
             .lock()
             .map_err(|e| anyhow::anyhow!("embedding lock: {e}"))?;
+        let model = guard
+            .as_mut()
+            .expect("ensure_loaded returned Ok, so the model is populated");
         let embeddings = model.embed(docs, None)?;
         Ok(embeddings)
     }
@@ -75,5 +144,125 @@ impl EmbeddingEngine {
     /// Returns the embedding dimension (384 for all-MiniLM-L6-v2).
     pub fn dimension() -> usize {
         384
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `new()` must not touch the ONNX model — this is the whole point of
+    /// lazy init. No env/network access needed to verify this, so it's
+    /// always safe to run.
+    #[test]
+    fn new_does_not_load_the_model() {
+        let engine = EmbeddingEngine::new().expect("new() is infallible in practice");
+        assert!(
+            !engine.is_loaded(),
+            "EmbeddingEngine::new() must not eagerly load the ONNX model"
+        );
+    }
+
+    /// First `embed` loads the model; a second `embed` reuses the already
+    /// loaded model instead of reloading it. Downloads the model on first
+    /// run, so this is gated like the rest of the model-dependent suite.
+    #[test]
+    #[ignore = "downloads the ~30MB ONNX model on first run; run with --ignored"]
+    fn first_embed_loads_then_reuses_the_model() {
+        let engine = EmbeddingEngine::new().unwrap();
+        assert!(!engine.is_loaded());
+
+        let first = engine.embed_single("lazy load probe").unwrap();
+        assert!(engine.is_loaded(), "first embed must load the model");
+        assert_eq!(first.len(), EmbeddingEngine::dimension());
+
+        // Second call must not reload: same loaded model, no panic/reinit.
+        let second = engine.embed_single("second call reuses the model").unwrap();
+        assert!(engine.is_loaded());
+        assert_eq!(second.len(), EmbeddingEngine::dimension());
+    }
+
+    #[test]
+    #[ignore = "downloads the ~30MB ONNX model on first run; run with --ignored"]
+    fn warm_loads_the_model_eagerly() {
+        let engine = EmbeddingEngine::new().unwrap();
+        assert!(!engine.is_loaded());
+        engine.warm().unwrap();
+        assert!(engine.is_loaded(), "warm() must load the model immediately");
+    }
+
+    // Serialize env-var mutation across these tests: `cargo test` runs
+    // tests in the same process on multiple threads, and std::env::var is
+    // process-global.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var("CSR_EMBED_THREADS").ok();
+        match value {
+            Some(v) => std::env::set_var("CSR_EMBED_THREADS", v),
+            None => std::env::remove_var("CSR_EMBED_THREADS"),
+        }
+        f();
+        match previous {
+            Some(v) => std::env::set_var("CSR_EMBED_THREADS", v),
+            None => std::env::remove_var("CSR_EMBED_THREADS"),
+        }
+    }
+
+    #[test]
+    fn thread_count_env_unset_falls_back_to_default() {
+        with_env(None, || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_intra_threads(), expected);
+        });
+    }
+
+    #[test]
+    fn thread_count_env_valid_override_is_used() {
+        with_env(Some("2"), || {
+            assert_eq!(resolve_intra_threads(), 2);
+        });
+    }
+
+    #[test]
+    fn thread_count_env_junk_falls_back_to_default() {
+        with_env(Some("not-a-number"), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_intra_threads(), expected);
+        });
+    }
+
+    #[test]
+    fn thread_count_env_excessive_falls_back_to_default() {
+        with_env(Some("4294967296"), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_intra_threads(), expected);
+        });
+        with_env(
+            Some(&(crate::runtime::MAX_THREAD_OVERRIDE + 1).to_string()),
+            || {
+                let expected = std::thread::available_parallelism()
+                    .map(|n| n.get().min(4))
+                    .unwrap_or(4);
+                assert_eq!(resolve_intra_threads(), expected);
+            },
+        );
+    }
+
+    #[test]
+    fn thread_count_env_zero_falls_back_to_default() {
+        with_env(Some("0"), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_intra_threads(), expected);
+        });
     }
 }

--- a/csr-engine/src/engine.rs
+++ b/csr-engine/src/engine.rs
@@ -97,21 +97,17 @@ impl Engine {
                     tracing::info!(blanked, "blanked orphan reflection entries in HNSW cache");
                 }
 
-                // Backfill reflections that exist in DB but not in HNSW
-                let missing: Vec<&str> = db_id_set
+                // Backfill reflections that exist in DB but not in HNSW.
+                // Fetch only the missing ids, in bounded batches — never the
+                // whole reflection table.
+                let missing: Vec<String> = db_id_set
                     .iter()
                     .filter(|id| !search.has_reflection(id))
-                    .copied()
+                    .map(|s| s.to_string())
                     .collect();
                 if !missing.is_empty() {
-                    if let Ok(all_vecs) = storage.load_all_reflection_vectors() {
-                        let mut added = 0;
-                        for (id, vec) in &all_vecs {
-                            if missing.contains(&id.as_str()) {
-                                search.insert_reflection(id.clone(), vec.clone());
-                                added += 1;
-                            }
-                        }
+                    if let Ok(added) = backfill_missing_reflections(&storage, &mut search, &missing)
+                    {
                         if added > 0 {
                             tracing::info!(added, "backfilled missing reflections into HNSW cache");
                         }
@@ -120,24 +116,18 @@ impl Engine {
             }
 
             // Backfill chunks added to DB since the last dump (additive drift).
-            // Cheap ID probe first; only load the (large) vector set if something is
-            // actually missing. This is what lets a stale-but-additive cache load in
-            // ~ms instead of triggering a full HNSW rebuild (~tens of seconds).
+            // Cheap ID probe first; only fetch the vectors that are actually
+            // missing (in bounded batches) if something is missing. This is what
+            // lets a stale-but-additive cache load in ~ms instead of triggering a
+            // full HNSW rebuild (~tens of seconds), while keeping peak transient
+            // memory O(batch) rather than O(corpus).
             if let Ok(db_chunk_ids) = storage.load_all_chunk_ids() {
-                let missing: std::collections::HashSet<&str> = db_chunk_ids
-                    .iter()
+                let missing: Vec<String> = db_chunk_ids
+                    .into_iter()
                     .filter(|id| !search.has_chunk(id))
-                    .map(|s| s.as_str())
                     .collect();
                 if !missing.is_empty() {
-                    if let Ok(all_vecs) = storage.load_all_chunk_vectors() {
-                        let mut added = 0;
-                        for (id, vec) in &all_vecs {
-                            if missing.contains(id.as_str()) {
-                                search.insert_chunk(id.clone(), vec.clone());
-                                added += 1;
-                            }
-                        }
+                    if let Ok(added) = backfill_missing_chunks(&storage, &mut search, &missing) {
                         if added > 0 {
                             tracing::info!(added, "backfilled missing chunks into HNSW cache");
                         }
@@ -146,21 +136,13 @@ impl Engine {
             }
             search
         } else {
-            // Cache miss — rebuild from SQLite vectors
+            // Cache miss — rebuild from SQLite vectors, streaming in bounded
+            // batches so peak transient memory is O(batch) instead of
+            // O(corpus) (no `load_all_chunk_vectors()` + clone-into-index).
             tracing::info!("building search index from stored vectors");
 
-            let chunk_vecs = storage.load_all_chunk_vectors()?;
-            let t_load = t0.elapsed();
-
-            let estimated_size = (chunk_vecs.len() + 1000).max(10_000);
-            let mut search = SearchEngine::new(estimated_size);
-            for (id, vec) in &chunk_vecs {
-                search.insert_chunk(id.clone(), vec.clone());
-            }
-            let reflection_vecs = storage.load_all_reflection_vectors()?;
-            for (id, vec) in &reflection_vecs {
-                search.insert_reflection(id.clone(), vec.clone());
-            }
+            let (mut search, chunk_total, reflection_total) =
+                rebuild_search_index_streaming(&storage, RECONCILE_BATCH)?;
             let t_hnsw = t0.elapsed();
 
             // Re-query counts right before dump to minimize staleness window (E-1)
@@ -175,19 +157,18 @@ impl Engine {
             let t_total = t0.elapsed();
 
             tracing::info!(
-                chunks = chunk_vecs.len(),
-                reflections = reflection_vecs.len(),
+                chunks = chunk_total,
+                reflections = reflection_total,
                 "search index rebuilt and cached"
             );
             let startup_line = format!(
-                "CSR startup: storage={:.0}ms embed={:.0}ms vectors={:.0}ms hnsw={:.0}ms dump={:.0}ms total={:.0}ms ({} chunks, rebuilt)",
+                "CSR startup: storage={:.0}ms embed={:.0}ms hnsw={:.0}ms dump={:.0}ms total={:.0}ms ({} chunks, rebuilt)",
                 t_storage.as_secs_f64() * 1000.0,
                 (t_embed - t_storage).as_secs_f64() * 1000.0,
-                (t_load - t_count).as_secs_f64() * 1000.0,
-                (t_hnsw - t_load).as_secs_f64() * 1000.0,
+                (t_hnsw - t_count).as_secs_f64() * 1000.0,
                 (t_total - t_hnsw).as_secs_f64() * 1000.0,
                 t_total.as_secs_f64() * 1000.0,
-                chunk_vecs.len(),
+                chunk_total,
             );
             eprintln!("{}", startup_line);
             log_timing(&startup_line);
@@ -509,5 +490,220 @@ impl Engine {
         }
 
         Ok(())
+    }
+}
+
+/// Batch size for reconciling the HNSW cache against SQLite: both the
+/// additive-drift backfill (missing ids only) and the cache-miss full
+/// rebuild fetch vectors this many ids at a time, so peak transient memory
+/// is O(batch) instead of O(corpus). See src/engine.rs:126-165 history.
+const RECONCILE_BATCH: usize = 2_000;
+
+/// Fetch and insert only the given missing chunk ids, in bounded batches.
+/// Never materializes more than `batch_size` vectors at once. Returns the
+/// number of points actually inserted.
+fn backfill_missing_chunks_batched(
+    storage: &Storage,
+    search: &mut SearchEngine,
+    missing_ids: &[String],
+    batch_size: usize,
+) -> Result<usize> {
+    let mut added = 0;
+    for batch in missing_ids.chunks(batch_size.max(1)) {
+        let vecs = storage.get_chunk_vectors_by_ids(batch)?;
+        added += vecs.len();
+        for (id, vec) in vecs {
+            search.insert_chunk(id, vec);
+        }
+    }
+    Ok(added)
+}
+
+fn backfill_missing_chunks(
+    storage: &Storage,
+    search: &mut SearchEngine,
+    missing_ids: &[String],
+) -> Result<usize> {
+    backfill_missing_chunks_batched(storage, search, missing_ids, RECONCILE_BATCH)
+}
+
+/// Reflection counterpart of [`backfill_missing_chunks_batched`].
+fn backfill_missing_reflections_batched(
+    storage: &Storage,
+    search: &mut SearchEngine,
+    missing_ids: &[String],
+    batch_size: usize,
+) -> Result<usize> {
+    let mut added = 0;
+    for batch in missing_ids.chunks(batch_size.max(1)) {
+        let vecs = storage.get_reflection_vectors_by_ids(batch)?;
+        added += vecs.len();
+        for (id, vec) in vecs {
+            search.insert_reflection(id, vec);
+        }
+    }
+    Ok(added)
+}
+
+fn backfill_missing_reflections(
+    storage: &Storage,
+    search: &mut SearchEngine,
+    missing_ids: &[String],
+) -> Result<usize> {
+    backfill_missing_reflections_batched(storage, search, missing_ids, RECONCILE_BATCH)
+}
+
+/// Rebuild the HNSW index from SQLite, streaming vectors in bounded batches
+/// instead of materializing `load_all_chunk_vectors()` (the whole corpus) as
+/// one `Vec<(String, Vec<f32>)>` before inserting. Cheap id probes
+/// (`load_all_chunk_ids` / `load_all_reflection_ids`) drive the batching;
+/// each batch's vectors are moved (not cloned) into the index and dropped
+/// before the next batch is fetched. Returns the built index plus the
+/// (chunks, reflections) counts actually inserted.
+fn rebuild_search_index_streaming(
+    storage: &Storage,
+    batch_size: usize,
+) -> Result<(SearchEngine, usize, usize)> {
+    let chunk_ids = storage.load_all_chunk_ids()?;
+    let reflection_ids = storage.load_all_reflection_ids()?;
+
+    let estimated_size = (chunk_ids.len() + 1000).max(10_000);
+    let mut search = SearchEngine::new(estimated_size);
+
+    let mut chunk_total = 0usize;
+    for batch in chunk_ids.chunks(batch_size.max(1)) {
+        let vecs = storage.get_chunk_vectors_by_ids(batch)?;
+        chunk_total += vecs.len();
+        for (id, vec) in vecs {
+            search.insert_chunk(id, vec);
+        }
+    }
+
+    let mut reflection_total = 0usize;
+    for batch in reflection_ids.chunks(batch_size.max(1)) {
+        let vecs = storage.get_reflection_vectors_by_ids(batch)?;
+        reflection_total += vecs.len();
+        for (id, vec) in vecs {
+            search.insert_reflection(id, vec);
+        }
+    }
+
+    Ok((search, chunk_total, reflection_total))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::import::ConversationChunk;
+    use crate::provenance::Speaker;
+
+    fn insert_test_chunk(storage: &Storage, id: &str) {
+        storage
+            .insert_chunk(
+                &ConversationChunk {
+                    id: id.into(),
+                    conversation_id: "conv".into(),
+                    project_name: "proj".into(),
+                    timestamp: "2026-09-08T00:00:00Z".into(),
+                    content: "x".into(),
+                    message_count: 1,
+                    summary: None,
+                    author: Speaker::User,
+                    seq: 0,
+                    is_sidechain: false,
+                },
+                &[0.1_f32; 384],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn backfill_missing_chunks_inserts_exactly_the_missing_ids_in_batches() {
+        let storage = Storage::open_memory().unwrap();
+        for i in 0..10 {
+            insert_test_chunk(&storage, &format!("chunk-{i}"));
+        }
+        let mut search = SearchEngine::new(100);
+        // Pre-seed half of them as already-present — these must be skipped,
+        // not re-fetched (proves we fetch only the missing ids, not the corpus).
+        for i in 0..5 {
+            search.insert_chunk(format!("chunk-{i}"), vec![0.1_f32; 384]);
+        }
+
+        let db_ids = storage.load_all_chunk_ids().unwrap();
+        let missing: Vec<String> = db_ids
+            .into_iter()
+            .filter(|id| !search.has_chunk(id))
+            .collect();
+        assert_eq!(missing.len(), 5, "sanity: half should be missing");
+
+        // batch_size=2 over 5 missing ids forces 3 separate batched lookups
+        // (2, 2, 1) — exercises the bounded-batch path, not a single big fetch.
+        let added = backfill_missing_chunks_batched(&storage, &mut search, &missing, 2).unwrap();
+
+        assert_eq!(
+            added, 5,
+            "must insert exactly the missing ids, not the whole corpus"
+        );
+        for i in 5..10 {
+            assert!(search.has_chunk(&format!("chunk-{i}")));
+        }
+    }
+
+    #[test]
+    fn backfill_missing_reflections_inserts_exactly_the_missing_ids_in_batches() {
+        let storage = Storage::open_memory().unwrap();
+        for i in 0..7 {
+            storage
+                .insert_reflection(&format!("refl-{i}"), "content", &[], &[0.2_f32; 384])
+                .unwrap();
+        }
+        let mut search = SearchEngine::new(100);
+        for i in 0..3 {
+            search.insert_reflection(format!("refl-{i}"), vec![0.2_f32; 384]);
+        }
+
+        let db_ids = storage.load_all_reflection_ids().unwrap();
+        let missing: Vec<String> = db_ids
+            .into_iter()
+            .filter(|id| !search.has_reflection(id))
+            .collect();
+        assert_eq!(missing.len(), 4, "sanity: 4 should be missing");
+
+        let added =
+            backfill_missing_reflections_batched(&storage, &mut search, &missing, 3).unwrap();
+
+        assert_eq!(added, 4);
+        for i in 3..7 {
+            assert!(search.has_reflection(&format!("refl-{i}")));
+        }
+    }
+
+    #[test]
+    fn rebuild_search_index_streaming_inserts_all_corpus_points_via_batches() {
+        let storage = Storage::open_memory().unwrap();
+        for i in 0..7 {
+            insert_test_chunk(&storage, &format!("chunk-{i}"));
+        }
+        for i in 0..3 {
+            storage
+                .insert_reflection(&format!("refl-{i}"), "content", &[], &[0.2_f32; 384])
+                .unwrap();
+        }
+
+        // batch_size=2 forces multiple batches for both chunks (7) and
+        // reflections (3) — proves the rebuild path never needs a single
+        // corpus-sized fetch to produce a correct index.
+        let (search, chunk_total, reflection_total) =
+            rebuild_search_index_streaming(&storage, 2).unwrap();
+
+        assert_eq!(chunk_total, 7);
+        assert_eq!(reflection_total, 3);
+        for i in 0..7 {
+            assert!(search.has_chunk(&format!("chunk-{i}")));
+        }
+        for i in 0..3 {
+            assert!(search.has_reflection(&format!("refl-{i}")));
+        }
     }
 }

--- a/csr-engine/src/hooks/post_tool_use.rs
+++ b/csr-engine/src/hooks/post_tool_use.rs
@@ -13,6 +13,14 @@ use anyhow::Result;
 use super::HookInput;
 use crate::engine::Engine;
 
+/// Tool names whose edits this hook tracks (code evolution + code graph).
+/// The transcript sync above the gate runs for every fire regardless; the
+/// installer's PostToolUse matcher (`Edit|Write|MultiEdit|NotebookEdit`,
+/// see `hooks::install`) is deliberately a superset of this list.
+pub fn is_acted_on_tool(tool_name: Option<&str>) -> bool {
+    matches!(tool_name, Some("Edit") | Some("Write") | Some("MultiEdit"))
+}
+
 /// Handle the post-tool-use hook.
 /// Always returns Ok(()) to never block Claude Code (C-2 fix).
 pub async fn handle(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<()> {
@@ -20,16 +28,14 @@ pub async fn handle(input: &HookInput, engine: &Engine, cwd: &Path) -> Result<()
     super::import_current_transcript(input, engine, cwd).await;
 
     // Track code evolution for Edit/Write/MultiEdit operations (v9)
-    if let Some(ref tool_name) = input.tool_name {
-        if tool_name == "Edit" || tool_name == "Write" || tool_name == "MultiEdit" {
-            if let Err(e) = track_code_evolution(input, engine).await {
-                eprintln!("CSR: code evolution tracking error (non-fatal): {}", e);
-            }
-            // v9.4 liveness path: re-extract the touched file into the code graph
-            // so callers/callees/ledger reflect the edit immediately.
-            if let Err(e) = update_code_graph(input, engine) {
-                eprintln!("CSR: code graph update error (non-fatal): {}", e);
-            }
+    if is_acted_on_tool(input.tool_name.as_deref()) {
+        if let Err(e) = track_code_evolution(input, engine).await {
+            eprintln!("CSR: code evolution tracking error (non-fatal): {}", e);
+        }
+        // v9.4 liveness path: re-extract the touched file into the code graph
+        // so callers/callees/ledger reflect the edit immediately.
+        if let Err(e) = update_code_graph(input, engine) {
+            eprintln!("CSR: code graph update error (non-fatal): {}", e);
         }
     }
 
@@ -331,6 +337,21 @@ fn resolve_project_for_hook_with(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_acted_on_tool_true_for_edit_write_multiedit() {
+        assert!(is_acted_on_tool(Some("Edit")));
+        assert!(is_acted_on_tool(Some("Write")));
+        assert!(is_acted_on_tool(Some("MultiEdit")));
+    }
+
+    #[test]
+    fn is_acted_on_tool_false_for_everything_else() {
+        assert!(!is_acted_on_tool(Some("Read")));
+        assert!(!is_acted_on_tool(Some("Bash")));
+        assert!(!is_acted_on_tool(Some("Grep")));
+        assert!(!is_acted_on_tool(None));
+    }
 
     #[test]
     fn resolve_project_for_hook_from_file_parent() {

--- a/csr-engine/src/lib.rs
+++ b/csr-engine/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ledger;
 pub mod mcp;
 pub mod narrative;
 pub mod provenance;
+pub mod runtime;
 pub mod search;
 pub mod setup;
 pub mod status;

--- a/csr-engine/src/main.rs
+++ b/csr-engine/src/main.rs
@@ -205,8 +205,16 @@ fn default_projects_dir() -> PathBuf {
         .join("projects")
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    let workers = csr_engine::runtime::resolve_tokio_workers();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .build()?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
@@ -250,6 +258,11 @@ async fn main() -> Result<()> {
             std::fs::create_dir_all(parent)?;
         }
         let eng = engine::Engine::new(&args.db_path, &args.projects_dir)?;
+        // The daemon embeds on its very first extraction tick (no initial
+        // sleep) — warm the model now, synchronously, instead of paying
+        // the load on that first tick with no log line to explain the
+        // stall.
+        eng.embeddings().warm()?;
         let config = csr_engine::daemon::DaemonConfig {
             extraction_interval_secs: 30,
             batch_size_trigger: batch_size,
@@ -305,6 +318,14 @@ async fn main() -> Result<()> {
             std::fs::create_dir_all(parent)?;
         }
         let eng = engine::Engine::new(&args.db_path, &args.projects_dir)?;
+        // quick/full/continuity/provenance embed on their first step and fold
+        // embedding errors into failed report rows, so load the model up front
+        // and let a broken model cache fail the command loudly. The codegraph
+        // modes only read storage; when codegraph is the selected branch
+        // (nothing above it in this if-chain is set) the model stays unloaded.
+        if continuity_live || continuity || provenance || !codegraph {
+            eng.embeddings().warm()?;
+        }
         if continuity_live {
             let out = csr_engine::eval::continuity::run_continuity_live(
                 eng.storage(),
@@ -497,6 +518,13 @@ async fn main() -> Result<()> {
     }
 
     let eng = engine::Engine::new(&args.db_path, &args.projects_dir)?;
+
+    if args.import || args.enrich {
+        // Both paths embed heavily and immediately — warm eagerly instead
+        // of paying the load cost inside the first batch with no log line
+        // to explain it. `--serve`/hooks never hit this branch.
+        eng.embeddings().warm()?;
+    }
 
     if args.import {
         let count = eng.import_conversations(args.limit).await?;

--- a/csr-engine/src/runtime.rs
+++ b/csr-engine/src/runtime.rs
@@ -1,0 +1,104 @@
+//! Tokio runtime sizing. Extracted out of `main.rs` (which is not exercised
+//! by `cargo test --lib`) so the env-parsing logic is unit-testable.
+
+/// Largest worker count an override may request; anything above falls back
+/// to the default like junk input does, so a typo cannot spawn thousands of
+/// OS threads.
+pub const MAX_THREAD_OVERRIDE: usize = 64;
+
+/// Resolve the tokio multi-thread runtime's worker-thread count:
+/// `CSR_TOKIO_WORKERS` if it parses as `1..=MAX_THREAD_OVERRIDE`, else
+/// `min(4, available_parallelism)`. An unbounded `#[tokio::main]` runtime
+/// spins up one worker per core, which is wasted on a process that is
+/// mostly a stdio-driven MCP server or a one-shot hook — cap it the same
+/// way `CSR_EMBED_THREADS` caps ORT.
+pub fn resolve_tokio_workers() -> usize {
+    if let Ok(raw) = std::env::var("CSR_TOKIO_WORKERS") {
+        if let Ok(n) = raw.trim().parse::<usize>() {
+            if (1..=MAX_THREAD_OVERRIDE).contains(&n) {
+                return n;
+            }
+        }
+    }
+    std::thread::available_parallelism()
+        .map(|n| n.get().min(4))
+        .unwrap_or(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var("CSR_TOKIO_WORKERS").ok();
+        match value {
+            Some(v) => std::env::set_var("CSR_TOKIO_WORKERS", v),
+            None => std::env::remove_var("CSR_TOKIO_WORKERS"),
+        }
+        f();
+        match previous {
+            Some(v) => std::env::set_var("CSR_TOKIO_WORKERS", v),
+            None => std::env::remove_var("CSR_TOKIO_WORKERS"),
+        }
+    }
+
+    #[test]
+    fn unset_falls_back_to_default() {
+        with_env(None, || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_tokio_workers(), expected);
+        });
+    }
+
+    #[test]
+    fn valid_override_is_used() {
+        with_env(Some("3"), || {
+            assert_eq!(resolve_tokio_workers(), 3);
+        });
+    }
+
+    #[test]
+    fn junk_falls_back_to_default() {
+        with_env(Some("nope"), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_tokio_workers(), expected);
+        });
+    }
+
+    #[test]
+    fn excessive_falls_back_to_default() {
+        with_env(Some("4294967296"), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_tokio_workers(), expected);
+        });
+        with_env(Some(&(MAX_THREAD_OVERRIDE + 1).to_string()), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_tokio_workers(), expected);
+        });
+        with_env(Some(&MAX_THREAD_OVERRIDE.to_string()), || {
+            assert_eq!(resolve_tokio_workers(), MAX_THREAD_OVERRIDE);
+        });
+    }
+
+    #[test]
+    fn zero_falls_back_to_default() {
+        with_env(Some("0"), || {
+            let expected = std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4);
+            assert_eq!(resolve_tokio_workers(), expected);
+        });
+    }
+}

--- a/csr-engine/src/setup.rs
+++ b/csr-engine/src/setup.rs
@@ -27,12 +27,19 @@ pub async fn handle(
 ) -> Result<()> {
     eprintln!("\n=== Claude Self-Reflect Setup ===\n");
 
-    // Step 1: Ensure DB directory exists
+    // Step 1: Ensure DB directory exists, open the engine, and load the
+    // embedding model. The model loads lazily on first embed everywhere else;
+    // here a first-run download belongs in front of the user (with progress),
+    // and it has to succeed BEFORE the MCP server and hooks are written into
+    // Claude's config, so a failed download never leaves setup half-applied.
     let csr_dir = db_path.parent().unwrap_or(Path::new("."));
     std::fs::create_dir_all(csr_dir)?;
     eprintln!("[1/6] Database directory ready: {}", csr_dir.display());
+    let eng = Engine::new(db_path, projects_dir)?;
+    eng.embeddings().warm()?;
+    eprintln!("  Embedding model ready");
 
-    // Step 2: Register as MCP server (before Engine::new — works without DB)
+    // Step 2: Register as MCP server
     eprintln!("[2/6] Registering MCP server...");
     register_mcp_server()?;
 
@@ -43,9 +50,8 @@ pub async fn handle(
         eprintln!("  You can run `csr-engine hook install --apply` later.");
     }
 
-    // Step 4: Create engine, import conversations
+    // Step 4: Import conversations
     eprintln!("[4/6] Importing conversations...");
-    let eng = Engine::new(db_path, projects_dir)?;
 
     // Count JSONL files for progress
     let total_files = count_total_files(projects_dir);

--- a/csr-engine/src/storage/mod.rs
+++ b/csr-engine/src/storage/mod.rs
@@ -883,6 +883,11 @@ impl Storage {
         queries::get_chunk_vectors_by_ids(&conn, ids)
     }
 
+    pub fn get_reflection_vectors_by_ids(&self, ids: &[String]) -> Result<Vec<(String, Vec<f32>)>> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
+        queries::get_reflection_vectors_by_ids(&conn, ids)
+    }
+
     pub fn files_for_session(&self, session_id: &str, limit: usize) -> Result<Vec<String>> {
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock: {e}"))?;
         queries::files_for_session(&conn, session_id, limit)
@@ -1447,6 +1452,64 @@ mod tests {
         assert!((map[&id1][0] - 0.1).abs() < 1e-6);
         assert!((map[&id2][0] - 0.2).abs() < 1e-6);
         assert!(!map.contains_key("nonexistent"));
+    }
+
+    #[test]
+    fn get_reflection_vectors_by_ids_returns_exactly_the_requested_ids() {
+        use std::collections::HashMap;
+
+        let storage = Storage::open_memory().unwrap();
+        let id1 = "vec-refl-1".to_string();
+        let id2 = "vec-refl-2".to_string();
+        let id3 = "vec-refl-3".to_string();
+        storage
+            .insert_reflection(&id1, "one", &[], &[0.1; 384])
+            .unwrap();
+        storage
+            .insert_reflection(&id2, "two", &[], &[0.2; 384])
+            .unwrap();
+        storage
+            .insert_reflection(&id3, "three", &[], &[0.3; 384])
+            .unwrap();
+
+        // Ask for a strict subset plus a nonexistent id — must get back
+        // exactly the requested-and-present ids, not the whole table.
+        let got = storage
+            .get_reflection_vectors_by_ids(&[id1.clone(), id3.clone(), "nonexistent".to_string()])
+            .unwrap();
+        assert_eq!(
+            got.len(),
+            2,
+            "must return exactly the requested-and-present ids"
+        );
+        let map: HashMap<String, Vec<f32>> = got.into_iter().collect();
+        assert!((map[&id1][0] - 0.1).abs() < 1e-6);
+        assert!((map[&id3][0] - 0.3).abs() < 1e-6);
+        assert!(
+            !map.contains_key(&id2),
+            "id2 was not requested and must not be returned"
+        );
+        assert!(!map.contains_key("nonexistent"));
+    }
+
+    #[test]
+    fn get_reflection_vectors_by_ids_crosses_the_sql_parameter_batch_boundary() {
+        // queries::get_reflection_vectors_by_ids binds at most 500 ids per
+        // statement; 1,001 requested ids force three statements and must
+        // still come back complete and correctly paired.
+        let storage = Storage::open_memory().unwrap();
+        let ids: Vec<String> = (0..1001).map(|i| format!("boundary-refl-{i}")).collect();
+        for (i, id) in ids.iter().enumerate() {
+            let mut v = [0.0_f32; 384];
+            v[0] = i as f32;
+            storage.insert_reflection(id, "content", &[], &v).unwrap();
+        }
+        let got = storage.get_reflection_vectors_by_ids(&ids).unwrap();
+        assert_eq!(got.len(), 1001);
+        for (id, vec) in got {
+            let i: usize = id.trim_start_matches("boundary-refl-").parse().unwrap();
+            assert_eq!(vec[0], i as f32, "vector paired with the wrong id");
+        }
     }
 
     #[test]

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -1997,6 +1997,41 @@ pub fn get_chunk_vectors_by_ids(
     Ok(results)
 }
 
+/// Reflection counterpart of [`get_chunk_vectors_by_ids`] — same chunked-IN-clause
+/// approach and blob decoding, scoped to `reflection_embeddings`. Lets the engine
+/// reconciliation path (engine.rs) fetch only the reflection ids missing from the
+/// HNSW cache instead of `load_all_reflection_vectors` (O(corpus)).
+pub fn get_reflection_vectors_by_ids(
+    conn: &Connection,
+    ids: &[String],
+) -> Result<Vec<(String, Vec<f32>)>> {
+    const BATCH: usize = 500;
+    let mut results = Vec::new();
+    for batch in ids.chunks(BATCH) {
+        if batch.is_empty() {
+            continue;
+        }
+        let placeholders = std::iter::repeat_n("?", batch.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT reflection_id, embedding FROM reflection_embeddings WHERE reflection_id IN ({placeholders})"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let bound: Vec<&dyn rusqlite::ToSql> =
+            batch.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let rows = stmt.query_map(bound.as_slice(), |row| {
+            let id: String = row.get(0)?;
+            let bytes: Vec<u8> = row.get(1)?;
+            Ok((id, bytes_to_vec(&bytes)))
+        })?;
+        for row in rows {
+            results.push(row?);
+        }
+    }
+    Ok(results)
+}
+
 /// Most-touched files for a session (code_evolution), highest-frequency first. Lifted from
 /// the Phase 0 spike (examples/saga_spike.rs::files_for_session), now with a caller-supplied
 /// limit instead of a hardcoded 4.


### PR DESCRIPTION
9.5 port of #300 (reviewed there by Codex xhigh twice and CodeRabbit; all findings folded). Same changes: lazy ONNX model with `warm()` on the paths that embed immediately, targeted HNSW reconciliation in 2,000-id batches, streaming cache-miss rebuild, deferred MCP-side enrichment loops (`CSR_ENRICH_INITIAL_DELAY_SECS`, default 120), ORT/tokio thread caps (`CSR_EMBED_THREADS` / `CSR_TOKIO_WORKERS`), and the `scripts/profile-memory.sh` harness. Plus one pre-existing example lint (`chunks_exact` in `examples/quick_check_floor.rs`) that clippy 1.98 fails under the release workflow's `-D warnings`.

Three files conflicted against the 9.5 code and were resolved by hand: `engine.rs` keeps 9.5's non-fatal `flush_index` and has no maintenance rebuild function; `setup.rs` keeps its six-step flow (engine + model now in step 1, before MCP/hook config is written); the daemon test module keeps 9.5's tests plus the four new ones.

## Gates (this branch, rustc 1.98.1, the stable the release workflow will use)

- `cargo fmt --check`: clean. `cargo clippy --locked --all-targets -- -D warnings`: clean.
- `cargo test --locked`: 923 lib / 45 hooks_integration / 61 integration, 0 failed.
- `cargo build --release --locked`: OK. `csr-engine eval`: 5/5.

## Before / after, 9.5.4 vs this branch

Same harness, 237,412-chunk isolated copy, medians of 3, every row with its receipt (initialize response, hook timing line, prompt-submit's "Injected N items", the engine's `backfilled ... added=1` line).

| Scenario | 9.5.4 RSS / footprint / wall | 9.5.5 RSS / footprint / wall |
|---|---|---|
| Bare MCP initialize | 1253.3 MB / 1209.3 MB / 0.86 s | 1103.7 MB / 1038.7 MB / 0.74 s |
| Hook post-tool-use (Edit) | 1245.2 MB / 1209.3 MB / 0.79 s | 1118.8 MB / 1038.7 MB / 0.75 s |
| Hook prompt-submit (real prompt) | 1254.4 MB / 1209.1 MB / 0.79 s | 1280.5 MB / 1038.6 MB / 0.84 s |
| Long-lived server, live heap | 898.5 MiB | 798.0 MiB |
| Long-lived server, footprint 6 s after initialize (3 servers) | 978.7-984.0 MB | 851.2-854.1 MB |
| Drift +1 chunk, bare initialize | +382.0 MB vs bare | +4.2 MB vs bare |

prompt-submit's RSS rises 26 MB because the model now loads after the index is resident (RSS counts the model file's page cache); its private footprint drops 170 MB. Every hook fire still pays the index load; that is the resident-engine work, not this release.

https://claude.ai/code/session_01YBD4pjYNHU9LuuPQVzdEzc