### PR TITLE
Make the Security workflow pass again, and unbreak the clippy gate

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,18 +11,53 @@ id = "openai-api-key"
 [rules.allowlist]
 commits = ["39b40d74", "d21f2d07", "0003ad17", "cd159bde"]
 
-# Allow test Voyage key in old Python script
 [[rules]]
 id = "generic-api-key"
-[rules.allowlist]
-commits = ["0003ad17", "4ff652ae"]
+
+# Allow test Voyage key in old Python script
+[[rules.allowlists]]
+condition = "AND"
+commits = [
+    "0003ad17a84eec1dd43e224f6a16f32cd63d2901",
+    "4ff652ae49908e863c4b83f506e2a6e9aff89dac"
+]
 paths = ['''scripts/import-live-conversation\.py''']
 
-# Allow false positive sourcegraph tokens in SARIF file (commit 0b77b64)
+# Frozen T3 eval data: the four flagged columns are Claude session UUIDs and
+# agent ids, not credentials. Pinned to commit AND path, so a real key added
+# to the same file in a later commit still fails the scan.
+[[rules.allowlists]]
+condition = "AND"
+commits = ["24b865cf7de3b738694a4fee7170b81ca2b8fdd6"]
+paths = ['''^csr-engine/eval-kit/t3/mech_pairs\.frozen\.csv$''']
+
+# Historical `pa-`-prefixed Voyage-shaped string in tool_usage_sample.json.
+# Not a live credential -- it never authenticated against Voyage AI -- but it
+# matches generic-api-key. The file was deleted from the tree in af3e299, so
+# the string survives only in history, which cannot be scrubbed without
+# rewriting published commits. Pinned to commit AND path so the other 27
+# files in each of those two commits stay under full detection.
+[[rules.allowlists]]
+condition = "AND"
+commits = [
+    "5c771160096fecab46b8df07a3dadf5feccf741f",
+    "f6bd3f640b0de07148ef3d435109959c75a40ae5"
+]
+paths = ['''^tool_usage_sample\.json$''']
+
+# gitleaks' own SARIF output: the 40-char commit SHAs it records in
+# partialFingerprints match the sourcegraph-access-token pattern. Scan output,
+# not source. The same blob (579a73f) is reachable from both commits, so both
+# are listed; dropping either re-exposes 15 findings.
 [[rules]]
 id = "sourcegraph-access-token"
-[rules.allowlist]
-commits = ["0b77b64e29e5b8a899e723341947f7ebf44217fa"]
+[[rules.allowlists]]
+condition = "AND"
+commits = [
+    "0b77b64e29e5b8a899e723341947f7ebf44217fa",
+    "7e0701f9659077842bd7410b96fc4148b981f562"
+]
+paths = ['''^work/claude-self-reflect/claude-self-reflect/results\.sarif$''']
 
 [allowlist]
 # Global allowlist configuration

--- a/csr-engine/Cargo.lock
+++ b/csr-engine/Cargo.lock
@@ -2490,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4757,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytes",
  "hashbrown 0.17.1",
@@ -4775,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/csr-engine/examples/quick_check_floor.rs
+++ b/csr-engine/examples/quick_check_floor.rs
@@ -108,8 +108,10 @@ const PROBES: &[Probe] = &[
 
 fn bytes_to_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect()
 }
 

--- a/csr-engine/src/storage/queries.rs
+++ b/csr-engine/src/storage/queries.rs
@@ -145,8 +145,10 @@ fn vec_to_bytes(v: &[f32]) -> Vec<u8> {
 /// Deserialize bytes back to f32 vector.
 fn bytes_to_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|chunk| f32::from_le_bytes(*chunk))
         .collect()
 }
 


### PR DESCRIPTION
The `Security` workflow has been red since mid-August. This makes it green again. Three fixes, one of which (clippy) was a latent CI failure unrelated to the workflow but would have shown up on this PR.

**secrets-scan (gitleaks).** Every reported finding is a historical false positive — scan-tool output and non-credential identifiers, none of them live secrets. Each is suppressed with a narrowly scoped rule allowlist pinned to both the exact commit and the exact path, so detection stays fully active for anything introduced in a new commit. The global allowlist is unchanged.

**cargo-audit.** Bumped h2 and rkyv/rkyv_derive to the patched releases that clear the open RUSTSEC advisories. The lockfile was edited to those versions only, with no other dependency movement.

**clippy.** `bytes_to_vec` tripped a lint added in a newer clippy release. CI runs an unpinned stable toolchain, so main had gone red on its own when that clippy shipped. Rewritten to the form clippy suggests; behavior is identical, and it applies to both the library and the example copy.

Verified locally against the gitleaks version and toolchain CI actually uses: full-history secret scan clean, `cargo audit` clean, `cargo fmt`/`clippy`/`clippy --all-targets` clean, and the full test suite green.

`Security` runs only on push to main and a weekly cron, so it does not report on this PR; it proves out on merge.

Left as follow-ups, both pre-existing and unrelated to the red workflow: the Rust cache action points at the repo root (which has no `Cargo.toml`), so nothing is actually cached; and the CI toolchain stays unpinned, so a future clippy release can turn the lint gate red the same way.
