### PR TITLE
perf(engine): mmap the HNSW vectors so processes share one copy

### DIFF
--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "fs2",
  "hnsw_rs",
  "ignore",
+ "libc",
  "notify",
  "ratatui",
  "regex",

--- a/csr-engine/Cargo.toml
+++ b/csr-engine/Cargo.toml
@@ -40,6 +40,7 @@ ratatui = "0.30"
 crossterm = "0.29"
 ignore = "0.4"
 toml = "0.9"
+libc = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/csr-engine/src/engine.rs
+++ b/csr-engine/src/engine.rs
@@ -190,6 +190,11 @@ impl Engine {
             // lock released on drop
         }
 
+        // The index is built and reconciled; hand the allocator's freed transient
+        // pages back to the OS so this server's steady-state footprint reflects live
+        // memory rather than retained slack (macOS-only; no-op elsewhere).
+        crate::runtime::release_freed_pages();
+
         Ok(Self {
             storage,
             embeddings,

--- a/csr-engine/src/main.rs
+++ b/csr-engine/src/main.rs
@@ -206,6 +206,9 @@ fn default_projects_dir() -> PathBuf {
 }
 
 fn main() -> Result<()> {
+    // Raise the open-file ceiling before any index load so a low soft RLIMIT_NOFILE
+    // cannot turn a transient EMFILE inside hnsw_rs's mmap load into a process exit.
+    csr_engine::runtime::raise_fd_limit();
     let workers = csr_engine::runtime::resolve_tokio_workers();
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(workers)

--- a/csr-engine/src/runtime.rs
+++ b/csr-engine/src/runtime.rs
@@ -25,6 +25,72 @@ pub fn resolve_tokio_workers() -> usize {
         .unwrap_or(4)
 }
 
+/// Raise this process's open-file soft limit toward its hard limit at startup.
+///
+/// With mmap on, loading an index has `hnsw_rs` open the graph and data files
+/// several times over (its `init()` holds both, then `from_hnswdump` reopens the
+/// graph). `hnsw_rs` 0.3.4 responds to an open/map failure with
+/// `std::process::exit(1)`, so a low descriptor ceiling — macOS defaults the soft
+/// `RLIMIT_NOFILE` to 256 — could turn transient `EMFILE` during load into a hard
+/// exit instead of the heap-rebuild fallback. Lifting the soft limit to the hard
+/// limit (capped, so macOS's `OPEN_MAX` is respected) removes that trigger. Needs
+/// no privilege: raising the soft limit up to the hard limit is always allowed.
+#[cfg(unix)]
+pub fn raise_fd_limit() {
+    // Cap the target so a huge/INFINITY hard limit does not exceed a kernel maximum
+    // (macOS rejects rlim_cur above OPEN_MAX).
+    const TARGET: u64 = 10_240;
+    // SAFETY: getrlimit/setrlimit with a valid resource id and a stack-allocated
+    // rlimit struct; we only ever raise the soft limit toward the hard limit.
+    unsafe {
+        let mut lim = std::mem::MaybeUninit::<libc::rlimit>::zeroed().assume_init();
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) != 0 {
+            return;
+        }
+        let desired = std::cmp::min(lim.rlim_max, TARGET as libc::rlim_t);
+        if lim.rlim_cur < desired {
+            lim.rlim_cur = desired;
+            let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &lim);
+        }
+    }
+}
+
+/// No-op on non-unix (no `RLIMIT_NOFILE`; mmap is disabled there anyway).
+#[cfg(not(unix))]
+pub fn raise_fd_limit() {}
+
+/// Ask the allocator to return freed-but-retained pages to the OS.
+///
+/// After the HNSW index is built or reconciled, the process has a large amount
+/// of transient allocation (batch buffers, the model's tokenizer scratch) that
+/// is freed but that macOS's `malloc` keeps as dirty pages in the process — the
+/// ~130 MB of allocator slack that makes a long-lived server's `vmmap` physical
+/// footprint bimodal on the same binary and DB. `heap -s` live bytes are
+/// deterministic; the swing is entirely these retained pages. Returning them
+/// makes the footprint an honest, low-variance reflection of live memory, which
+/// is what Activity Monitor shows.
+///
+/// macOS-only via `malloc_zone_pressure_relief(NULL, 0)` (releases across every
+/// zone; the documented way to hint the allocator under memory pressure). A
+/// no-op elsewhere — glibc reclaims on its own and there is no portable hook.
+#[cfg(target_os = "macos")]
+pub fn release_freed_pages() {
+    // SAFETY: `malloc_zone_pressure_relief` is part of the system malloc API in
+    // libSystem. A null zone pointer means "all zones"; a goal of 0 means
+    // "release as much as possible". It takes no ownership and returns the byte
+    // count released, which we ignore.
+    unsafe {
+        extern "C" {
+            fn malloc_zone_pressure_relief(zone: *mut core::ffi::c_void, goal: usize) -> usize;
+        }
+        let _ = malloc_zone_pressure_relief(core::ptr::null_mut(), 0);
+    }
+}
+
+/// No-op on non-macOS targets (see the macOS variant's docs).
+#[cfg(not(target_os = "macos"))]
+pub fn release_freed_pages() {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,6 +156,35 @@ mod tests {
         with_env(Some(&MAX_THREAD_OVERRIDE.to_string()), || {
             assert_eq!(resolve_tokio_workers(), MAX_THREAD_OVERRIDE);
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raise_fd_limit_lifts_the_soft_limit() {
+        // SAFETY: reads this process's RLIMIT_NOFILE.
+        let soft_before = unsafe {
+            let mut lim = std::mem::MaybeUninit::<libc::rlimit>::zeroed().assume_init();
+            assert_eq!(libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim), 0);
+            lim
+        };
+        raise_fd_limit();
+        let soft_after = unsafe {
+            let mut lim = std::mem::MaybeUninit::<libc::rlimit>::zeroed().assume_init();
+            assert_eq!(libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim), 0);
+            lim
+        };
+        // Never lowers the limit, and raises it toward the hard limit when there is room.
+        assert!(soft_after.rlim_cur >= soft_before.rlim_cur);
+        let target = std::cmp::min(soft_before.rlim_max, 10_240 as libc::rlim_t);
+        assert!(soft_after.rlim_cur >= target);
+    }
+
+    #[test]
+    fn release_freed_pages_is_callable() {
+        // No observable return; the contract is only that it never panics or
+        // aborts, on macOS (real call) or elsewhere (no-op).
+        release_freed_pages();
+        release_freed_pages();
     }
 
     #[test]

--- a/csr-engine/src/search/mod.rs
+++ b/csr-engine/src/search/mod.rs
@@ -15,6 +15,7 @@ use fs2::FileExt;
 use hnsw_rs::api::AnnT;
 use hnsw_rs::hnsw::Hnsw;
 use hnsw_rs::hnswio::HnswIo;
+use hnsw_rs::hnswio::ReloadOptions;
 use hnsw_rs::prelude::DistCosine;
 use hnsw_rs::prelude::Distance;
 use serde::{Deserialize, Serialize};
@@ -554,8 +555,15 @@ impl SearchEngine {
         // `chunks.hnsw.*` files a prior generation left behind and map fresh ids onto
         // those stale vectors. Gating on the id map treats that manifest as empty and
         // rebuilds from the DB instead.
+        let lock_held = _lock_guard.is_some();
+        let chunk_use_mmap = should_mmap_generation(
+            dir,
+            &manifest.chunk_basename,
+            &default_chunk_basename(),
+            lock_held,
+        );
         let mut chunk_io = (!manifest.chunk_id_map.is_empty())
-            .then(|| PendingHnswIo::new(dir, &manifest.chunk_basename));
+            .then(|| PendingHnswIo::new(dir, &manifest.chunk_basename, chunk_use_mmap));
         let chunk_hnsw = if let Some(io) = chunk_io.as_mut() {
             match io.load() {
                 Ok(hnsw) => hnsw,
@@ -576,8 +584,14 @@ impl SearchEngine {
 
         // Same reasoning as the chunk index above: gate on the persisted id map, which
         // is what `dump_to_disk` keyed the generation write on, not the DB count.
+        let refl_use_mmap = should_mmap_generation(
+            dir,
+            &manifest.reflection_basename,
+            &default_reflection_basename(),
+            lock_held,
+        );
         let mut refl_io = (!manifest.reflection_id_map.is_empty())
-            .then(|| PendingHnswIo::new(dir, &manifest.reflection_basename));
+            .then(|| PendingHnswIo::new(dir, &manifest.reflection_basename, refl_use_mmap));
         let refl_hnsw = if let Some(io) = refl_io.as_mut() {
             match io.load() {
                 Ok(hnsw) => hnsw,
@@ -684,13 +698,125 @@ fn write_manifest_atomically(dir: &Path, manifest: &IndexManifest) -> Result<()>
     Ok(())
 }
 
+/// Decide whether a HNSW generation is safe to mmap rather than heap-load.
+///
+/// Two conditions, both required:
+///
+/// 1. **Not the legacy canonical basename.** A dump from a pre-9.5.4 process
+///    (before numbered generations) writes the canonical `chunks.hnsw.data` /
+///    `reflections.hnsw.data` in place with `overwrite=true`, truncating it. If
+///    this process had that file mapped, the truncation would SIGBUS it. Numbered
+///    generations (`chunks-<pid>-<n>`) are written once to a unique name and never
+///    overwritten or truncated, so only they are safe to map while other processes
+///    (possibly older builds) share the directory. A canonical generation is loaded
+///    heap-backed; the mmap win arrives once any dump migrates the index to a
+///    numbered generation (every post-9.5.4 dump does).
+///
+/// 2. **The files are actually mappable.** `hnsw_rs`'s `from_hnswdump` calls
+///    `std::process::exit(1)` — not a recoverable error — if the graph file cannot
+///    be opened, the data file cannot be stat'd/opened, or the data file cannot be
+///    mapped. Turning mmap on would therefore let a transient mapping failure kill
+///    the MCP server or a hook instead of falling back to a heap rebuild. Probing
+///    the exact operations here (open the graph, map the data, unmap) means a
+///    failure returns `false` and the caller heap-loads, preserving the pre-mmap
+///    fallback behaviour.
+fn should_mmap_generation(
+    dir: &Path,
+    basename: &str,
+    default_basename: &str,
+    lock_held: bool,
+) -> bool {
+    // Only map with the shared load lock held. Without it, a concurrent dump could
+    // publish a new generation and unlink these files between hnsw_rs's `init()` and
+    // `from_hnswdump` reopening them, reaching a `process::exit(1)` path. The lock is
+    // present in normal operation (dump/startup create `index.lock`); a copied cache
+    // that lacks it is loaded heap-backed, which is always safe.
+    if !lock_held {
+        return false;
+    }
+    // Only map a NUMBERED generation (`<prefix>-...`), never the legacy canonical
+    // `<prefix>.hnsw.data`: a pre-9.5.4 process can truncate the canonical file in
+    // place, which would SIGBUS a process mapping it. Engine-written manifests only
+    // ever name `<prefix>` or `<prefix>-<pid>-<n>`, so this prefix check is exact for
+    // real inputs; it is not a general alias validator (a hand-crafted `<prefix>-x`
+    // pointing elsewhere would pass), which real manifests never produce.
+    let numbered_prefix = format!("{default_basename}-");
+    if !basename.starts_with(&numbered_prefix) {
+        return false;
+    }
+    // The graph file must open (from_hnswdump exits if it cannot) and the data file
+    // must be mappable (else from_hnswdump exits). Probing up front lets a failure
+    // fall back to a heap rebuild instead of killing the process. This narrows but
+    // cannot fully close the exit window: hnsw_rs reopens the files during the real
+    // load, so a resource failure that appears only then (e.g. EMFILE) can still hit
+    // its exit path — `raise_fd_limit` removes that specific trigger at startup.
+    if std::fs::File::open(dir.join(format!("{basename}.hnsw.graph"))).is_err() {
+        return false;
+    }
+    data_file_is_mmappable(&dir.join(format!("{basename}.hnsw.data")))
+}
+
+/// Probe that a file can be memory-mapped read-only, then unmap it. Returns false
+/// on any failure (missing, empty, unmappable filesystem, resource limit) so the
+/// caller can heap-load instead of handing an un-mappable file to `hnsw_rs`, which
+/// would `process::exit(1)`.
+#[cfg(unix)]
+fn data_file_is_mmappable(path: &Path) -> bool {
+    use std::os::unix::io::AsRawFd;
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(meta) = file.metadata() else {
+        return false;
+    };
+    let len = meta.len();
+    if len == 0 {
+        return false;
+    }
+    let Ok(len) = usize::try_from(len) else {
+        return false;
+    };
+    // SAFETY: a read-only probe map of an open regular file at offset 0. We never
+    // dereference the returned pointer and unmap it immediately; on failure `mmap`
+    // returns MAP_FAILED, which we check before calling `munmap`.
+    unsafe {
+        let addr = libc::mmap(
+            std::ptr::null_mut(),
+            len,
+            libc::PROT_READ,
+            libc::MAP_SHARED,
+            file.as_raw_fd(),
+            0,
+        );
+        if addr == libc::MAP_FAILED {
+            return false;
+        }
+        libc::munmap(addr, len);
+    }
+    true
+}
+
+/// Non-unix has no reliable unlink-under-mmap guarantee (Windows can deny or defer
+/// deletion of a mapped file), so never mmap there — heap-load is always correct.
+#[cfg(not(unix))]
+fn data_file_is_mmappable(_path: &Path) -> bool {
+    false
+}
+
 struct PendingHnswIo {
     io: NonNull<HnswIo>,
 }
 
 impl PendingHnswIo {
-    fn new(dir: &Path, basename: &str) -> Self {
-        let io = Box::new(HnswIo::new(dir, basename));
+    /// `use_mmap` maps the `.hnsw.data` vectors instead of reading them into the
+    /// heap. The returned `Hnsw` then borrows point slices from this `HnswIo`'s
+    /// mapping, which is why a fully successful load leaks the `HnswIo` (see `leak`)
+    /// so the mapping outlives the process's use of the index. It must only be set
+    /// for a numbered generation the caller has already confirmed is mappable — see
+    /// `should_mmap_generation`.
+    fn new(dir: &Path, basename: &str, use_mmap: bool) -> Self {
+        let options = ReloadOptions::new(use_mmap);
+        let io = Box::new(HnswIo::new_with_options(dir, basename, options));
         Self {
             io: NonNull::new(Box::into_raw(io)).expect("Box::into_raw never returns null"),
         }
@@ -1169,5 +1295,250 @@ mod tests {
     #[test]
     fn test_cleanup_no_panic_on_nonexistent_dir() {
         cleanup_stale_index_files(Path::new("/nonexistent/path")); // should not panic
+    }
+
+    // Build `n` deterministic 384-dim unit-ish vectors keyed by index.
+    fn synthetic_vectors(n: usize) -> Vec<Vec<f32>> {
+        (0..n)
+            .map(|i| {
+                (0..384)
+                    .map(|j| (((i * 384 + j) as f32) * 0.001).sin())
+                    .collect()
+            })
+            .collect()
+    }
+
+    // The canonical (legacy, pre-9.5.4) basename must NOT be mmapped, because an old
+    // process can truncate it in place. `should_mmap_generation` returns false for it,
+    // true for a numbered generation with real files, and false when the files are
+    // missing. A canonical index still loads and searches correctly (heap-backed).
+    #[test]
+    fn canonical_generation_is_never_mmapped_but_still_loads() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Canonical basename is refused regardless of whether files exist.
+        assert!(!should_mmap_generation(
+            dir,
+            &default_chunk_basename(),
+            &default_chunk_basename(),
+            true
+        ));
+        // A numbered basename with no files on disk is refused (would exit in hnsw_rs).
+        assert!(!should_mmap_generation(
+            dir,
+            "chunks-1-2",
+            &default_chunk_basename(),
+            true
+        ));
+
+        // Build an index, dump it, then rewrite the manifest to the LEGACY canonical
+        // layout (as a pre-9.5.4 dump would have left it) and rename the files to match.
+        let vecs = synthetic_vectors(300);
+        let mut writer = SearchEngine::new(400);
+        for (i, v) in vecs.iter().enumerate() {
+            writer.insert_chunk(format!("c{i}"), v.clone());
+        }
+        writer.dump_to_disk(dir, 300, 0).unwrap();
+        let manifest: IndexManifest =
+            serde_json::from_slice(&std::fs::read(dir.join("manifest.json")).unwrap()).unwrap();
+        let numbered = manifest.chunk_basename.clone();
+        std::fs::rename(
+            dir.join(format!("{numbered}.hnsw.data")),
+            dir.join("chunks.hnsw.data"),
+        )
+        .unwrap();
+        std::fs::rename(
+            dir.join(format!("{numbered}.hnsw.graph")),
+            dir.join("chunks.hnsw.graph"),
+        )
+        .unwrap();
+        let mut legacy = serde_json::to_value(&manifest).unwrap();
+        legacy["chunk_basename"] = serde_json::json!("chunks");
+        legacy["version"] = serde_json::json!(1);
+        std::fs::write(
+            dir.join("manifest.json"),
+            serde_json::to_vec_pretty(&legacy).unwrap(),
+        )
+        .unwrap();
+
+        // Now the numbered generation is refused (files gone), the canonical layout is
+        // refused by basename, and the index still loads heap-backed and searches.
+        assert!(!should_mmap_generation(
+            dir,
+            "chunks",
+            &default_chunk_basename(),
+            true
+        ));
+        // A numbered generation with a missing lock is refused (no unlink protection).
+        assert!(!should_mmap_generation(
+            dir,
+            "chunks-9-9",
+            &default_chunk_basename(),
+            false
+        ));
+        let loaded = SearchEngine::load_from_disk(dir, 300, 0).expect("canonical index loads");
+        assert_eq!(
+            loaded
+                .search_chunks(&vecs[42], 3, 0.1)
+                .first()
+                .map(|r| r.id.as_str()),
+            Some("c42"),
+            "canonical (heap-backed) index must search correctly"
+        );
+    }
+
+    // The core PR2 safety property: a process holding an mmap-backed generation keeps
+    // serving correct results after ANOTHER process publishes a new generation and
+    // `cleanup_stale_index_files` unlinks the older one. On unix the inode and its
+    // pages survive until the last mapping is dropped, so the mapped reads stay valid.
+    // This is what makes turning mmap on safe under concurrent csr-engine processes.
+    #[cfg(unix)]
+    #[test]
+    fn mmap_backed_index_survives_concurrent_generation_cleanup() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        // Generation 1: 300 chunks (> EXACT_SCAN_THRESHOLD, so search walks the HNSW
+        // graph and reads vectors through the mmap rather than exact-scanning).
+        let vecs = synthetic_vectors(300);
+        let mut writer = SearchEngine::new(400);
+        for (i, v) in vecs.iter().enumerate() {
+            writer.insert_chunk(format!("c{i}"), v.clone());
+        }
+        writer.dump_to_disk(dir, 300, 0).unwrap();
+
+        // A reader loads generation 1 mmap-backed (leaks an HnswIo holding the map).
+        let reader = SearchEngine::load_from_disk(dir, 300, 0).expect("load generation 1");
+        let gen1_data = {
+            let manifest: IndexManifest =
+                serde_json::from_slice(&std::fs::read(dir.join("manifest.json")).unwrap()).unwrap();
+            dir.join(format!("{}.hnsw.data", manifest.chunk_basename))
+        };
+        assert!(gen1_data.exists(), "generation 1 data file should exist");
+        // The generation must be numbered so `should_mmap_generation` mapped it (a
+        // canonical basename would be heap-loaded and this test would not exercise mmap).
+        let gen1_basename = gen1_data
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap()
+            .trim_end_matches(".hnsw.data")
+            .to_string();
+        assert!(
+            gen1_basename.starts_with("chunks-"),
+            "expected a numbered generation, got {gen1_basename}"
+        );
+        assert!(
+            should_mmap_generation(dir, &gen1_basename, &default_chunk_basename(), true),
+            "generation 1 should be mmap-backed"
+        );
+
+        // Sanity: the mmap-backed reader returns the self-match with a near-1.0 score.
+        let before = reader.search_chunks(&vecs[142], 5, 0.1);
+        assert_eq!(before.first().map(|r| r.id.as_str()), Some("c142"));
+
+        // Another process publishes generation 2 (500 chunks). dump_to_disk commits the
+        // new manifest and runs cleanup, which unlinks generation 1's numbered files.
+        let vecs2 = synthetic_vectors(500);
+        let mut publisher = SearchEngine::new(600);
+        for (i, v) in vecs2.iter().enumerate() {
+            publisher.insert_chunk(format!("c{i}"), v.clone());
+        }
+        publisher.dump_to_disk(dir, 500, 0).unwrap();
+        assert!(
+            !gen1_data.exists(),
+            "cleanup should have unlinked generation 1's data file"
+        );
+
+        // The still-mapped reader must keep returning correct results after the unlink.
+        let after = reader.search_chunks(&vecs[142], 5, 0.1);
+        assert_eq!(
+            after.first().map(|r| r.id.as_str()),
+            Some("c142"),
+            "mmap-backed reads must survive the file being unlinked by another process"
+        );
+        // A vector that only differs slightly should still resolve to its own id.
+        let after_7 = reader.search_chunks(&vecs[7], 3, 0.1);
+        assert_eq!(after_7.first().map(|r| r.id.as_str()), Some("c7"));
+
+        // And a fresh load now picks up generation 2, including the newer ids.
+        let reloaded = SearchEngine::load_from_disk(dir, 500, 0).expect("load generation 2");
+        assert!(reloaded.has_chunk("c499"));
+        assert!(reloaded.has_chunk("c142"));
+        assert_eq!(
+            reloaded
+                .search_chunks(&vecs2[499], 3, 0.1)
+                .first()
+                .map(|r| r.id.as_str()),
+            Some("c499"),
+            "generation 2 must search correctly after reload"
+        );
+    }
+
+    // Additive backfill into an mmap-backed index: newly inserted points are heap-owned
+    // Vecs while the loaded points remain mmap slices. Both must be searchable, and a
+    // subsequent dump (which writes a fresh generation, never truncating the mapped
+    // file) must round-trip every id.
+    #[cfg(unix)]
+    #[test]
+    fn mmap_backed_index_accepts_new_inserts_and_redumps() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path();
+
+        let vecs = synthetic_vectors(300);
+        let mut writer = SearchEngine::new(400);
+        for (i, v) in vecs.iter().enumerate() {
+            writer.insert_chunk(format!("c{i}"), v.clone());
+        }
+        writer.dump_to_disk(dir, 300, 0).unwrap();
+
+        let mut reader = SearchEngine::load_from_disk(dir, 300, 0).expect("load generation 1");
+
+        // Insert a new point (heap-owned) alongside the mmap-backed ones.
+        let newv: Vec<f32> = (0..384).map(|j| ((j as f32) * 0.002).cos()).collect();
+        reader.insert_chunk("c_new".into(), newv.clone());
+
+        assert_eq!(
+            reader
+                .search_chunks(&newv, 3, 0.1)
+                .first()
+                .map(|r| r.id.as_str()),
+            Some("c_new"),
+            "newly inserted heap-owned point must be searchable"
+        );
+        assert_eq!(
+            reader
+                .search_chunks(&vecs[10], 3, 0.1)
+                .first()
+                .map(|r| r.id.as_str()),
+            Some("c10"),
+            "mmap-backed points must remain searchable after a new insert"
+        );
+
+        // Re-dump: writes a new generation, must not truncate the mapped file, and the
+        // result must round-trip both the mmap-origin ids and the new one.
+        reader.dump_to_disk(dir, 301, 0).unwrap();
+        let reloaded = SearchEngine::load_from_disk(dir, 301, 0).expect("reload after redump");
+        assert!(reloaded.has_chunk("c_new"));
+        assert!(reloaded.has_chunk("c0"));
+        assert!(reloaded.has_chunk("c299"));
+        // Search must return the right vectors after the re-dump/reload, for both a
+        // mmap-origin point and the point that was inserted heap-side before the dump.
+        assert_eq!(
+            reloaded
+                .search_chunks(&vecs[0], 3, 0.1)
+                .first()
+                .map(|r| r.id.as_str()),
+            Some("c0"),
+            "mmap-origin vector must search correctly after redump/reload"
+        );
+        assert_eq!(
+            reloaded
+                .search_chunks(&newv, 3, 0.1)
+                .first()
+                .map(|r| r.id.as_str()),
+            Some("c_new"),
+            "inserted vector must search correctly after redump/reload"
+        );
     }
 }


### PR DESCRIPTION
## Why

The 9.5.5 hygiene tier trimmed the model and the drift transient but left the ~370 MB of HNSW vectors read fully into each process's heap as dirty, non-reclaimable memory. Every `csr-engine` process — one per MCP client, plus every hook fire — carried its own private copy.

This maps those vectors from the on-disk index instead of copying them to the heap. Two things follow: the vectors become **clean, reclaimable file-backed pages** instead of dirty heap (so they drop out of each process's pressure-counted footprint and the OS can evict them under pressure), and processes that map the **same** on-disk generation share one physical copy. It is the second tier of the memory work (startup hygiene was #300/#301); the heap-resident edge graph is untouched and is the separate resident-engine tier.

## What changed

- **mmap the vector data** (`ReloadOptions::new(true)`). The substrate for this shipped in 9.5.4/9.5.5: dumps write immutable numbered generations (`chunks-<pid>-<n>`), the manifest is swapped atomically, cleanup only unlinks superseded generations, and `PendingHnswIo` already leaks the loader so a mapping can outlive the load. hnsw_rs now maps `.hnsw.data` and the `Hnsw` borrows point slices from it.
- **mmap is enabled only when provably safe** (`should_mmap_generation`), gated on three conditions:
  1. **Numbered generation only**, never the legacy canonical `chunks.hnsw.data`. A still-running pre-9.5.4 process rebuilds and truncates the canonical file in place (`file_dump` `overwrite=true`); mapping it would `SIGBUS` this process. Numbered generations are write-once to a unique name. A canonical index loads heap-backed exactly as before; the mmap win arrives once any dump migrates the index to a numbered generation, which every post-9.5.4 dump does.
  2. **Shared load lock held.** Without it a concurrent dump could publish a new generation and unlink the mapped files mid-load. A copied cache lacking `index.lock` loads heap-backed.
  3. **Pre-flight probe passes.** hnsw_rs 0.3.4's `from_hnswdump` calls `std::process::exit(1)` — not a recoverable error — if the graph file cannot open or the data file cannot be stat'd/opened/mapped. The probe (open graph, mmap data read-only, `munmap`) makes a failure heap-load instead of killing the process.
- **`raise_fd_limit()` at startup.** A preflight cannot cover a failure that appears only during the real load (hnsw_rs reopens the files, so a low `RLIMIT_NOFILE` could turn transient `EMFILE` into `exit(1)`). Lifting the soft limit toward the hard limit at process start removes that trigger. macOS `malloc_zone_pressure_relief` after load returns freed transient pages to tighten steady-state slack.

## Before / after — probe

Measured on a 237,412-chunk / 12,606-reflection isolated DB copy, the **same numbered generation** loaded by both binaries, same harness (`scripts/profile-memory.sh`), release builds of `release/v9.5.5` HEAD (baseline) and this branch, medians of 3, every trial confirming the cached startup path.

| Metric | 9.5.5 (heap) | This branch (mmap) |
|---|---|---|
| Live heap (`heap -s`, deterministic) | 792 MB | 440 MB |
| Steady-state private footprint, 6 s after initialize (3 servers) | 868 MB | 475-608 MB |
| Bare MCP initialize footprint | 1051 MB | 689 MB |
| Vectors | dirty private copy per process | 371 MB clean file mapping, shared across same-generation processes |
| Drift +1 chunk, delta vs bare init | +1.7 MB | +4 MB |

Live heap is the deterministic figure — identical on every run, 352 MB lower. The steady-state private footprint is bimodal on the same binary and index (allocator page retention after the index load); pressure relief tightens the 3-server spread within a run to under 11 MB but does not pin the mode, so it lands 475-608 MB across runs versus baseline's tight 868 MB.

## Before / after — live dogfood

Installed to `/usr/local/bin` and measured every live `csr-engine` on the maintainer's machine with `footprint` + `vmmap` (classifier: does `vmmap` show the vector file as a mapped region). Clean split, no overlap:

| Binary | vectors | phys_footprint / proc |
|---|---|---|
| pre-swap (heap) | dirty anonymous heap | 868-1071 MB (avg ~982) |
| this branch (mmap) | clean file-backed `SM=COW`, `DIRTY=0K` | 467-654 MB (avg ~557) |

**~425 MB/proc off the pressure-counted footprint.** `phys_footprint` is what macOS uses for memory-pressure and jetsam decisions, so this is the number that counts.

**Honest scope of the sharing.** This is not one physical copy across *all* processes at all times. Each process dumps its own numbered generation when it imports and pins it via unlink-under-mmap, so long-lived, staggered processes fragment across generations; physical page-sharing happens only between processes on the **same** generation. Full single-copy sharing holds right after a simultaneous cold restart (all processes map the current generation) and degrades with uptime. The mapped pages are clean and reclaimable regardless of whether they are shared — that reclaimability, plus the ~425 MB/proc footprint drop, is the durable win; cross-process dedup is an additional, uptime-dependent bonus. Resident RAM drops less than footprint (the vectors are still resident, just clean rather than dirty).

## Verification

- `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings`: clean.
- `cargo test --release --locked`: lib 928, `--test hooks_integration` 45, `--test integration` 61. Zero failures.
- New tests: a mmap-backed reader keeps returning correct search results after another process publishes a new generation and unlinks the one it mapped (asserting the generation is numbered, i.e. actually mmap-eligible); additive backfill into a mmap-backed index round-trips through a re-dump with correct post-reload search for both a mmap-origin and a heap-inserted vector; `should_mmap_generation` refuses both the canonical basename and a lock-less load while the index still loads and searches heap-backed; `raise_fd_limit` lifts the soft limit. mmap tests are `#[cfg(unix)]`.
- The harness never touches the live `~/.claude-self-reflect`: it refuses that path, runs every child under a scratch HOME, and asserts the live dir is unchanged before and after.
- Reviews: Codex (gpt-6-astra, xhigh, read-only), three passes. Pass 1 and 2 raised two majors — the canonical-truncation hazard and the `process::exit` fallback — both addressed here (numbered-only + lock gating, pre-flight probe, raised fd limit) and confirmed. CodeRabbit: no actionable comments. CI targets are macOS and Linux only (no Windows); both honour unlink-under-mmap.
- Residual, stated plainly: fully closing hnsw_rs's `process::exit` on a load failure would need a patched fork of the crate, deferred as a supply-chain change. With the fd ceiling raised, the lock held, and the probe passing, no realistic routine trigger remains; the residual is exceptional-resource only (a low inherited hard limit, system-wide `ENFILE`, or address-space / mapping-count exhaustion). A 370 MB read-only file mapping's size alone is not a credible failure on a normal 64-bit host.

## Scope

Startup/steady-state memory only. The edge graph stays on the heap; a resident engine with thin per-client proxies is the next tier.

https://claude.ai/code/session_01YBD4pjYNHU9LuuPQVzdEzc
